### PR TITLE
Build template from resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # cos-fleet-catalog-camel
 
+## Generate resources
+
+Running `./gen_templates.sh` will generate `templates/cos-fleet-catalog-camel.yaml` from `etc/connectors`.
+Setting `BUILD=true` will regenerate the content in `etc/connectors`
+
+```bash
+BUILD=true ./gen_templates.sh
+```

--- a/etc/connectors/connector-catalog-camel-aws/aws_cloudwatch_sink_0.1.json
+++ b/etc/connectors/connector-catalog-camel-aws/aws_cloudwatch_sink_0.1.json
@@ -16,16 +16,20 @@
           },
           "kafka" : {
             "name" : "cos-kafka-source",
-            "prefix" : "kafka"
+            "prefix": "kafka"
           },
-          "processors" : {
-            "throttle" : "throttle-action",
-            "jsonpath_set" : "cos-jsonpath-set-action",
-            "log" : "cos-log-action",
-            "jsonpath_rename" : "cos-jsonpath-rename-action",
-            "jsonpath_extract" : "cos-jsonpath-extract-action",
-            "jsonpath_remove" : "cos-jsonpath-remove-action"
+          "processors": {
+            "throttle": "throttle-action",
+            "jsonpath_set": "cos-jsonpath-set-action",
+            "log": "cos-log-action",
+            "jsonpath_rename": "cos-jsonpath-rename-action",
+            "jsonpath_extract": "cos-jsonpath-extract-action",
+            "jsonpath_remove": "cos-jsonpath-remove-action"
           }
+        },
+        "annotations": {
+          "trait.camel.apache.org/container.request-memory": "256m",
+          "trait.camel.apache.org/container.request-cpu": "1"
         }
       }
     }

--- a/gen_templates.sh
+++ b/gen_templates.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# Generate template from .json
+
+function print_exit() {
+    echo $1
+    exit 1
+}
+
+for CMD in "oc sed"; do
+  hash $CMD 2>/dev/null || print_exit "Dependency ${CMD} not met"
+done
+
+MAVEN_OPTS=${MAVEN_OPTS:-"-Xmx3000m"}
+MAVEN_ARGS=${MAVEN_ARGS:-"-V -ntp -Dhttp.keepAlive=false -e"}
+BUILD=${BUILD:-false}
+
+[ "${BUILD}" == "true" ] && ./mvnw ${MAVEN_ARGS} clean install -U
+
+CONNECTORS_DIR=${1:-etc/connectors}
+TEMPLATE=${2:-templates/cos-fleet-catalog-camel.yaml}
+
+cat <<EOT > $TEMPLATE
+apiVersion: template.openshift.io/v1
+kind: Template
+name: cos-fleet-catalog-camel
+metadata:
+  name: cos-fleet-catalog-camel
+  annotations:
+    openshift.io/display-name: Cos Fleet Manager Connector Catalog
+    description: List of available camel connectors and metadata
+objects:
+EOT
+
+echo "Overwriting template ${TEMPLATE}"
+
+for D in "${CONNECTORS_DIR}"/*; do
+  CM_NAME=$(basename "${D}")
+
+  echo "Adding configmap ${CM_NAME} to template ${TEMPLATE}"
+  echo "-" >> ${TEMPLATE}
+  oc create configmap "${CM_NAME}" \
+    --from-file="${CONNECTORS_DIR}/${CM_NAME}/" \
+    --dry-run=client \
+    -o yaml | sed -e 's/^/  /' >> $TEMPLATE
+done

--- a/templates/cos-fleet-catalog-camel.yaml
+++ b/templates/cos-fleet-catalog-camel.yaml
@@ -1,0 +1,19220 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+name: cos-fleet-catalog-camel
+metadata:
+  name: cos-fleet-catalog-camel
+  annotations:
+    openshift.io/display-name: Cos Fleet Manager Connector Catalog
+    description: List of available camel connectors and metadata
+objects:
+  - apiVersion: v1
+    data:
+      aws_cloudwatch_sink_0.1.json: |-
+        {
+          "channels" : {
+            "stable" : {
+              "shard_metadata" : {
+                "connector_revision" : "8",
+                "connector_type" : "sink",
+                "connector_image" : "quay.io/rhoas/cos-connector-aws-cloudwatch:0.1.8",
+                "operators" : [ {
+                  "type" : "camel-connector-operator",
+                  "version" : "[1.0.0,2.0.0)"
+                } ],
+                "kamelets" : {
+                  "adapter" : {
+                    "name" : "aws-cloudwatch-sink",
+                    "prefix" : "aws"
+                  },
+                  "kafka" : {
+                    "name" : "cos-kafka-source",
+                    "prefix" : "kafka"
+                  },
+                  "processors" : {
+                    "throttle" : "throttle-action",
+                    "jsonpath_set" : "cos-jsonpath-set-action",
+                    "log" : "cos-log-action",
+                    "jsonpath_rename" : "cos-jsonpath-rename-action",
+                    "jsonpath_extract" : "cos-jsonpath-extract-action",
+                    "jsonpath_remove" : "cos-jsonpath-remove-action"
+                  }
+                },
+                "annotations" : {
+                  "trait.camel.apache.org/container.request-memory" : "256m",
+                  "trait.camel.apache.org/container.request-cpu" : "1"
+                }
+              }
+            }
+          },
+          "connector_type" : {
+            "id" : "aws_cloudwatch_sink_0.1",
+            "kind" : "ConnectorType",
+            "icon_href" : "TODO",
+            "name" : "AWS Cloudwatch Sink",
+            "description" : "AWS Cloudwatch Sink",
+            "version" : "0.1",
+            "labels" : [ "sink" ],
+            "capabilities" : [ "error_handler", "processors" ],
+            "channels" : [ "stable" ],
+            "schema" : {
+              "type" : "object",
+              "required" : [ "aws_cw_namespace", "aws_region", "kafka_topic" ],
+              "properties" : {
+                "aws_cw_namespace" : {
+                  "title" : "Cloud Watch Namespace",
+                  "description" : "The cloud watch metric namespace.",
+                  "type" : "string"
+                },
+                "aws_access_key" : {
+                  "title" : "Access Key",
+                  "x-group" : "credentials",
+                  "oneOf" : [ {
+                    "title" : "Access Key",
+                    "description" : "The access key obtained from AWS.",
+                    "type" : "string",
+                    "format" : "password"
+                  }, {
+                    "description" : "An opaque reference to the aws_access_key",
+                    "type" : "object",
+                    "properties" : { }
+                  } ]
+                },
+                "aws_secret_key" : {
+                  "title" : "Secret Key",
+                  "x-group" : "credentials",
+                  "oneOf" : [ {
+                    "title" : "Secret Key",
+                    "description" : "The secret key obtained from AWS.",
+                    "type" : "string",
+                    "format" : "password"
+                  }, {
+                    "description" : "An opaque reference to the aws_secret_key",
+                    "type" : "object",
+                    "properties" : { }
+                  } ]
+                },
+                "aws_region" : {
+                  "title" : "AWS Region",
+                  "description" : "The AWS region to connect to.",
+                  "type" : "string",
+                  "example" : "eu-west-1"
+                },
+                "aws_use_default_credentials_provider" : {
+                  "title" : "Default Credentials Provider",
+                  "description" : "Set whether the CloudWatch client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.",
+                  "type" : "boolean",
+                  "default" : false
+                },
+                "kafka_topic" : {
+                  "title" : "Topic Names",
+                  "description" : "Comma separated list of Kafka topic names",
+                  "type" : "string"
+                },
+                "processors" : {
+                  "type" : "array",
+                  "items" : {
+                    "oneOf" : [ {
+                      "type" : "object",
+                      "required" : [ "throttle" ],
+                      "properties" : {
+                        "throttle" : {
+                          "$ref" : "#/$defs/processors/throttle"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "log" ],
+                      "properties" : {
+                        "log" : {
+                          "$ref" : "#/$defs/processors/log"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_extract" ],
+                      "properties" : {
+                        "jsonpath_extract" : {
+                          "$ref" : "#/$defs/processors/jsonpath_extract"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_remove" ],
+                      "properties" : {
+                        "jsonpath_remove" : {
+                          "$ref" : "#/$defs/processors/jsonpath_remove"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_rename" ],
+                      "properties" : {
+                        "jsonpath_rename" : {
+                          "$ref" : "#/$defs/processors/jsonpath_rename"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_set" ],
+                      "properties" : {
+                        "jsonpath_set" : {
+                          "$ref" : "#/$defs/processors/jsonpath_set"
+                        }
+                      }
+                    } ]
+                  }
+                },
+                "error_handler" : {
+                  "type" : "object",
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "dead_letter_queue" ],
+                    "properties" : {
+                      "dead_letter_queue" : {
+                        "$ref" : "#/$defs/error_handler/dead_letter_queue"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "log" ],
+                    "properties" : {
+                      "log" : {
+                        "$ref" : "#/$defs/error_handler/log"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "stop" ],
+                    "properties" : {
+                      "stop" : {
+                        "$ref" : "#/$defs/error_handler/stop"
+                      }
+                    }
+                  } ]
+                }
+              },
+              "$defs" : {
+                "processors" : {
+                  "throttle" : {
+                    "title" : "Throttle Action",
+                    "description" : "The Throttle action allows to ensure that a specific sink does not get overloaded.",
+                    "required" : [ "messages" ],
+                    "properties" : {
+                      "messages" : {
+                        "title" : "Messages Number",
+                        "description" : "The number of messages to send in the time period set",
+                        "type" : "integer",
+                        "example" : 10
+                      },
+                      "timePeriod" : {
+                        "title" : "Time Period",
+                        "description" : "Sets the time period during which the maximum request count is valid for, in milliseconds",
+                        "type" : "string",
+                        "default" : "1000"
+                      }
+                    },
+                    "type" : "object"
+                  },
+                  "log" : {
+                    "title" : "Log",
+                    "description" : "Log payload.",
+                    "type" : "object",
+                    "properties" : {
+                      "multiLine" : {
+                        "title" : "Multi Line",
+                        "description" : "Multi Line",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showProperties" : {
+                        "title" : "Show Properties",
+                        "description" : "Show Properties",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showHeaders" : {
+                        "title" : "Show Headers",
+                        "description" : "Show Headers",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      }
+                    }
+                  },
+                  "jsonpath_extract" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_remove" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_rename" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "newKey" : {
+                        "title" : "NewKey",
+                        "description" : "NewKey",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_set" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "title" : "Value",
+                        "description" : "Value",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "dead_letter_queue" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "topic" ],
+                    "properties" : {
+                      "topic" : {
+                        "type" : "string",
+                        "title" : "Dead Letter Topic Name",
+                        "description" : "The name of the Kafka topic used as dead letter queue"
+                      }
+                    }
+                  },
+                  "log" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  },
+                  "stop" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  }
+                }
+              }
+            }
+          }
+        }
+      aws_ddb_streams_source_0.1.json: |-
+        {
+          "channels" : {
+            "stable" : {
+              "shard_metadata" : {
+                "connector_revision" : "8",
+                "connector_type" : "source",
+                "connector_image" : "quay.io/rhoas/cos-connector-aws-ddb-streams:0.1.8",
+                "operators" : [ {
+                  "type" : "camel-connector-operator",
+                  "version" : "[1.0.0,2.0.0)"
+                } ],
+                "kamelets" : {
+                  "adapter" : {
+                    "name" : "aws-ddb-streams-source",
+                    "prefix" : "aws"
+                  },
+                  "kafka" : {
+                    "name" : "cos-kafka-sink",
+                    "prefix" : "kafka"
+                  },
+                  "processors" : {
+                    "throttle" : "throttle-action",
+                    "jsonpath_set" : "cos-jsonpath-set-action",
+                    "log" : "cos-log-action",
+                    "jsonpath_rename" : "cos-jsonpath-rename-action",
+                    "jsonpath_extract" : "cos-jsonpath-extract-action",
+                    "jsonpath_remove" : "cos-jsonpath-remove-action"
+                  }
+                },
+                "consumes" : "application/json",
+                "produces" : "application/json"
+              }
+            }
+          },
+          "connector_type" : {
+            "id" : "aws_ddb_streams_source_0.1",
+            "kind" : "ConnectorType",
+            "icon_href" : "TODO",
+            "name" : "AWS DynamoDB Streams Source",
+            "description" : "AWS DynamoDB Streams Source",
+            "version" : "0.1",
+            "labels" : [ "source" ],
+            "capabilities" : [ "data_shape", "error_handler", "processors" ],
+            "channels" : [ "stable" ],
+            "schema" : {
+              "type" : "object",
+              "required" : [ "aws_table", "aws_region", "kafka_topic" ],
+              "properties" : {
+                "aws_table" : {
+                  "title" : "Table",
+                  "description" : "Name of the DynamoDB table to look at",
+                  "type" : "string"
+                },
+                "aws_access_key" : {
+                  "title" : "Access Key",
+                  "x-group" : "credentials",
+                  "oneOf" : [ {
+                    "title" : "Access Key",
+                    "description" : "The access key obtained from AWS",
+                    "type" : "string",
+                    "format" : "password"
+                  }, {
+                    "description" : "An opaque reference to the aws_access_key",
+                    "type" : "object",
+                    "properties" : { }
+                  } ]
+                },
+                "aws_secret_key" : {
+                  "title" : "Secret Key",
+                  "x-group" : "credentials",
+                  "oneOf" : [ {
+                    "title" : "Secret Key",
+                    "description" : "The secret key obtained from AWS",
+                    "type" : "string",
+                    "format" : "password"
+                  }, {
+                    "description" : "An opaque reference to the aws_secret_key",
+                    "type" : "object",
+                    "properties" : { }
+                  } ]
+                },
+                "aws_region" : {
+                  "title" : "AWS Region",
+                  "description" : "The AWS region to connect to",
+                  "type" : "string",
+                  "example" : "eu-west-1"
+                },
+                "aws_iterator_type" : {
+                  "title" : "Iterator Type",
+                  "description" : "Defines where in the DynaboDB stream to start getting records. Note that using TRIM_HORIZON can cause a significant delay before the stream has caught up to real-time. if {AT,AFTER}_SEQUENCE_NUMBER are used, then a sequenceNumberProvider MUST be supplied. There are 4 enums and the value can be one of TRIM_HORIZON, LATEST, AT_SEQUENCE_NUMBER, AFTER_SEQUENCE_NUMBER",
+                  "type" : "string",
+                  "default" : "LATEST"
+                },
+                "aws_sequence_number_provider" : {
+                  "title" : "Sequence Number Provider",
+                  "description" : "Provider for the sequence number when using one of the two ShardIteratorType AT_SEQUENCE_NUMBER or AFTER_SEQUENCE_NUMBER iterator types. Can be a registry reference or a literal sequence number.",
+                  "type" : "string",
+                  "example" : "900000000005745712447",
+                  "default" : "000000000000000000000"
+                },
+                "aws_use_default_credentials_provider" : {
+                  "title" : "Default Credentials Provider",
+                  "description" : "Set whether the S3 client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.",
+                  "type" : "boolean",
+                  "default" : false
+                },
+                "kafka_topic" : {
+                  "title" : "Topic Names",
+                  "description" : "Comma separated list of Kafka topic names",
+                  "type" : "string"
+                },
+                "processors" : {
+                  "type" : "array",
+                  "items" : {
+                    "oneOf" : [ {
+                      "type" : "object",
+                      "required" : [ "throttle" ],
+                      "properties" : {
+                        "throttle" : {
+                          "$ref" : "#/$defs/processors/throttle"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "log" ],
+                      "properties" : {
+                        "log" : {
+                          "$ref" : "#/$defs/processors/log"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_extract" ],
+                      "properties" : {
+                        "jsonpath_extract" : {
+                          "$ref" : "#/$defs/processors/jsonpath_extract"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_remove" ],
+                      "properties" : {
+                        "jsonpath_remove" : {
+                          "$ref" : "#/$defs/processors/jsonpath_remove"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_rename" ],
+                      "properties" : {
+                        "jsonpath_rename" : {
+                          "$ref" : "#/$defs/processors/jsonpath_rename"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_set" ],
+                      "properties" : {
+                        "jsonpath_set" : {
+                          "$ref" : "#/$defs/processors/jsonpath_set"
+                        }
+                      }
+                    } ]
+                  }
+                },
+                "data_shape" : {
+                  "type" : "object",
+                  "additionalProperties" : false,
+                  "properties" : {
+                    "produces" : {
+                      "$ref" : "#/$defs/data_shape/produces"
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "type" : "object",
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "dead_letter_queue" ],
+                    "properties" : {
+                      "dead_letter_queue" : {
+                        "$ref" : "#/$defs/error_handler/dead_letter_queue"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "log" ],
+                    "properties" : {
+                      "log" : {
+                        "$ref" : "#/$defs/error_handler/log"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "stop" ],
+                    "properties" : {
+                      "stop" : {
+                        "$ref" : "#/$defs/error_handler/stop"
+                      }
+                    }
+                  } ]
+                }
+              },
+              "$defs" : {
+                "processors" : {
+                  "throttle" : {
+                    "title" : "Throttle Action",
+                    "description" : "The Throttle action allows to ensure that a specific sink does not get overloaded.",
+                    "required" : [ "messages" ],
+                    "properties" : {
+                      "messages" : {
+                        "title" : "Messages Number",
+                        "description" : "The number of messages to send in the time period set",
+                        "type" : "integer",
+                        "example" : 10
+                      },
+                      "timePeriod" : {
+                        "title" : "Time Period",
+                        "description" : "Sets the time period during which the maximum request count is valid for, in milliseconds",
+                        "type" : "string",
+                        "default" : "1000"
+                      }
+                    },
+                    "type" : "object"
+                  },
+                  "log" : {
+                    "title" : "Log",
+                    "description" : "Log payload.",
+                    "type" : "object",
+                    "properties" : {
+                      "multiLine" : {
+                        "title" : "Multi Line",
+                        "description" : "Multi Line",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showProperties" : {
+                        "title" : "Show Properties",
+                        "description" : "Show Properties",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showHeaders" : {
+                        "title" : "Show Headers",
+                        "description" : "Show Headers",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      }
+                    }
+                  },
+                  "jsonpath_extract" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_remove" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_rename" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "newKey" : {
+                        "title" : "NewKey",
+                        "description" : "NewKey",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_set" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "title" : "Value",
+                        "description" : "Value",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  }
+                },
+                "data_shape" : {
+                  "produces" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "format" ],
+                    "properties" : {
+                      "format" : {
+                        "type" : "string",
+                        "default" : "application/json",
+                        "enum" : [ "application/json", "avro/binary" ]
+                      }
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "dead_letter_queue" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "topic" ],
+                    "properties" : {
+                      "topic" : {
+                        "type" : "string",
+                        "title" : "Dead Letter Topic Name",
+                        "description" : "The name of the Kafka topic used as dead letter queue"
+                      }
+                    }
+                  },
+                  "log" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  },
+                  "stop" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  }
+                }
+              }
+            }
+          }
+        }
+      aws_kinesis_sink_0.1.json: |-
+        {
+          "channels" : {
+            "stable" : {
+              "shard_metadata" : {
+                "connector_revision" : "8",
+                "connector_type" : "sink",
+                "connector_image" : "quay.io/rhoas/cos-connector-aws-kinesis:0.1.8",
+                "operators" : [ {
+                  "type" : "camel-connector-operator",
+                  "version" : "[1.0.0,2.0.0)"
+                } ],
+                "kamelets" : {
+                  "adapter" : {
+                    "name" : "aws-kinesis-sink",
+                    "prefix" : "aws"
+                  },
+                  "kafka" : {
+                    "name" : "cos-kafka-source",
+                    "prefix" : "kafka"
+                  },
+                  "processors" : {
+                    "throttle" : "throttle-action",
+                    "jsonpath_set" : "cos-jsonpath-set-action",
+                    "log" : "cos-log-action",
+                    "jsonpath_rename" : "cos-jsonpath-rename-action",
+                    "jsonpath_extract" : "cos-jsonpath-extract-action",
+                    "jsonpath_remove" : "cos-jsonpath-remove-action"
+                  }
+                }
+              }
+            }
+          },
+          "connector_type" : {
+            "id" : "aws_kinesis_sink_0.1",
+            "kind" : "ConnectorType",
+            "icon_href" : "TODO",
+            "name" : "AWS Kinesis Sink",
+            "description" : "AWS Kinesis Sink",
+            "version" : "0.1",
+            "labels" : [ "sink" ],
+            "capabilities" : [ "error_handler", "processors" ],
+            "channels" : [ "stable" ],
+            "schema" : {
+              "type" : "object",
+              "required" : [ "aws_stream", "aws_region", "kafka_topic" ],
+              "properties" : {
+                "aws_stream" : {
+                  "title" : "Stream Name",
+                  "description" : "The Kinesis stream that you want to access (needs to be created in advance)",
+                  "type" : "string"
+                },
+                "aws_access_key" : {
+                  "title" : "Access Key",
+                  "x-group" : "credentials",
+                  "oneOf" : [ {
+                    "title" : "Access Key",
+                    "description" : "The access key obtained from AWS",
+                    "type" : "string",
+                    "format" : "password"
+                  }, {
+                    "description" : "An opaque reference to the aws_access_key",
+                    "type" : "object",
+                    "properties" : { }
+                  } ]
+                },
+                "aws_secret_key" : {
+                  "title" : "Secret Key",
+                  "x-group" : "credentials",
+                  "oneOf" : [ {
+                    "title" : "Secret Key",
+                    "description" : "The secret key obtained from AWS",
+                    "type" : "string",
+                    "format" : "password"
+                  }, {
+                    "description" : "An opaque reference to the aws_secret_key",
+                    "type" : "object",
+                    "properties" : { }
+                  } ]
+                },
+                "aws_region" : {
+                  "title" : "AWS Region",
+                  "description" : "The AWS region to connect to",
+                  "type" : "string",
+                  "example" : "eu-west-1"
+                },
+                "aws_use_default_credentials_provider" : {
+                  "title" : "Default Credentials Provider",
+                  "description" : "Set whether the Kinesis client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.",
+                  "type" : "boolean",
+                  "default" : false
+                },
+                "kafka_topic" : {
+                  "title" : "Topic Names",
+                  "description" : "Comma separated list of Kafka topic names",
+                  "type" : "string"
+                },
+                "processors" : {
+                  "type" : "array",
+                  "items" : {
+                    "oneOf" : [ {
+                      "type" : "object",
+                      "required" : [ "throttle" ],
+                      "properties" : {
+                        "throttle" : {
+                          "$ref" : "#/$defs/processors/throttle"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "log" ],
+                      "properties" : {
+                        "log" : {
+                          "$ref" : "#/$defs/processors/log"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_extract" ],
+                      "properties" : {
+                        "jsonpath_extract" : {
+                          "$ref" : "#/$defs/processors/jsonpath_extract"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_remove" ],
+                      "properties" : {
+                        "jsonpath_remove" : {
+                          "$ref" : "#/$defs/processors/jsonpath_remove"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_rename" ],
+                      "properties" : {
+                        "jsonpath_rename" : {
+                          "$ref" : "#/$defs/processors/jsonpath_rename"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_set" ],
+                      "properties" : {
+                        "jsonpath_set" : {
+                          "$ref" : "#/$defs/processors/jsonpath_set"
+                        }
+                      }
+                    } ]
+                  }
+                },
+                "error_handler" : {
+                  "type" : "object",
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "dead_letter_queue" ],
+                    "properties" : {
+                      "dead_letter_queue" : {
+                        "$ref" : "#/$defs/error_handler/dead_letter_queue"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "log" ],
+                    "properties" : {
+                      "log" : {
+                        "$ref" : "#/$defs/error_handler/log"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "stop" ],
+                    "properties" : {
+                      "stop" : {
+                        "$ref" : "#/$defs/error_handler/stop"
+                      }
+                    }
+                  } ]
+                }
+              },
+              "$defs" : {
+                "processors" : {
+                  "throttle" : {
+                    "title" : "Throttle Action",
+                    "description" : "The Throttle action allows to ensure that a specific sink does not get overloaded.",
+                    "required" : [ "messages" ],
+                    "properties" : {
+                      "messages" : {
+                        "title" : "Messages Number",
+                        "description" : "The number of messages to send in the time period set",
+                        "type" : "integer",
+                        "example" : 10
+                      },
+                      "timePeriod" : {
+                        "title" : "Time Period",
+                        "description" : "Sets the time period during which the maximum request count is valid for, in milliseconds",
+                        "type" : "string",
+                        "default" : "1000"
+                      }
+                    },
+                    "type" : "object"
+                  },
+                  "log" : {
+                    "title" : "Log",
+                    "description" : "Log payload.",
+                    "type" : "object",
+                    "properties" : {
+                      "multiLine" : {
+                        "title" : "Multi Line",
+                        "description" : "Multi Line",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showProperties" : {
+                        "title" : "Show Properties",
+                        "description" : "Show Properties",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showHeaders" : {
+                        "title" : "Show Headers",
+                        "description" : "Show Headers",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      }
+                    }
+                  },
+                  "jsonpath_extract" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_remove" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_rename" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "newKey" : {
+                        "title" : "NewKey",
+                        "description" : "NewKey",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_set" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "title" : "Value",
+                        "description" : "Value",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "dead_letter_queue" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "topic" ],
+                    "properties" : {
+                      "topic" : {
+                        "type" : "string",
+                        "title" : "Dead Letter Topic Name",
+                        "description" : "The name of the Kafka topic used as dead letter queue"
+                      }
+                    }
+                  },
+                  "log" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  },
+                  "stop" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  }
+                }
+              }
+            }
+          }
+        }
+      aws_kinesis_source_0.1.json: |-
+        {
+          "channels" : {
+            "stable" : {
+              "shard_metadata" : {
+                "connector_revision" : "8",
+                "connector_type" : "source",
+                "connector_image" : "quay.io/rhoas/cos-connector-aws-kinesis:0.1.8",
+                "operators" : [ {
+                  "type" : "camel-connector-operator",
+                  "version" : "[1.0.0,2.0.0)"
+                } ],
+                "kamelets" : {
+                  "adapter" : {
+                    "name" : "aws-kinesis-source",
+                    "prefix" : "aws"
+                  },
+                  "kafka" : {
+                    "name" : "cos-kafka-sink",
+                    "prefix" : "kafka"
+                  },
+                  "processors" : {
+                    "throttle" : "throttle-action",
+                    "jsonpath_set" : "cos-jsonpath-set-action",
+                    "log" : "cos-log-action",
+                    "jsonpath_rename" : "cos-jsonpath-rename-action",
+                    "jsonpath_extract" : "cos-jsonpath-extract-action",
+                    "jsonpath_remove" : "cos-jsonpath-remove-action"
+                  }
+                },
+                "consumes" : "application/json",
+                "produces" : "application/json"
+              }
+            }
+          },
+          "connector_type" : {
+            "id" : "aws_kinesis_source_0.1",
+            "kind" : "ConnectorType",
+            "icon_href" : "TODO",
+            "name" : "AWS Kinesis Source",
+            "description" : "AWS Kinesis Source",
+            "version" : "0.1",
+            "labels" : [ "source" ],
+            "capabilities" : [ "data_shape", "error_handler", "processors" ],
+            "channels" : [ "stable" ],
+            "schema" : {
+              "type" : "object",
+              "required" : [ "aws_stream", "aws_region", "kafka_topic" ],
+              "properties" : {
+                "aws_stream" : {
+                  "title" : "Stream Name",
+                  "description" : "The Kinesis stream that you want to access (needs to be created in advance)",
+                  "type" : "string"
+                },
+                "aws_access_key" : {
+                  "title" : "Access Key",
+                  "x-group" : "credentials",
+                  "oneOf" : [ {
+                    "title" : "Access Key",
+                    "description" : "The access key obtained from AWS",
+                    "type" : "string",
+                    "format" : "password"
+                  }, {
+                    "description" : "An opaque reference to the aws_access_key",
+                    "type" : "object",
+                    "properties" : { }
+                  } ]
+                },
+                "aws_secret_key" : {
+                  "title" : "Secret Key",
+                  "x-group" : "credentials",
+                  "oneOf" : [ {
+                    "title" : "Secret Key",
+                    "description" : "The secret key obtained from AWS",
+                    "type" : "string",
+                    "format" : "password"
+                  }, {
+                    "description" : "An opaque reference to the aws_secret_key",
+                    "type" : "object",
+                    "properties" : { }
+                  } ]
+                },
+                "aws_region" : {
+                  "title" : "AWS Region",
+                  "description" : "The AWS region to connect to",
+                  "type" : "string",
+                  "example" : "eu-west-1"
+                },
+                "aws_use_default_credentials_provider" : {
+                  "title" : "Default Credentials Provider",
+                  "description" : "Set whether the Kinesis client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.",
+                  "type" : "boolean",
+                  "default" : false
+                },
+                "kafka_topic" : {
+                  "title" : "Topic Names",
+                  "description" : "Comma separated list of Kafka topic names",
+                  "type" : "string"
+                },
+                "processors" : {
+                  "type" : "array",
+                  "items" : {
+                    "oneOf" : [ {
+                      "type" : "object",
+                      "required" : [ "throttle" ],
+                      "properties" : {
+                        "throttle" : {
+                          "$ref" : "#/$defs/processors/throttle"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "log" ],
+                      "properties" : {
+                        "log" : {
+                          "$ref" : "#/$defs/processors/log"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_extract" ],
+                      "properties" : {
+                        "jsonpath_extract" : {
+                          "$ref" : "#/$defs/processors/jsonpath_extract"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_remove" ],
+                      "properties" : {
+                        "jsonpath_remove" : {
+                          "$ref" : "#/$defs/processors/jsonpath_remove"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_rename" ],
+                      "properties" : {
+                        "jsonpath_rename" : {
+                          "$ref" : "#/$defs/processors/jsonpath_rename"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_set" ],
+                      "properties" : {
+                        "jsonpath_set" : {
+                          "$ref" : "#/$defs/processors/jsonpath_set"
+                        }
+                      }
+                    } ]
+                  }
+                },
+                "data_shape" : {
+                  "type" : "object",
+                  "additionalProperties" : false,
+                  "properties" : {
+                    "produces" : {
+                      "$ref" : "#/$defs/data_shape/produces"
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "type" : "object",
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "dead_letter_queue" ],
+                    "properties" : {
+                      "dead_letter_queue" : {
+                        "$ref" : "#/$defs/error_handler/dead_letter_queue"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "log" ],
+                    "properties" : {
+                      "log" : {
+                        "$ref" : "#/$defs/error_handler/log"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "stop" ],
+                    "properties" : {
+                      "stop" : {
+                        "$ref" : "#/$defs/error_handler/stop"
+                      }
+                    }
+                  } ]
+                }
+              },
+              "$defs" : {
+                "processors" : {
+                  "throttle" : {
+                    "title" : "Throttle Action",
+                    "description" : "The Throttle action allows to ensure that a specific sink does not get overloaded.",
+                    "required" : [ "messages" ],
+                    "properties" : {
+                      "messages" : {
+                        "title" : "Messages Number",
+                        "description" : "The number of messages to send in the time period set",
+                        "type" : "integer",
+                        "example" : 10
+                      },
+                      "timePeriod" : {
+                        "title" : "Time Period",
+                        "description" : "Sets the time period during which the maximum request count is valid for, in milliseconds",
+                        "type" : "string",
+                        "default" : "1000"
+                      }
+                    },
+                    "type" : "object"
+                  },
+                  "log" : {
+                    "title" : "Log",
+                    "description" : "Log payload.",
+                    "type" : "object",
+                    "properties" : {
+                      "multiLine" : {
+                        "title" : "Multi Line",
+                        "description" : "Multi Line",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showProperties" : {
+                        "title" : "Show Properties",
+                        "description" : "Show Properties",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showHeaders" : {
+                        "title" : "Show Headers",
+                        "description" : "Show Headers",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      }
+                    }
+                  },
+                  "jsonpath_extract" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_remove" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_rename" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "newKey" : {
+                        "title" : "NewKey",
+                        "description" : "NewKey",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_set" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "title" : "Value",
+                        "description" : "Value",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  }
+                },
+                "data_shape" : {
+                  "produces" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "format" ],
+                    "properties" : {
+                      "format" : {
+                        "type" : "string",
+                        "default" : "application/json",
+                        "enum" : [ "application/json", "avro/binary" ]
+                      }
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "dead_letter_queue" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "topic" ],
+                    "properties" : {
+                      "topic" : {
+                        "type" : "string",
+                        "title" : "Dead Letter Topic Name",
+                        "description" : "The name of the Kafka topic used as dead letter queue"
+                      }
+                    }
+                  },
+                  "log" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  },
+                  "stop" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  }
+                }
+              }
+            }
+          }
+        }
+      aws_lambda_sink_0.1.json: |-
+        {
+          "channels" : {
+            "stable" : {
+              "shard_metadata" : {
+                "connector_revision" : "8",
+                "connector_type" : "sink",
+                "connector_image" : "quay.io/rhoas/cos-connector-aws-lambda:0.1.8",
+                "operators" : [ {
+                  "type" : "camel-connector-operator",
+                  "version" : "[1.0.0,2.0.0)"
+                } ],
+                "kamelets" : {
+                  "adapter" : {
+                    "name" : "aws-lambda-sink",
+                    "prefix" : "aws"
+                  },
+                  "kafka" : {
+                    "name" : "cos-kafka-source",
+                    "prefix" : "kafka"
+                  },
+                  "processors" : {
+                    "throttle" : "throttle-action",
+                    "jsonpath_set" : "cos-jsonpath-set-action",
+                    "log" : "cos-log-action",
+                    "jsonpath_rename" : "cos-jsonpath-rename-action",
+                    "jsonpath_extract" : "cos-jsonpath-extract-action",
+                    "jsonpath_remove" : "cos-jsonpath-remove-action"
+                  }
+                }
+              }
+            }
+          },
+          "connector_type" : {
+            "id" : "aws_lambda_sink_0.1",
+            "kind" : "ConnectorType",
+            "icon_href" : "TODO",
+            "name" : "AWS Lambda Sink",
+            "description" : "AWS Lambda Sink",
+            "version" : "0.1",
+            "labels" : [ "sink" ],
+            "capabilities" : [ "error_handler", "processors" ],
+            "channels" : [ "stable" ],
+            "schema" : {
+              "type" : "object",
+              "required" : [ "aws_function", "aws_region", "kafka_topic" ],
+              "properties" : {
+                "aws_function" : {
+                  "title" : "Function Name",
+                  "description" : "The Lambda Function name",
+                  "type" : "string"
+                },
+                "aws_access_key" : {
+                  "title" : "Access Key",
+                  "x-group" : "credentials",
+                  "oneOf" : [ {
+                    "title" : "Access Key",
+                    "description" : "The access key obtained from AWS",
+                    "type" : "string",
+                    "format" : "password"
+                  }, {
+                    "description" : "An opaque reference to the aws_access_key",
+                    "type" : "object",
+                    "properties" : { }
+                  } ]
+                },
+                "aws_secret_key" : {
+                  "title" : "Secret Key",
+                  "x-group" : "credentials",
+                  "oneOf" : [ {
+                    "title" : "Secret Key",
+                    "description" : "The secret key obtained from AWS",
+                    "type" : "string",
+                    "format" : "password"
+                  }, {
+                    "description" : "An opaque reference to the aws_secret_key",
+                    "type" : "object",
+                    "properties" : { }
+                  } ]
+                },
+                "aws_region" : {
+                  "title" : "AWS Region",
+                  "description" : "The AWS region to connect to",
+                  "type" : "string",
+                  "example" : "eu-west-1"
+                },
+                "aws_use_default_credentials_provider" : {
+                  "title" : "Default Credentials Provider",
+                  "description" : "Set whether the Lambda client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.",
+                  "type" : "boolean",
+                  "default" : false
+                },
+                "kafka_topic" : {
+                  "title" : "Topic Names",
+                  "description" : "Comma separated list of Kafka topic names",
+                  "type" : "string"
+                },
+                "processors" : {
+                  "type" : "array",
+                  "items" : {
+                    "oneOf" : [ {
+                      "type" : "object",
+                      "required" : [ "throttle" ],
+                      "properties" : {
+                        "throttle" : {
+                          "$ref" : "#/$defs/processors/throttle"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "log" ],
+                      "properties" : {
+                        "log" : {
+                          "$ref" : "#/$defs/processors/log"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_extract" ],
+                      "properties" : {
+                        "jsonpath_extract" : {
+                          "$ref" : "#/$defs/processors/jsonpath_extract"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_remove" ],
+                      "properties" : {
+                        "jsonpath_remove" : {
+                          "$ref" : "#/$defs/processors/jsonpath_remove"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_rename" ],
+                      "properties" : {
+                        "jsonpath_rename" : {
+                          "$ref" : "#/$defs/processors/jsonpath_rename"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_set" ],
+                      "properties" : {
+                        "jsonpath_set" : {
+                          "$ref" : "#/$defs/processors/jsonpath_set"
+                        }
+                      }
+                    } ]
+                  }
+                },
+                "error_handler" : {
+                  "type" : "object",
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "dead_letter_queue" ],
+                    "properties" : {
+                      "dead_letter_queue" : {
+                        "$ref" : "#/$defs/error_handler/dead_letter_queue"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "log" ],
+                    "properties" : {
+                      "log" : {
+                        "$ref" : "#/$defs/error_handler/log"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "stop" ],
+                    "properties" : {
+                      "stop" : {
+                        "$ref" : "#/$defs/error_handler/stop"
+                      }
+                    }
+                  } ]
+                }
+              },
+              "$defs" : {
+                "processors" : {
+                  "throttle" : {
+                    "title" : "Throttle Action",
+                    "description" : "The Throttle action allows to ensure that a specific sink does not get overloaded.",
+                    "required" : [ "messages" ],
+                    "properties" : {
+                      "messages" : {
+                        "title" : "Messages Number",
+                        "description" : "The number of messages to send in the time period set",
+                        "type" : "integer",
+                        "example" : 10
+                      },
+                      "timePeriod" : {
+                        "title" : "Time Period",
+                        "description" : "Sets the time period during which the maximum request count is valid for, in milliseconds",
+                        "type" : "string",
+                        "default" : "1000"
+                      }
+                    },
+                    "type" : "object"
+                  },
+                  "log" : {
+                    "title" : "Log",
+                    "description" : "Log payload.",
+                    "type" : "object",
+                    "properties" : {
+                      "multiLine" : {
+                        "title" : "Multi Line",
+                        "description" : "Multi Line",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showProperties" : {
+                        "title" : "Show Properties",
+                        "description" : "Show Properties",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showHeaders" : {
+                        "title" : "Show Headers",
+                        "description" : "Show Headers",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      }
+                    }
+                  },
+                  "jsonpath_extract" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_remove" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_rename" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "newKey" : {
+                        "title" : "NewKey",
+                        "description" : "NewKey",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_set" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "title" : "Value",
+                        "description" : "Value",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "dead_letter_queue" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "topic" ],
+                    "properties" : {
+                      "topic" : {
+                        "type" : "string",
+                        "title" : "Dead Letter Topic Name",
+                        "description" : "The name of the Kafka topic used as dead letter queue"
+                      }
+                    }
+                  },
+                  "log" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  },
+                  "stop" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  }
+                }
+              }
+            }
+          }
+        }
+      aws_s3_sink_0.1.json: |-
+        {
+          "channels" : {
+            "stable" : {
+              "shard_metadata" : {
+                "connector_revision" : "8",
+                "connector_type" : "sink",
+                "connector_image" : "quay.io/rhoas/cos-connector-aws-s3:0.1.8",
+                "operators" : [ {
+                  "type" : "camel-connector-operator",
+                  "version" : "[1.0.0,2.0.0)"
+                } ],
+                "kamelets" : {
+                  "adapter" : {
+                    "name" : "aws-s3-sink",
+                    "prefix" : "aws"
+                  },
+                  "kafka" : {
+                    "name" : "cos-kafka-source",
+                    "prefix" : "kafka"
+                  },
+                  "processors" : {
+                    "throttle" : "throttle-action",
+                    "jsonpath_set" : "cos-jsonpath-set-action",
+                    "log" : "cos-log-action",
+                    "jsonpath_rename" : "cos-jsonpath-rename-action",
+                    "jsonpath_extract" : "cos-jsonpath-extract-action",
+                    "jsonpath_remove" : "cos-jsonpath-remove-action"
+                  }
+                },
+                "annotations" : {
+                  "trait.camel.apache.org/container.request-memory" : "128m",
+                  "trait.camel.apache.org/container.request-cpu" : "1"
+                }
+              }
+            }
+          },
+          "connector_type" : {
+            "id" : "aws_s3_sink_0.1",
+            "kind" : "ConnectorType",
+            "icon_href" : "TODO",
+            "name" : "AWS S3 Sink",
+            "description" : "AWS S3 Sink",
+            "version" : "0.1",
+            "labels" : [ "sink" ],
+            "capabilities" : [ "error_handler", "processors" ],
+            "channels" : [ "stable" ],
+            "schema" : {
+              "type" : "object",
+              "required" : [ "aws_bucket_name_or_arn", "aws_region", "kafka_topic" ],
+              "properties" : {
+                "aws_bucket_name_or_arn" : {
+                  "title" : "Bucket Name",
+                  "description" : "The S3 Bucket name or ARN.",
+                  "type" : "string"
+                },
+                "aws_access_key" : {
+                  "title" : "Access Key",
+                  "x-group" : "credentials",
+                  "oneOf" : [ {
+                    "title" : "Access Key",
+                    "description" : "The access key obtained from AWS.",
+                    "type" : "string",
+                    "format" : "password"
+                  }, {
+                    "description" : "An opaque reference to the aws_access_key",
+                    "type" : "object",
+                    "properties" : { }
+                  } ]
+                },
+                "aws_secret_key" : {
+                  "title" : "Secret Key",
+                  "x-group" : "credentials",
+                  "oneOf" : [ {
+                    "title" : "Secret Key",
+                    "description" : "The secret key obtained from AWS.",
+                    "type" : "string",
+                    "format" : "password"
+                  }, {
+                    "description" : "An opaque reference to the aws_secret_key",
+                    "type" : "object",
+                    "properties" : { }
+                  } ]
+                },
+                "aws_region" : {
+                  "title" : "AWS Region",
+                  "description" : "The AWS region to connect to.",
+                  "type" : "string",
+                  "example" : "eu-west-1"
+                },
+                "aws_auto_create_bucket" : {
+                  "title" : "Autocreate Bucket",
+                  "description" : "Setting the autocreation of the S3 bucket bucketName.",
+                  "type" : "boolean",
+                  "default" : false
+                },
+                "aws_use_default_credentials_provider" : {
+                  "title" : "Default Credentials Provider",
+                  "description" : "Set whether the S3 client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.",
+                  "type" : "boolean",
+                  "default" : false
+                },
+                "kafka_topic" : {
+                  "title" : "Topic Names",
+                  "description" : "Comma separated list of Kafka topic names",
+                  "type" : "string"
+                },
+                "processors" : {
+                  "type" : "array",
+                  "items" : {
+                    "oneOf" : [ {
+                      "type" : "object",
+                      "required" : [ "throttle" ],
+                      "properties" : {
+                        "throttle" : {
+                          "$ref" : "#/$defs/processors/throttle"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "log" ],
+                      "properties" : {
+                        "log" : {
+                          "$ref" : "#/$defs/processors/log"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_extract" ],
+                      "properties" : {
+                        "jsonpath_extract" : {
+                          "$ref" : "#/$defs/processors/jsonpath_extract"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_remove" ],
+                      "properties" : {
+                        "jsonpath_remove" : {
+                          "$ref" : "#/$defs/processors/jsonpath_remove"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_rename" ],
+                      "properties" : {
+                        "jsonpath_rename" : {
+                          "$ref" : "#/$defs/processors/jsonpath_rename"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_set" ],
+                      "properties" : {
+                        "jsonpath_set" : {
+                          "$ref" : "#/$defs/processors/jsonpath_set"
+                        }
+                      }
+                    } ]
+                  }
+                },
+                "error_handler" : {
+                  "type" : "object",
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "dead_letter_queue" ],
+                    "properties" : {
+                      "dead_letter_queue" : {
+                        "$ref" : "#/$defs/error_handler/dead_letter_queue"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "log" ],
+                    "properties" : {
+                      "log" : {
+                        "$ref" : "#/$defs/error_handler/log"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "stop" ],
+                    "properties" : {
+                      "stop" : {
+                        "$ref" : "#/$defs/error_handler/stop"
+                      }
+                    }
+                  } ]
+                }
+              },
+              "$defs" : {
+                "processors" : {
+                  "throttle" : {
+                    "title" : "Throttle Action",
+                    "description" : "The Throttle action allows to ensure that a specific sink does not get overloaded.",
+                    "required" : [ "messages" ],
+                    "properties" : {
+                      "messages" : {
+                        "title" : "Messages Number",
+                        "description" : "The number of messages to send in the time period set",
+                        "type" : "integer",
+                        "example" : 10
+                      },
+                      "timePeriod" : {
+                        "title" : "Time Period",
+                        "description" : "Sets the time period during which the maximum request count is valid for, in milliseconds",
+                        "type" : "string",
+                        "default" : "1000"
+                      }
+                    },
+                    "type" : "object"
+                  },
+                  "log" : {
+                    "title" : "Log",
+                    "description" : "Log payload.",
+                    "type" : "object",
+                    "properties" : {
+                      "multiLine" : {
+                        "title" : "Multi Line",
+                        "description" : "Multi Line",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showProperties" : {
+                        "title" : "Show Properties",
+                        "description" : "Show Properties",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showHeaders" : {
+                        "title" : "Show Headers",
+                        "description" : "Show Headers",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      }
+                    }
+                  },
+                  "jsonpath_extract" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_remove" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_rename" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "newKey" : {
+                        "title" : "NewKey",
+                        "description" : "NewKey",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_set" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "title" : "Value",
+                        "description" : "Value",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "dead_letter_queue" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "topic" ],
+                    "properties" : {
+                      "topic" : {
+                        "type" : "string",
+                        "title" : "Dead Letter Topic Name",
+                        "description" : "The name of the Kafka topic used as dead letter queue"
+                      }
+                    }
+                  },
+                  "log" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  },
+                  "stop" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  }
+                }
+              }
+            }
+          }
+        }
+      aws_s3_source_0.1.json: |-
+        {
+          "channels" : {
+            "stable" : {
+              "shard_metadata" : {
+                "connector_revision" : "8",
+                "connector_type" : "source",
+                "connector_image" : "quay.io/rhoas/cos-connector-aws-s3:0.1.8",
+                "operators" : [ {
+                  "type" : "camel-connector-operator",
+                  "version" : "[1.0.0,2.0.0)"
+                } ],
+                "kamelets" : {
+                  "adapter" : {
+                    "name" : "aws-s3-source",
+                    "prefix" : "aws"
+                  },
+                  "kafka" : {
+                    "name" : "cos-kafka-sink",
+                    "prefix" : "kafka"
+                  },
+                  "processors" : {
+                    "throttle" : "throttle-action",
+                    "jsonpath_set" : "cos-jsonpath-set-action",
+                    "log" : "cos-log-action",
+                    "jsonpath_rename" : "cos-jsonpath-rename-action",
+                    "jsonpath_extract" : "cos-jsonpath-extract-action",
+                    "jsonpath_remove" : "cos-jsonpath-remove-action"
+                  }
+                },
+                "annotations" : {
+                  "trait.camel.apache.org/container.request-memory" : "128m",
+                  "trait.camel.apache.org/container.request-cpu" : "1"
+                }
+              }
+            }
+          },
+          "connector_type" : {
+            "id" : "aws_s3_source_0.1",
+            "kind" : "ConnectorType",
+            "icon_href" : "TODO",
+            "name" : "AWS S3 Source",
+            "description" : "AWS S3 Source",
+            "version" : "0.1",
+            "labels" : [ "source" ],
+            "capabilities" : [ "error_handler", "processors" ],
+            "channels" : [ "stable" ],
+            "schema" : {
+              "type" : "object",
+              "required" : [ "aws_bucket_name_or_arn", "aws_region", "kafka_topic" ],
+              "properties" : {
+                "aws_bucket_name_or_arn" : {
+                  "title" : "Bucket Name",
+                  "description" : "The S3 Bucket name or ARN",
+                  "type" : "string"
+                },
+                "aws_delete_after_read" : {
+                  "title" : "Auto-delete Objects",
+                  "description" : "Delete objects after consuming them",
+                  "type" : "boolean",
+                  "default" : true
+                },
+                "aws_access_key" : {
+                  "title" : "Access Key",
+                  "x-group" : "credentials",
+                  "oneOf" : [ {
+                    "title" : "Access Key",
+                    "description" : "The access key obtained from AWS",
+                    "type" : "string",
+                    "format" : "password"
+                  }, {
+                    "description" : "An opaque reference to the aws_access_key",
+                    "type" : "object",
+                    "properties" : { }
+                  } ]
+                },
+                "aws_secret_key" : {
+                  "title" : "Secret Key",
+                  "x-group" : "credentials",
+                  "oneOf" : [ {
+                    "title" : "Secret Key",
+                    "description" : "The secret key obtained from AWS",
+                    "type" : "string",
+                    "format" : "password"
+                  }, {
+                    "description" : "An opaque reference to the aws_secret_key",
+                    "type" : "object",
+                    "properties" : { }
+                  } ]
+                },
+                "aws_region" : {
+                  "title" : "AWS Region",
+                  "description" : "The AWS region to connect to",
+                  "type" : "string",
+                  "example" : "eu-west-1"
+                },
+                "aws_auto_create_bucket" : {
+                  "title" : "Autocreate Bucket",
+                  "description" : "Setting the autocreation of the S3 bucket bucketName.",
+                  "type" : "boolean",
+                  "default" : false
+                },
+                "aws_include_body" : {
+                  "title" : "Include Body",
+                  "description" : "If it is true, the exchange will be consumed and put into the body and closed. If false the S3Object stream will be put raw into the body and the headers will be set with the S3 object metadata.",
+                  "type" : "boolean",
+                  "default" : true
+                },
+                "aws_prefix" : {
+                  "title" : "Prefix",
+                  "description" : "The AWS S3 bucket prefix to consider while searching",
+                  "type" : "string",
+                  "example" : "folder/"
+                },
+                "aws_ignore_body" : {
+                  "title" : "Ignore Body",
+                  "description" : "If it is true, the S3 Object Body will be ignored completely, if it is set to false the S3 Object will be put in the body. Setting this to true, will override any behavior defined by includeBody option.",
+                  "type" : "boolean",
+                  "default" : false
+                },
+                "aws_use_default_credentials_provider" : {
+                  "title" : "Default Credentials Provider",
+                  "description" : "Set whether the S3 client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.",
+                  "type" : "boolean",
+                  "default" : false
+                },
+                "kafka_topic" : {
+                  "title" : "Topic Names",
+                  "description" : "Comma separated list of Kafka topic names",
+                  "type" : "string"
+                },
+                "processors" : {
+                  "type" : "array",
+                  "items" : {
+                    "oneOf" : [ {
+                      "type" : "object",
+                      "required" : [ "throttle" ],
+                      "properties" : {
+                        "throttle" : {
+                          "$ref" : "#/$defs/processors/throttle"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "log" ],
+                      "properties" : {
+                        "log" : {
+                          "$ref" : "#/$defs/processors/log"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_extract" ],
+                      "properties" : {
+                        "jsonpath_extract" : {
+                          "$ref" : "#/$defs/processors/jsonpath_extract"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_remove" ],
+                      "properties" : {
+                        "jsonpath_remove" : {
+                          "$ref" : "#/$defs/processors/jsonpath_remove"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_rename" ],
+                      "properties" : {
+                        "jsonpath_rename" : {
+                          "$ref" : "#/$defs/processors/jsonpath_rename"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_set" ],
+                      "properties" : {
+                        "jsonpath_set" : {
+                          "$ref" : "#/$defs/processors/jsonpath_set"
+                        }
+                      }
+                    } ]
+                  }
+                },
+                "error_handler" : {
+                  "type" : "object",
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "dead_letter_queue" ],
+                    "properties" : {
+                      "dead_letter_queue" : {
+                        "$ref" : "#/$defs/error_handler/dead_letter_queue"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "log" ],
+                    "properties" : {
+                      "log" : {
+                        "$ref" : "#/$defs/error_handler/log"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "stop" ],
+                    "properties" : {
+                      "stop" : {
+                        "$ref" : "#/$defs/error_handler/stop"
+                      }
+                    }
+                  } ]
+                }
+              },
+              "$defs" : {
+                "processors" : {
+                  "throttle" : {
+                    "title" : "Throttle Action",
+                    "description" : "The Throttle action allows to ensure that a specific sink does not get overloaded.",
+                    "required" : [ "messages" ],
+                    "properties" : {
+                      "messages" : {
+                        "title" : "Messages Number",
+                        "description" : "The number of messages to send in the time period set",
+                        "type" : "integer",
+                        "example" : 10
+                      },
+                      "timePeriod" : {
+                        "title" : "Time Period",
+                        "description" : "Sets the time period during which the maximum request count is valid for, in milliseconds",
+                        "type" : "string",
+                        "default" : "1000"
+                      }
+                    },
+                    "type" : "object"
+                  },
+                  "log" : {
+                    "title" : "Log",
+                    "description" : "Log payload.",
+                    "type" : "object",
+                    "properties" : {
+                      "multiLine" : {
+                        "title" : "Multi Line",
+                        "description" : "Multi Line",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showProperties" : {
+                        "title" : "Show Properties",
+                        "description" : "Show Properties",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showHeaders" : {
+                        "title" : "Show Headers",
+                        "description" : "Show Headers",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      }
+                    }
+                  },
+                  "jsonpath_extract" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_remove" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_rename" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "newKey" : {
+                        "title" : "NewKey",
+                        "description" : "NewKey",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_set" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "title" : "Value",
+                        "description" : "Value",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "dead_letter_queue" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "topic" ],
+                    "properties" : {
+                      "topic" : {
+                        "type" : "string",
+                        "title" : "Dead Letter Topic Name",
+                        "description" : "The name of the Kafka topic used as dead letter queue"
+                      }
+                    }
+                  },
+                  "log" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  },
+                  "stop" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  }
+                }
+              }
+            }
+          }
+        }
+      aws_sns_sink_0.1.json: |-
+        {
+          "channels" : {
+            "stable" : {
+              "shard_metadata" : {
+                "connector_revision" : "8",
+                "connector_type" : "sink",
+                "connector_image" : "quay.io/rhoas/cos-connector-aws-sns:0.1.8",
+                "operators" : [ {
+                  "type" : "camel-connector-operator",
+                  "version" : "[1.0.0,2.0.0)"
+                } ],
+                "kamelets" : {
+                  "adapter" : {
+                    "name" : "aws-sns-sink",
+                    "prefix" : "aws"
+                  },
+                  "kafka" : {
+                    "name" : "cos-kafka-source",
+                    "prefix" : "kafka"
+                  },
+                  "processors" : {
+                    "throttle" : "throttle-action",
+                    "jsonpath_set" : "cos-jsonpath-set-action",
+                    "log" : "cos-log-action",
+                    "jsonpath_rename" : "cos-jsonpath-rename-action",
+                    "jsonpath_extract" : "cos-jsonpath-extract-action",
+                    "jsonpath_remove" : "cos-jsonpath-remove-action"
+                  }
+                }
+              }
+            }
+          },
+          "connector_type" : {
+            "id" : "aws_sns_sink_0.1",
+            "kind" : "ConnectorType",
+            "icon_href" : "TODO",
+            "name" : "AWS SNS Sink",
+            "description" : "AWS SNS Sink",
+            "version" : "0.1",
+            "labels" : [ "sink" ],
+            "capabilities" : [ "error_handler", "processors" ],
+            "channels" : [ "stable" ],
+            "schema" : {
+              "type" : "object",
+              "required" : [ "aws_topic_name_or_arn", "aws_region", "kafka_topic" ],
+              "properties" : {
+                "aws_topic_name_or_arn" : {
+                  "title" : "Topic Name",
+                  "description" : "The SQS Topic name or ARN",
+                  "type" : "string"
+                },
+                "aws_access_key" : {
+                  "title" : "Access Key",
+                  "x-group" : "credentials",
+                  "oneOf" : [ {
+                    "title" : "Access Key",
+                    "description" : "The access key obtained from AWS",
+                    "type" : "string",
+                    "format" : "password"
+                  }, {
+                    "description" : "An opaque reference to the aws_access_key",
+                    "type" : "object",
+                    "properties" : { }
+                  } ]
+                },
+                "aws_secret_key" : {
+                  "title" : "Secret Key",
+                  "x-group" : "credentials",
+                  "oneOf" : [ {
+                    "title" : "Secret Key",
+                    "description" : "The secret key obtained from AWS",
+                    "type" : "string",
+                    "format" : "password"
+                  }, {
+                    "description" : "An opaque reference to the aws_secret_key",
+                    "type" : "object",
+                    "properties" : { }
+                  } ]
+                },
+                "aws_region" : {
+                  "title" : "AWS Region",
+                  "description" : "The AWS region to connect to",
+                  "type" : "string",
+                  "example" : "eu-west-1"
+                },
+                "aws_auto_create_topic" : {
+                  "title" : "Autocreate Topic",
+                  "description" : "Setting the autocreation of the SNS topic.",
+                  "type" : "boolean",
+                  "default" : false
+                },
+                "aws_use_default_credentials_provider" : {
+                  "title" : "Default Credentials Provider",
+                  "description" : "Set whether the SNS client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.",
+                  "type" : "boolean",
+                  "default" : false
+                },
+                "kafka_topic" : {
+                  "title" : "Topic Names",
+                  "description" : "Comma separated list of Kafka topic names",
+                  "type" : "string"
+                },
+                "processors" : {
+                  "type" : "array",
+                  "items" : {
+                    "oneOf" : [ {
+                      "type" : "object",
+                      "required" : [ "throttle" ],
+                      "properties" : {
+                        "throttle" : {
+                          "$ref" : "#/$defs/processors/throttle"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "log" ],
+                      "properties" : {
+                        "log" : {
+                          "$ref" : "#/$defs/processors/log"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_extract" ],
+                      "properties" : {
+                        "jsonpath_extract" : {
+                          "$ref" : "#/$defs/processors/jsonpath_extract"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_remove" ],
+                      "properties" : {
+                        "jsonpath_remove" : {
+                          "$ref" : "#/$defs/processors/jsonpath_remove"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_rename" ],
+                      "properties" : {
+                        "jsonpath_rename" : {
+                          "$ref" : "#/$defs/processors/jsonpath_rename"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_set" ],
+                      "properties" : {
+                        "jsonpath_set" : {
+                          "$ref" : "#/$defs/processors/jsonpath_set"
+                        }
+                      }
+                    } ]
+                  }
+                },
+                "error_handler" : {
+                  "type" : "object",
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "dead_letter_queue" ],
+                    "properties" : {
+                      "dead_letter_queue" : {
+                        "$ref" : "#/$defs/error_handler/dead_letter_queue"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "log" ],
+                    "properties" : {
+                      "log" : {
+                        "$ref" : "#/$defs/error_handler/log"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "stop" ],
+                    "properties" : {
+                      "stop" : {
+                        "$ref" : "#/$defs/error_handler/stop"
+                      }
+                    }
+                  } ]
+                }
+              },
+              "$defs" : {
+                "processors" : {
+                  "throttle" : {
+                    "title" : "Throttle Action",
+                    "description" : "The Throttle action allows to ensure that a specific sink does not get overloaded.",
+                    "required" : [ "messages" ],
+                    "properties" : {
+                      "messages" : {
+                        "title" : "Messages Number",
+                        "description" : "The number of messages to send in the time period set",
+                        "type" : "integer",
+                        "example" : 10
+                      },
+                      "timePeriod" : {
+                        "title" : "Time Period",
+                        "description" : "Sets the time period during which the maximum request count is valid for, in milliseconds",
+                        "type" : "string",
+                        "default" : "1000"
+                      }
+                    },
+                    "type" : "object"
+                  },
+                  "log" : {
+                    "title" : "Log",
+                    "description" : "Log payload.",
+                    "type" : "object",
+                    "properties" : {
+                      "multiLine" : {
+                        "title" : "Multi Line",
+                        "description" : "Multi Line",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showProperties" : {
+                        "title" : "Show Properties",
+                        "description" : "Show Properties",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showHeaders" : {
+                        "title" : "Show Headers",
+                        "description" : "Show Headers",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      }
+                    }
+                  },
+                  "jsonpath_extract" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_remove" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_rename" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "newKey" : {
+                        "title" : "NewKey",
+                        "description" : "NewKey",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_set" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "title" : "Value",
+                        "description" : "Value",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "dead_letter_queue" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "topic" ],
+                    "properties" : {
+                      "topic" : {
+                        "type" : "string",
+                        "title" : "Dead Letter Topic Name",
+                        "description" : "The name of the Kafka topic used as dead letter queue"
+                      }
+                    }
+                  },
+                  "log" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  },
+                  "stop" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  }
+                }
+              }
+            }
+          }
+        }
+      aws_sqs_sink_0.1.json: |-
+        {
+          "channels" : {
+            "stable" : {
+              "shard_metadata" : {
+                "connector_revision" : "8",
+                "connector_type" : "sink",
+                "connector_image" : "quay.io/rhoas/cos-connector-aws-sqs:0.1.8",
+                "operators" : [ {
+                  "type" : "camel-connector-operator",
+                  "version" : "[1.0.0,2.0.0)"
+                } ],
+                "kamelets" : {
+                  "adapter" : {
+                    "name" : "aws-sqs-sink",
+                    "prefix" : "aws"
+                  },
+                  "kafka" : {
+                    "name" : "cos-kafka-source",
+                    "prefix" : "kafka"
+                  },
+                  "processors" : {
+                    "throttle" : "throttle-action",
+                    "jsonpath_set" : "cos-jsonpath-set-action",
+                    "log" : "cos-log-action",
+                    "jsonpath_rename" : "cos-jsonpath-rename-action",
+                    "jsonpath_extract" : "cos-jsonpath-extract-action",
+                    "jsonpath_remove" : "cos-jsonpath-remove-action"
+                  }
+                },
+                "annotations" : {
+                  "trait.camel.apache.org/container.request-memory" : "128m",
+                  "trait.camel.apache.org/container.request-cpu" : "1"
+                }
+              }
+            }
+          },
+          "connector_type" : {
+            "id" : "aws_sqs_sink_0.1",
+            "kind" : "ConnectorType",
+            "icon_href" : "TODO",
+            "name" : "AWS SQS Sink",
+            "description" : "AWS SQS Sink",
+            "version" : "0.1",
+            "labels" : [ "sink" ],
+            "capabilities" : [ "error_handler", "processors" ],
+            "channels" : [ "stable" ],
+            "schema" : {
+              "type" : "object",
+              "required" : [ "aws_queue_name_or_arn", "aws_region", "kafka_topic" ],
+              "properties" : {
+                "aws_queue_name_or_arn" : {
+                  "title" : "Queue Name",
+                  "description" : "The SQS Queue name or ARN",
+                  "type" : "string"
+                },
+                "aws_access_key" : {
+                  "title" : "Access Key",
+                  "x-group" : "credentials",
+                  "oneOf" : [ {
+                    "title" : "Access Key",
+                    "description" : "The access key obtained from AWS",
+                    "type" : "string",
+                    "format" : "password"
+                  }, {
+                    "description" : "An opaque reference to the aws_access_key",
+                    "type" : "object",
+                    "properties" : { }
+                  } ]
+                },
+                "aws_secret_key" : {
+                  "title" : "Secret Key",
+                  "x-group" : "credentials",
+                  "oneOf" : [ {
+                    "title" : "Secret Key",
+                    "description" : "The secret key obtained from AWS",
+                    "type" : "string",
+                    "format" : "password"
+                  }, {
+                    "description" : "An opaque reference to the aws_secret_key",
+                    "type" : "object",
+                    "properties" : { }
+                  } ]
+                },
+                "aws_region" : {
+                  "title" : "AWS Region",
+                  "description" : "The AWS region to connect to",
+                  "type" : "string",
+                  "example" : "eu-west-1"
+                },
+                "aws_auto_create_queue" : {
+                  "title" : "Autocreate Queue",
+                  "description" : "Setting the autocreation of the SQS queue.",
+                  "type" : "boolean",
+                  "default" : false
+                },
+                "aws_amazon_a_w_s_host" : {
+                  "title" : "AWS Host",
+                  "description" : "The hostname of the Amazon AWS cloud.",
+                  "type" : "string"
+                },
+                "aws_protocol" : {
+                  "title" : "Protocol",
+                  "description" : "The underlying protocol used to communicate with SQS",
+                  "type" : "string",
+                  "example" : "http or https",
+                  "default" : "https"
+                },
+                "aws_use_default_credentials_provider" : {
+                  "title" : "Default Credentials Provider",
+                  "description" : "Set whether the SQS client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.",
+                  "type" : "boolean",
+                  "default" : false
+                },
+                "kafka_topic" : {
+                  "title" : "Topic Names",
+                  "description" : "Comma separated list of Kafka topic names",
+                  "type" : "string"
+                },
+                "processors" : {
+                  "type" : "array",
+                  "items" : {
+                    "oneOf" : [ {
+                      "type" : "object",
+                      "required" : [ "throttle" ],
+                      "properties" : {
+                        "throttle" : {
+                          "$ref" : "#/$defs/processors/throttle"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "log" ],
+                      "properties" : {
+                        "log" : {
+                          "$ref" : "#/$defs/processors/log"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_extract" ],
+                      "properties" : {
+                        "jsonpath_extract" : {
+                          "$ref" : "#/$defs/processors/jsonpath_extract"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_remove" ],
+                      "properties" : {
+                        "jsonpath_remove" : {
+                          "$ref" : "#/$defs/processors/jsonpath_remove"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_rename" ],
+                      "properties" : {
+                        "jsonpath_rename" : {
+                          "$ref" : "#/$defs/processors/jsonpath_rename"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_set" ],
+                      "properties" : {
+                        "jsonpath_set" : {
+                          "$ref" : "#/$defs/processors/jsonpath_set"
+                        }
+                      }
+                    } ]
+                  }
+                },
+                "error_handler" : {
+                  "type" : "object",
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "dead_letter_queue" ],
+                    "properties" : {
+                      "dead_letter_queue" : {
+                        "$ref" : "#/$defs/error_handler/dead_letter_queue"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "log" ],
+                    "properties" : {
+                      "log" : {
+                        "$ref" : "#/$defs/error_handler/log"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "stop" ],
+                    "properties" : {
+                      "stop" : {
+                        "$ref" : "#/$defs/error_handler/stop"
+                      }
+                    }
+                  } ]
+                }
+              },
+              "$defs" : {
+                "processors" : {
+                  "throttle" : {
+                    "title" : "Throttle Action",
+                    "description" : "The Throttle action allows to ensure that a specific sink does not get overloaded.",
+                    "required" : [ "messages" ],
+                    "properties" : {
+                      "messages" : {
+                        "title" : "Messages Number",
+                        "description" : "The number of messages to send in the time period set",
+                        "type" : "integer",
+                        "example" : 10
+                      },
+                      "timePeriod" : {
+                        "title" : "Time Period",
+                        "description" : "Sets the time period during which the maximum request count is valid for, in milliseconds",
+                        "type" : "string",
+                        "default" : "1000"
+                      }
+                    },
+                    "type" : "object"
+                  },
+                  "log" : {
+                    "title" : "Log",
+                    "description" : "Log payload.",
+                    "type" : "object",
+                    "properties" : {
+                      "multiLine" : {
+                        "title" : "Multi Line",
+                        "description" : "Multi Line",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showProperties" : {
+                        "title" : "Show Properties",
+                        "description" : "Show Properties",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showHeaders" : {
+                        "title" : "Show Headers",
+                        "description" : "Show Headers",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      }
+                    }
+                  },
+                  "jsonpath_extract" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_remove" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_rename" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "newKey" : {
+                        "title" : "NewKey",
+                        "description" : "NewKey",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_set" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "title" : "Value",
+                        "description" : "Value",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "dead_letter_queue" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "topic" ],
+                    "properties" : {
+                      "topic" : {
+                        "type" : "string",
+                        "title" : "Dead Letter Topic Name",
+                        "description" : "The name of the Kafka topic used as dead letter queue"
+                      }
+                    }
+                  },
+                  "log" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  },
+                  "stop" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  }
+                }
+              }
+            }
+          }
+        }
+      aws_sqs_source_0.1.json: |-
+        {
+          "channels" : {
+            "stable" : {
+              "shard_metadata" : {
+                "connector_revision" : "8",
+                "connector_type" : "source",
+                "connector_image" : "quay.io/rhoas/cos-connector-aws-sqs:0.1.8",
+                "operators" : [ {
+                  "type" : "camel-connector-operator",
+                  "version" : "[1.0.0,2.0.0)"
+                } ],
+                "kamelets" : {
+                  "adapter" : {
+                    "name" : "aws-sqs-source",
+                    "prefix" : "aws"
+                  },
+                  "kafka" : {
+                    "name" : "cos-kafka-sink",
+                    "prefix" : "kafka"
+                  },
+                  "processors" : {
+                    "throttle" : "throttle-action",
+                    "jsonpath_set" : "cos-jsonpath-set-action",
+                    "log" : "cos-log-action",
+                    "jsonpath_rename" : "cos-jsonpath-rename-action",
+                    "jsonpath_extract" : "cos-jsonpath-extract-action",
+                    "jsonpath_remove" : "cos-jsonpath-remove-action"
+                  }
+                },
+                "annotations" : {
+                  "trait.camel.apache.org/container.request-memory" : "128m",
+                  "trait.camel.apache.org/container.request-cpu" : "1"
+                }
+              }
+            }
+          },
+          "connector_type" : {
+            "id" : "aws_sqs_source_0.1",
+            "kind" : "ConnectorType",
+            "icon_href" : "TODO",
+            "name" : "AWS SQS Source",
+            "description" : "AWS SQS Source",
+            "version" : "0.1",
+            "labels" : [ "source" ],
+            "capabilities" : [ "error_handler", "processors" ],
+            "channels" : [ "stable" ],
+            "schema" : {
+              "type" : "object",
+              "required" : [ "aws_queue_name_or_arn", "aws_region", "kafka_topic" ],
+              "properties" : {
+                "aws_queue_name_or_arn" : {
+                  "title" : "Queue Name",
+                  "description" : "The SQS Queue Name or ARN",
+                  "type" : "string"
+                },
+                "aws_delete_after_read" : {
+                  "title" : "Auto-delete Messages",
+                  "description" : "Delete messages after consuming them",
+                  "type" : "boolean",
+                  "default" : true
+                },
+                "aws_access_key" : {
+                  "title" : "Access Key",
+                  "x-group" : "credentials",
+                  "oneOf" : [ {
+                    "title" : "Access Key",
+                    "description" : "The access key obtained from AWS",
+                    "type" : "string",
+                    "format" : "password"
+                  }, {
+                    "description" : "An opaque reference to the aws_access_key",
+                    "type" : "object",
+                    "properties" : { }
+                  } ]
+                },
+                "aws_secret_key" : {
+                  "title" : "Secret Key",
+                  "x-group" : "credentials",
+                  "oneOf" : [ {
+                    "title" : "Secret Key",
+                    "description" : "The secret key obtained from AWS",
+                    "type" : "string",
+                    "format" : "password"
+                  }, {
+                    "description" : "An opaque reference to the aws_secret_key",
+                    "type" : "object",
+                    "properties" : { }
+                  } ]
+                },
+                "aws_region" : {
+                  "title" : "AWS Region",
+                  "description" : "The AWS region to connect to",
+                  "type" : "string",
+                  "example" : "eu-west-1"
+                },
+                "aws_auto_create_queue" : {
+                  "title" : "Autocreate Queue",
+                  "description" : "Setting the autocreation of the SQS queue.",
+                  "type" : "boolean",
+                  "default" : false
+                },
+                "aws_amazon_a_w_s_host" : {
+                  "title" : "AWS Host",
+                  "description" : "The hostname of the Amazon AWS cloud.",
+                  "type" : "string"
+                },
+                "aws_protocol" : {
+                  "title" : "Protocol",
+                  "description" : "The underlying protocol used to communicate with SQS",
+                  "type" : "string",
+                  "example" : "http or https",
+                  "default" : "https"
+                },
+                "aws_queue_u_r_l" : {
+                  "title" : "Queue URL",
+                  "description" : "The full SQS Queue URL (required if using KEDA)",
+                  "type" : "string"
+                },
+                "aws_use_default_credentials_provider" : {
+                  "title" : "Default Credentials Provider",
+                  "description" : "Set whether the SQS client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.",
+                  "type" : "boolean",
+                  "default" : false
+                },
+                "kafka_topic" : {
+                  "title" : "Topic Names",
+                  "description" : "Comma separated list of Kafka topic names",
+                  "type" : "string"
+                },
+                "processors" : {
+                  "type" : "array",
+                  "items" : {
+                    "oneOf" : [ {
+                      "type" : "object",
+                      "required" : [ "throttle" ],
+                      "properties" : {
+                        "throttle" : {
+                          "$ref" : "#/$defs/processors/throttle"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "log" ],
+                      "properties" : {
+                        "log" : {
+                          "$ref" : "#/$defs/processors/log"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_extract" ],
+                      "properties" : {
+                        "jsonpath_extract" : {
+                          "$ref" : "#/$defs/processors/jsonpath_extract"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_remove" ],
+                      "properties" : {
+                        "jsonpath_remove" : {
+                          "$ref" : "#/$defs/processors/jsonpath_remove"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_rename" ],
+                      "properties" : {
+                        "jsonpath_rename" : {
+                          "$ref" : "#/$defs/processors/jsonpath_rename"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_set" ],
+                      "properties" : {
+                        "jsonpath_set" : {
+                          "$ref" : "#/$defs/processors/jsonpath_set"
+                        }
+                      }
+                    } ]
+                  }
+                },
+                "error_handler" : {
+                  "type" : "object",
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "dead_letter_queue" ],
+                    "properties" : {
+                      "dead_letter_queue" : {
+                        "$ref" : "#/$defs/error_handler/dead_letter_queue"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "log" ],
+                    "properties" : {
+                      "log" : {
+                        "$ref" : "#/$defs/error_handler/log"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "stop" ],
+                    "properties" : {
+                      "stop" : {
+                        "$ref" : "#/$defs/error_handler/stop"
+                      }
+                    }
+                  } ]
+                }
+              },
+              "$defs" : {
+                "processors" : {
+                  "throttle" : {
+                    "title" : "Throttle Action",
+                    "description" : "The Throttle action allows to ensure that a specific sink does not get overloaded.",
+                    "required" : [ "messages" ],
+                    "properties" : {
+                      "messages" : {
+                        "title" : "Messages Number",
+                        "description" : "The number of messages to send in the time period set",
+                        "type" : "integer",
+                        "example" : 10
+                      },
+                      "timePeriod" : {
+                        "title" : "Time Period",
+                        "description" : "Sets the time period during which the maximum request count is valid for, in milliseconds",
+                        "type" : "string",
+                        "default" : "1000"
+                      }
+                    },
+                    "type" : "object"
+                  },
+                  "log" : {
+                    "title" : "Log",
+                    "description" : "Log payload.",
+                    "type" : "object",
+                    "properties" : {
+                      "multiLine" : {
+                        "title" : "Multi Line",
+                        "description" : "Multi Line",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showProperties" : {
+                        "title" : "Show Properties",
+                        "description" : "Show Properties",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showHeaders" : {
+                        "title" : "Show Headers",
+                        "description" : "Show Headers",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      }
+                    }
+                  },
+                  "jsonpath_extract" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_remove" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_rename" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "newKey" : {
+                        "title" : "NewKey",
+                        "description" : "NewKey",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_set" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "title" : "Value",
+                        "description" : "Value",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "dead_letter_queue" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "topic" ],
+                    "properties" : {
+                      "topic" : {
+                        "type" : "string",
+                        "title" : "Dead Letter Topic Name",
+                        "description" : "The name of the Kafka topic used as dead letter queue"
+                      }
+                    }
+                  },
+                  "log" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  },
+                  "stop" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  }
+                }
+              }
+            }
+          }
+        }
+    kind: ConfigMap
+    metadata:
+      creationTimestamp: null
+      name: connector-catalog-camel-aws
+  - apiVersion: v1
+    data:
+      azure_storage_blob_sink_0.1.json: |-
+        {
+          "channels" : {
+            "stable" : {
+              "shard_metadata" : {
+                "connector_revision" : "8",
+                "connector_type" : "sink",
+                "connector_image" : "quay.io/rhoas/cos-connector-azure-storage-blob:0.1.8",
+                "operators" : [ {
+                  "type" : "camel-connector-operator",
+                  "version" : "[1.0.0,2.0.0)"
+                } ],
+                "kamelets" : {
+                  "adapter" : {
+                    "name" : "azure-storage-blob-sink",
+                    "prefix" : "azure"
+                  },
+                  "kafka" : {
+                    "name" : "cos-kafka-source",
+                    "prefix" : "kafka"
+                  },
+                  "processors" : {
+                    "throttle" : "throttle-action",
+                    "jsonpath_set" : "cos-jsonpath-set-action",
+                    "log" : "cos-log-action",
+                    "jsonpath_rename" : "cos-jsonpath-rename-action",
+                    "jsonpath_extract" : "cos-jsonpath-extract-action",
+                    "jsonpath_remove" : "cos-jsonpath-remove-action"
+                  }
+                },
+                "annotations" : {
+                  "trait.camel.apache.org/container.request-memory" : "128m",
+                  "trait.camel.apache.org/container.request-cpu" : "1"
+                }
+              }
+            }
+          },
+          "connector_type" : {
+            "id" : "azure_storage_blob_sink_0.1",
+            "kind" : "ConnectorType",
+            "icon_href" : "TODO",
+            "name" : "Azure Storage Blob Sink",
+            "description" : "Azure Storage Blob Sink",
+            "version" : "0.1",
+            "labels" : [ "sink" ],
+            "capabilities" : [ "error_handler", "processors" ],
+            "channels" : [ "stable" ],
+            "schema" : {
+              "type" : "object",
+              "required" : [ "azure_account_name", "azure_container_name", "azure_access_key", "kafka_topic" ],
+              "properties" : {
+                "azure_account_name" : {
+                  "title" : "Account Name",
+                  "description" : "The Azure Storage Blob account name.",
+                  "type" : "string",
+                  "x-group" : "credentials"
+                },
+                "azure_container_name" : {
+                  "title" : "Container Name",
+                  "description" : "The Azure Storage Blob container name.",
+                  "type" : "string"
+                },
+                "azure_access_key" : {
+                  "title" : "Access Key",
+                  "x-group" : "credentials",
+                  "oneOf" : [ {
+                    "title" : "Access Key",
+                    "description" : "The Azure Storage Blob access Key.",
+                    "type" : "string",
+                    "format" : "password"
+                  }, {
+                    "description" : "An opaque reference to the azure_access_key",
+                    "type" : "object",
+                    "properties" : { }
+                  } ]
+                },
+                "azure_operation" : {
+                  "title" : "Operation name",
+                  "description" : "The operation to perform.",
+                  "type" : "string",
+                  "default" : "uploadBlockBlob"
+                },
+                "kafka_topic" : {
+                  "title" : "Topic Names",
+                  "description" : "Comma separated list of Kafka topic names",
+                  "type" : "string"
+                },
+                "processors" : {
+                  "type" : "array",
+                  "items" : {
+                    "oneOf" : [ {
+                      "type" : "object",
+                      "required" : [ "throttle" ],
+                      "properties" : {
+                        "throttle" : {
+                          "$ref" : "#/$defs/processors/throttle"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "log" ],
+                      "properties" : {
+                        "log" : {
+                          "$ref" : "#/$defs/processors/log"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_extract" ],
+                      "properties" : {
+                        "jsonpath_extract" : {
+                          "$ref" : "#/$defs/processors/jsonpath_extract"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_remove" ],
+                      "properties" : {
+                        "jsonpath_remove" : {
+                          "$ref" : "#/$defs/processors/jsonpath_remove"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_rename" ],
+                      "properties" : {
+                        "jsonpath_rename" : {
+                          "$ref" : "#/$defs/processors/jsonpath_rename"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_set" ],
+                      "properties" : {
+                        "jsonpath_set" : {
+                          "$ref" : "#/$defs/processors/jsonpath_set"
+                        }
+                      }
+                    } ]
+                  }
+                },
+                "error_handler" : {
+                  "type" : "object",
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "dead_letter_queue" ],
+                    "properties" : {
+                      "dead_letter_queue" : {
+                        "$ref" : "#/$defs/error_handler/dead_letter_queue"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "log" ],
+                    "properties" : {
+                      "log" : {
+                        "$ref" : "#/$defs/error_handler/log"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "stop" ],
+                    "properties" : {
+                      "stop" : {
+                        "$ref" : "#/$defs/error_handler/stop"
+                      }
+                    }
+                  } ]
+                }
+              },
+              "$defs" : {
+                "processors" : {
+                  "throttle" : {
+                    "title" : "Throttle Action",
+                    "description" : "The Throttle action allows to ensure that a specific sink does not get overloaded.",
+                    "required" : [ "messages" ],
+                    "properties" : {
+                      "messages" : {
+                        "title" : "Messages Number",
+                        "description" : "The number of messages to send in the time period set",
+                        "type" : "integer",
+                        "example" : 10
+                      },
+                      "timePeriod" : {
+                        "title" : "Time Period",
+                        "description" : "Sets the time period during which the maximum request count is valid for, in milliseconds",
+                        "type" : "string",
+                        "default" : "1000"
+                      }
+                    },
+                    "type" : "object"
+                  },
+                  "log" : {
+                    "title" : "Log",
+                    "description" : "Log payload.",
+                    "type" : "object",
+                    "properties" : {
+                      "multiLine" : {
+                        "title" : "Multi Line",
+                        "description" : "Multi Line",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showProperties" : {
+                        "title" : "Show Properties",
+                        "description" : "Show Properties",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showHeaders" : {
+                        "title" : "Show Headers",
+                        "description" : "Show Headers",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      }
+                    }
+                  },
+                  "jsonpath_extract" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_remove" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_rename" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "newKey" : {
+                        "title" : "NewKey",
+                        "description" : "NewKey",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_set" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "title" : "Value",
+                        "description" : "Value",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "dead_letter_queue" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "topic" ],
+                    "properties" : {
+                      "topic" : {
+                        "type" : "string",
+                        "title" : "Dead Letter Topic Name",
+                        "description" : "The name of the Kafka topic used as dead letter queue"
+                      }
+                    }
+                  },
+                  "log" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  },
+                  "stop" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  }
+                }
+              }
+            }
+          }
+        }
+      azure_storage_blob_source_0.1.json: |-
+        {
+          "channels" : {
+            "stable" : {
+              "shard_metadata" : {
+                "connector_revision" : "8",
+                "connector_type" : "source",
+                "connector_image" : "quay.io/rhoas/cos-connector-azure-storage-blob:0.1.8",
+                "operators" : [ {
+                  "type" : "camel-connector-operator",
+                  "version" : "[1.0.0,2.0.0)"
+                } ],
+                "kamelets" : {
+                  "adapter" : {
+                    "name" : "azure-storage-blob-source",
+                    "prefix" : "azure"
+                  },
+                  "kafka" : {
+                    "name" : "cos-kafka-sink",
+                    "prefix" : "kafka"
+                  },
+                  "processors" : {
+                    "throttle" : "throttle-action",
+                    "jsonpath_set" : "cos-jsonpath-set-action",
+                    "log" : "cos-log-action",
+                    "jsonpath_rename" : "cos-jsonpath-rename-action",
+                    "jsonpath_extract" : "cos-jsonpath-extract-action",
+                    "jsonpath_remove" : "cos-jsonpath-remove-action"
+                  }
+                },
+                "annotations" : {
+                  "trait.camel.apache.org/container.request-memory" : "128m",
+                  "trait.camel.apache.org/container.request-cpu" : "1"
+                }
+              }
+            }
+          },
+          "connector_type" : {
+            "id" : "azure_storage_blob_source_0.1",
+            "kind" : "ConnectorType",
+            "icon_href" : "TODO",
+            "name" : "Azure Storage Blob Source",
+            "description" : "Azure Storage Blob Source",
+            "version" : "0.1",
+            "labels" : [ "source" ],
+            "capabilities" : [ "error_handler", "processors" ],
+            "channels" : [ "stable" ],
+            "schema" : {
+              "type" : "object",
+              "required" : [ "azure_period", "azure_account_name", "azure_container_name", "azure_access_key", "kafka_topic" ],
+              "properties" : {
+                "azure_period" : {
+                  "title" : "Period between Polls",
+                  "description" : "The interval between fetches to the Azure Storage Container in milliseconds",
+                  "type" : "integer",
+                  "default" : 10000
+                },
+                "azure_account_name" : {
+                  "title" : "Account Name",
+                  "description" : "The Azure Storage Blob account name.",
+                  "type" : "string",
+                  "x-group" : "credentials"
+                },
+                "azure_container_name" : {
+                  "title" : "Container Name",
+                  "description" : "The Azure Storage Blob container name.",
+                  "type" : "string"
+                },
+                "azure_access_key" : {
+                  "title" : "Access Key",
+                  "x-group" : "credentials",
+                  "oneOf" : [ {
+                    "title" : "Access Key",
+                    "description" : "The Azure Storage Blob access Key.",
+                    "type" : "string",
+                    "format" : "password"
+                  }, {
+                    "description" : "An opaque reference to the azure_access_key",
+                    "type" : "object",
+                    "properties" : { }
+                  } ]
+                },
+                "kafka_topic" : {
+                  "title" : "Topic Names",
+                  "description" : "Comma separated list of Kafka topic names",
+                  "type" : "string"
+                },
+                "processors" : {
+                  "type" : "array",
+                  "items" : {
+                    "oneOf" : [ {
+                      "type" : "object",
+                      "required" : [ "throttle" ],
+                      "properties" : {
+                        "throttle" : {
+                          "$ref" : "#/$defs/processors/throttle"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "log" ],
+                      "properties" : {
+                        "log" : {
+                          "$ref" : "#/$defs/processors/log"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_extract" ],
+                      "properties" : {
+                        "jsonpath_extract" : {
+                          "$ref" : "#/$defs/processors/jsonpath_extract"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_remove" ],
+                      "properties" : {
+                        "jsonpath_remove" : {
+                          "$ref" : "#/$defs/processors/jsonpath_remove"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_rename" ],
+                      "properties" : {
+                        "jsonpath_rename" : {
+                          "$ref" : "#/$defs/processors/jsonpath_rename"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_set" ],
+                      "properties" : {
+                        "jsonpath_set" : {
+                          "$ref" : "#/$defs/processors/jsonpath_set"
+                        }
+                      }
+                    } ]
+                  }
+                },
+                "error_handler" : {
+                  "type" : "object",
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "dead_letter_queue" ],
+                    "properties" : {
+                      "dead_letter_queue" : {
+                        "$ref" : "#/$defs/error_handler/dead_letter_queue"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "log" ],
+                    "properties" : {
+                      "log" : {
+                        "$ref" : "#/$defs/error_handler/log"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "stop" ],
+                    "properties" : {
+                      "stop" : {
+                        "$ref" : "#/$defs/error_handler/stop"
+                      }
+                    }
+                  } ]
+                }
+              },
+              "$defs" : {
+                "processors" : {
+                  "throttle" : {
+                    "title" : "Throttle Action",
+                    "description" : "The Throttle action allows to ensure that a specific sink does not get overloaded.",
+                    "required" : [ "messages" ],
+                    "properties" : {
+                      "messages" : {
+                        "title" : "Messages Number",
+                        "description" : "The number of messages to send in the time period set",
+                        "type" : "integer",
+                        "example" : 10
+                      },
+                      "timePeriod" : {
+                        "title" : "Time Period",
+                        "description" : "Sets the time period during which the maximum request count is valid for, in milliseconds",
+                        "type" : "string",
+                        "default" : "1000"
+                      }
+                    },
+                    "type" : "object"
+                  },
+                  "log" : {
+                    "title" : "Log",
+                    "description" : "Log payload.",
+                    "type" : "object",
+                    "properties" : {
+                      "multiLine" : {
+                        "title" : "Multi Line",
+                        "description" : "Multi Line",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showProperties" : {
+                        "title" : "Show Properties",
+                        "description" : "Show Properties",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showHeaders" : {
+                        "title" : "Show Headers",
+                        "description" : "Show Headers",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      }
+                    }
+                  },
+                  "jsonpath_extract" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_remove" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_rename" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "newKey" : {
+                        "title" : "NewKey",
+                        "description" : "NewKey",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_set" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "title" : "Value",
+                        "description" : "Value",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "dead_letter_queue" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "topic" ],
+                    "properties" : {
+                      "topic" : {
+                        "type" : "string",
+                        "title" : "Dead Letter Topic Name",
+                        "description" : "The name of the Kafka topic used as dead letter queue"
+                      }
+                    }
+                  },
+                  "log" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  },
+                  "stop" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  }
+                }
+              }
+            }
+          }
+        }
+      azure_storage_queue_sink_0.1.json: |-
+        {
+          "channels" : {
+            "stable" : {
+              "shard_metadata" : {
+                "connector_revision" : "8",
+                "connector_type" : "sink",
+                "connector_image" : "quay.io/rhoas/cos-connector-azure-storage-queue:0.1.8",
+                "operators" : [ {
+                  "type" : "camel-connector-operator",
+                  "version" : "[1.0.0,2.0.0)"
+                } ],
+                "kamelets" : {
+                  "adapter" : {
+                    "name" : "azure-storage-queue-sink",
+                    "prefix" : "azure"
+                  },
+                  "kafka" : {
+                    "name" : "cos-kafka-source",
+                    "prefix" : "kafka"
+                  },
+                  "processors" : {
+                    "throttle" : "throttle-action",
+                    "jsonpath_set" : "cos-jsonpath-set-action",
+                    "log" : "cos-log-action",
+                    "jsonpath_rename" : "cos-jsonpath-rename-action",
+                    "jsonpath_extract" : "cos-jsonpath-extract-action",
+                    "jsonpath_remove" : "cos-jsonpath-remove-action"
+                  }
+                }
+              }
+            }
+          },
+          "connector_type" : {
+            "id" : "azure_storage_queue_sink_0.1",
+            "kind" : "ConnectorType",
+            "icon_href" : "TODO",
+            "name" : "Azure Storage Queue Sink",
+            "description" : "Azure Storage Queue Sink",
+            "version" : "0.1",
+            "labels" : [ "sink" ],
+            "capabilities" : [ "error_handler", "processors" ],
+            "channels" : [ "stable" ],
+            "schema" : {
+              "type" : "object",
+              "required" : [ "azure_account_name", "azure_queue_name", "azure_access_key", "kafka_topic" ],
+              "properties" : {
+                "azure_account_name" : {
+                  "title" : "Account Name",
+                  "description" : "The Azure Storage Queue account name.",
+                  "type" : "string",
+                  "x-group" : "credentials"
+                },
+                "azure_queue_name" : {
+                  "title" : "Queue Name",
+                  "description" : "The Azure Storage Queue container name.",
+                  "type" : "string"
+                },
+                "azure_access_key" : {
+                  "title" : "Access Key",
+                  "x-group" : "credentials",
+                  "oneOf" : [ {
+                    "title" : "Access Key",
+                    "description" : "The Azure Storage Queue access Key.",
+                    "type" : "string",
+                    "format" : "password"
+                  }, {
+                    "description" : "An opaque reference to the azure_access_key",
+                    "type" : "object",
+                    "properties" : { }
+                  } ]
+                },
+                "kafka_topic" : {
+                  "title" : "Topic Names",
+                  "description" : "Comma separated list of Kafka topic names",
+                  "type" : "string"
+                },
+                "processors" : {
+                  "type" : "array",
+                  "items" : {
+                    "oneOf" : [ {
+                      "type" : "object",
+                      "required" : [ "throttle" ],
+                      "properties" : {
+                        "throttle" : {
+                          "$ref" : "#/$defs/processors/throttle"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "log" ],
+                      "properties" : {
+                        "log" : {
+                          "$ref" : "#/$defs/processors/log"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_extract" ],
+                      "properties" : {
+                        "jsonpath_extract" : {
+                          "$ref" : "#/$defs/processors/jsonpath_extract"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_remove" ],
+                      "properties" : {
+                        "jsonpath_remove" : {
+                          "$ref" : "#/$defs/processors/jsonpath_remove"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_rename" ],
+                      "properties" : {
+                        "jsonpath_rename" : {
+                          "$ref" : "#/$defs/processors/jsonpath_rename"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_set" ],
+                      "properties" : {
+                        "jsonpath_set" : {
+                          "$ref" : "#/$defs/processors/jsonpath_set"
+                        }
+                      }
+                    } ]
+                  }
+                },
+                "error_handler" : {
+                  "type" : "object",
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "dead_letter_queue" ],
+                    "properties" : {
+                      "dead_letter_queue" : {
+                        "$ref" : "#/$defs/error_handler/dead_letter_queue"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "log" ],
+                    "properties" : {
+                      "log" : {
+                        "$ref" : "#/$defs/error_handler/log"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "stop" ],
+                    "properties" : {
+                      "stop" : {
+                        "$ref" : "#/$defs/error_handler/stop"
+                      }
+                    }
+                  } ]
+                }
+              },
+              "$defs" : {
+                "processors" : {
+                  "throttle" : {
+                    "title" : "Throttle Action",
+                    "description" : "The Throttle action allows to ensure that a specific sink does not get overloaded.",
+                    "required" : [ "messages" ],
+                    "properties" : {
+                      "messages" : {
+                        "title" : "Messages Number",
+                        "description" : "The number of messages to send in the time period set",
+                        "type" : "integer",
+                        "example" : 10
+                      },
+                      "timePeriod" : {
+                        "title" : "Time Period",
+                        "description" : "Sets the time period during which the maximum request count is valid for, in milliseconds",
+                        "type" : "string",
+                        "default" : "1000"
+                      }
+                    },
+                    "type" : "object"
+                  },
+                  "log" : {
+                    "title" : "Log",
+                    "description" : "Log payload.",
+                    "type" : "object",
+                    "properties" : {
+                      "multiLine" : {
+                        "title" : "Multi Line",
+                        "description" : "Multi Line",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showProperties" : {
+                        "title" : "Show Properties",
+                        "description" : "Show Properties",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showHeaders" : {
+                        "title" : "Show Headers",
+                        "description" : "Show Headers",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      }
+                    }
+                  },
+                  "jsonpath_extract" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_remove" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_rename" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "newKey" : {
+                        "title" : "NewKey",
+                        "description" : "NewKey",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_set" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "title" : "Value",
+                        "description" : "Value",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "dead_letter_queue" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "topic" ],
+                    "properties" : {
+                      "topic" : {
+                        "type" : "string",
+                        "title" : "Dead Letter Topic Name",
+                        "description" : "The name of the Kafka topic used as dead letter queue"
+                      }
+                    }
+                  },
+                  "log" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  },
+                  "stop" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  }
+                }
+              }
+            }
+          }
+        }
+      azure_storage_queue_source_0.1.json: |-
+        {
+          "channels" : {
+            "stable" : {
+              "shard_metadata" : {
+                "connector_revision" : "8",
+                "connector_type" : "source",
+                "connector_image" : "quay.io/rhoas/cos-connector-azure-storage-queue:0.1.8",
+                "operators" : [ {
+                  "type" : "camel-connector-operator",
+                  "version" : "[1.0.0,2.0.0)"
+                } ],
+                "kamelets" : {
+                  "adapter" : {
+                    "name" : "azure-storage-queue-source",
+                    "prefix" : "azure"
+                  },
+                  "kafka" : {
+                    "name" : "cos-kafka-sink",
+                    "prefix" : "kafka"
+                  },
+                  "processors" : {
+                    "throttle" : "throttle-action",
+                    "jsonpath_set" : "cos-jsonpath-set-action",
+                    "log" : "cos-log-action",
+                    "jsonpath_rename" : "cos-jsonpath-rename-action",
+                    "jsonpath_extract" : "cos-jsonpath-extract-action",
+                    "jsonpath_remove" : "cos-jsonpath-remove-action"
+                  }
+                }
+              }
+            }
+          },
+          "connector_type" : {
+            "id" : "azure_storage_queue_source_0.1",
+            "kind" : "ConnectorType",
+            "icon_href" : "TODO",
+            "name" : "Azure Storage Queue Source",
+            "description" : "Azure Storage Queue Source",
+            "version" : "0.1",
+            "labels" : [ "source" ],
+            "capabilities" : [ "error_handler", "processors" ],
+            "channels" : [ "stable" ],
+            "schema" : {
+              "type" : "object",
+              "required" : [ "azure_account_name", "azure_queue_name", "azure_access_key", "kafka_topic" ],
+              "properties" : {
+                "azure_account_name" : {
+                  "title" : "Account Name",
+                  "description" : "The Azure Storage Queue account name.",
+                  "type" : "string",
+                  "x-group" : "credentials"
+                },
+                "azure_queue_name" : {
+                  "title" : "Queue Name",
+                  "description" : "The Azure Storage Queue container name.",
+                  "type" : "string"
+                },
+                "azure_access_key" : {
+                  "title" : "Access Key",
+                  "x-group" : "credentials",
+                  "oneOf" : [ {
+                    "title" : "Access Key",
+                    "description" : "The Azure Storage Queue access Key.",
+                    "type" : "string",
+                    "format" : "password"
+                  }, {
+                    "description" : "An opaque reference to the azure_access_key",
+                    "type" : "object",
+                    "properties" : { }
+                  } ]
+                },
+                "azure_max_messages" : {
+                  "title" : "Maximum Messages",
+                  "description" : "Maximum number of messages to get, if there are less messages exist in the queue than requested all the messages will be returned. By default it will consider 1 message to be retrieved, the allowed range is 1 to 32 messages.",
+                  "type" : "integer",
+                  "default" : 1
+                },
+                "kafka_topic" : {
+                  "title" : "Topic Names",
+                  "description" : "Comma separated list of Kafka topic names",
+                  "type" : "string"
+                },
+                "processors" : {
+                  "type" : "array",
+                  "items" : {
+                    "oneOf" : [ {
+                      "type" : "object",
+                      "required" : [ "throttle" ],
+                      "properties" : {
+                        "throttle" : {
+                          "$ref" : "#/$defs/processors/throttle"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "log" ],
+                      "properties" : {
+                        "log" : {
+                          "$ref" : "#/$defs/processors/log"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_extract" ],
+                      "properties" : {
+                        "jsonpath_extract" : {
+                          "$ref" : "#/$defs/processors/jsonpath_extract"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_remove" ],
+                      "properties" : {
+                        "jsonpath_remove" : {
+                          "$ref" : "#/$defs/processors/jsonpath_remove"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_rename" ],
+                      "properties" : {
+                        "jsonpath_rename" : {
+                          "$ref" : "#/$defs/processors/jsonpath_rename"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_set" ],
+                      "properties" : {
+                        "jsonpath_set" : {
+                          "$ref" : "#/$defs/processors/jsonpath_set"
+                        }
+                      }
+                    } ]
+                  }
+                },
+                "error_handler" : {
+                  "type" : "object",
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "dead_letter_queue" ],
+                    "properties" : {
+                      "dead_letter_queue" : {
+                        "$ref" : "#/$defs/error_handler/dead_letter_queue"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "log" ],
+                    "properties" : {
+                      "log" : {
+                        "$ref" : "#/$defs/error_handler/log"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "stop" ],
+                    "properties" : {
+                      "stop" : {
+                        "$ref" : "#/$defs/error_handler/stop"
+                      }
+                    }
+                  } ]
+                }
+              },
+              "$defs" : {
+                "processors" : {
+                  "throttle" : {
+                    "title" : "Throttle Action",
+                    "description" : "The Throttle action allows to ensure that a specific sink does not get overloaded.",
+                    "required" : [ "messages" ],
+                    "properties" : {
+                      "messages" : {
+                        "title" : "Messages Number",
+                        "description" : "The number of messages to send in the time period set",
+                        "type" : "integer",
+                        "example" : 10
+                      },
+                      "timePeriod" : {
+                        "title" : "Time Period",
+                        "description" : "Sets the time period during which the maximum request count is valid for, in milliseconds",
+                        "type" : "string",
+                        "default" : "1000"
+                      }
+                    },
+                    "type" : "object"
+                  },
+                  "log" : {
+                    "title" : "Log",
+                    "description" : "Log payload.",
+                    "type" : "object",
+                    "properties" : {
+                      "multiLine" : {
+                        "title" : "Multi Line",
+                        "description" : "Multi Line",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showProperties" : {
+                        "title" : "Show Properties",
+                        "description" : "Show Properties",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showHeaders" : {
+                        "title" : "Show Headers",
+                        "description" : "Show Headers",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      }
+                    }
+                  },
+                  "jsonpath_extract" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_remove" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_rename" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "newKey" : {
+                        "title" : "NewKey",
+                        "description" : "NewKey",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_set" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "title" : "Value",
+                        "description" : "Value",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "dead_letter_queue" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "topic" ],
+                    "properties" : {
+                      "topic" : {
+                        "type" : "string",
+                        "title" : "Dead Letter Topic Name",
+                        "description" : "The name of the Kafka topic used as dead letter queue"
+                      }
+                    }
+                  },
+                  "log" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  },
+                  "stop" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  }
+                }
+              }
+            }
+          }
+        }
+    kind: ConfigMap
+    metadata:
+      creationTimestamp: null
+      name: connector-catalog-camel-azure
+  - apiVersion: v1
+    data:
+      google_functions_sink_0.1.json: |-
+        {
+          "channels" : {
+            "stable" : {
+              "shard_metadata" : {
+                "connector_revision" : "8",
+                "connector_type" : "sink",
+                "connector_image" : "quay.io/rhoas/cos-connector-google-functions:0.1.8",
+                "operators" : [ {
+                  "type" : "camel-connector-operator",
+                  "version" : "[1.0.0,2.0.0)"
+                } ],
+                "kamelets" : {
+                  "adapter" : {
+                    "name" : "google-functions-sink",
+                    "prefix" : "gcp"
+                  },
+                  "kafka" : {
+                    "name" : "cos-kafka-source",
+                    "prefix" : "kafka"
+                  },
+                  "processors" : {
+                    "throttle" : "throttle-action",
+                    "jsonpath_set" : "cos-jsonpath-set-action",
+                    "log" : "cos-log-action",
+                    "jsonpath_rename" : "cos-jsonpath-rename-action",
+                    "jsonpath_extract" : "cos-jsonpath-extract-action",
+                    "jsonpath_remove" : "cos-jsonpath-remove-action"
+                  }
+                }
+              }
+            }
+          },
+          "connector_type" : {
+            "id" : "google_functions_sink_0.1",
+            "kind" : "ConnectorType",
+            "icon_href" : "TODO",
+            "name" : "Google Cloud Functions Sink",
+            "description" : "Google Cloud Functions Sink",
+            "version" : "0.1",
+            "labels" : [ "sink" ],
+            "capabilities" : [ "error_handler", "processors" ],
+            "channels" : [ "stable" ],
+            "schema" : {
+              "type" : "object",
+              "required" : [ "gcp_project_id", "gcp_function_name", "gcp_region", "gcp_service_account_key", "kafka_topic" ],
+              "properties" : {
+                "gcp_project_id" : {
+                  "title" : "Project Id",
+                  "description" : "The Google Cloud Functions Project Id",
+                  "type" : "string"
+                },
+                "gcp_region" : {
+                  "title" : "Region",
+                  "description" : "The Region where the Google Cloud Functions has been deployed",
+                  "type" : "string"
+                },
+                "gcp_function_name" : {
+                  "title" : "Function Name",
+                  "description" : "The Function Name",
+                  "type" : "string"
+                },
+                "gcp_service_account_key" : {
+                  "title" : "Service Account Key",
+                  "description" : "The Service account key that can be used as credentials for the Google Cloud Functions platform",
+                  "type" : "string",
+                  "x-group" : "credentials"
+                },
+                "kafka_topic" : {
+                  "title" : "Topic Names",
+                  "description" : "Comma separated list of Kafka topic names",
+                  "type" : "string"
+                },
+                "processors" : {
+                  "type" : "array",
+                  "items" : {
+                    "oneOf" : [ {
+                      "type" : "object",
+                      "required" : [ "throttle" ],
+                      "properties" : {
+                        "throttle" : {
+                          "$ref" : "#/$defs/processors/throttle"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "log" ],
+                      "properties" : {
+                        "log" : {
+                          "$ref" : "#/$defs/processors/log"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_extract" ],
+                      "properties" : {
+                        "jsonpath_extract" : {
+                          "$ref" : "#/$defs/processors/jsonpath_extract"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_remove" ],
+                      "properties" : {
+                        "jsonpath_remove" : {
+                          "$ref" : "#/$defs/processors/jsonpath_remove"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_rename" ],
+                      "properties" : {
+                        "jsonpath_rename" : {
+                          "$ref" : "#/$defs/processors/jsonpath_rename"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_set" ],
+                      "properties" : {
+                        "jsonpath_set" : {
+                          "$ref" : "#/$defs/processors/jsonpath_set"
+                        }
+                      }
+                    } ]
+                  }
+                },
+                "error_handler" : {
+                  "type" : "object",
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "dead_letter_queue" ],
+                    "properties" : {
+                      "dead_letter_queue" : {
+                        "$ref" : "#/$defs/error_handler/dead_letter_queue"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "log" ],
+                    "properties" : {
+                      "log" : {
+                        "$ref" : "#/$defs/error_handler/log"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "stop" ],
+                    "properties" : {
+                      "stop" : {
+                        "$ref" : "#/$defs/error_handler/stop"
+                      }
+                    }
+                  } ]
+                }
+              },
+              "$defs" : {
+                "processors" : {
+                  "throttle" : {
+                    "title" : "Throttle Action",
+                    "description" : "The Throttle action allows to ensure that a specific sink does not get overloaded.",
+                    "required" : [ "messages" ],
+                    "properties" : {
+                      "messages" : {
+                        "title" : "Messages Number",
+                        "description" : "The number of messages to send in the time period set",
+                        "type" : "integer",
+                        "example" : 10
+                      },
+                      "timePeriod" : {
+                        "title" : "Time Period",
+                        "description" : "Sets the time period during which the maximum request count is valid for, in milliseconds",
+                        "type" : "string",
+                        "default" : "1000"
+                      }
+                    },
+                    "type" : "object"
+                  },
+                  "log" : {
+                    "title" : "Log",
+                    "description" : "Log payload.",
+                    "type" : "object",
+                    "properties" : {
+                      "multiLine" : {
+                        "title" : "Multi Line",
+                        "description" : "Multi Line",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showProperties" : {
+                        "title" : "Show Properties",
+                        "description" : "Show Properties",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showHeaders" : {
+                        "title" : "Show Headers",
+                        "description" : "Show Headers",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      }
+                    }
+                  },
+                  "jsonpath_extract" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_remove" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_rename" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "newKey" : {
+                        "title" : "NewKey",
+                        "description" : "NewKey",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_set" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "title" : "Value",
+                        "description" : "Value",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "dead_letter_queue" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "topic" ],
+                    "properties" : {
+                      "topic" : {
+                        "type" : "string",
+                        "title" : "Dead Letter Topic Name",
+                        "description" : "The name of the Kafka topic used as dead letter queue"
+                      }
+                    }
+                  },
+                  "log" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  },
+                  "stop" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  }
+                }
+              }
+            }
+          }
+        }
+      google_pubsub_sink_0.1.json: |-
+        {
+          "channels" : {
+            "stable" : {
+              "shard_metadata" : {
+                "connector_revision" : "8",
+                "connector_type" : "sink",
+                "connector_image" : "quay.io/rhoas/cos-connector-google-pubsub:0.1.8",
+                "operators" : [ {
+                  "type" : "camel-connector-operator",
+                  "version" : "[1.0.0,2.0.0)"
+                } ],
+                "kamelets" : {
+                  "adapter" : {
+                    "name" : "google-pubsub-sink",
+                    "prefix" : "gcp"
+                  },
+                  "kafka" : {
+                    "name" : "cos-kafka-source",
+                    "prefix" : "kafka"
+                  },
+                  "processors" : {
+                    "throttle" : "throttle-action",
+                    "jsonpath_set" : "cos-jsonpath-set-action",
+                    "log" : "cos-log-action",
+                    "jsonpath_rename" : "cos-jsonpath-rename-action",
+                    "jsonpath_extract" : "cos-jsonpath-extract-action",
+                    "jsonpath_remove" : "cos-jsonpath-remove-action"
+                  }
+                }
+              }
+            }
+          },
+          "connector_type" : {
+            "id" : "google_pubsub_sink_0.1",
+            "kind" : "ConnectorType",
+            "icon_href" : "TODO",
+            "name" : "Google Cloud Pubsub Sink",
+            "description" : "Google Cloud Pubsub Sink",
+            "version" : "0.1",
+            "labels" : [ "sink" ],
+            "capabilities" : [ "error_handler", "processors" ],
+            "channels" : [ "stable" ],
+            "schema" : {
+              "type" : "object",
+              "required" : [ "gcp_project_id", "gcp_destination_name", "gcp_service_account_key", "kafka_topic" ],
+              "properties" : {
+                "gcp_project_id" : {
+                  "title" : "Project Id",
+                  "description" : "The Google Cloud PubSub Project Id",
+                  "type" : "string"
+                },
+                "gcp_destination_name" : {
+                  "title" : "Destination Name",
+                  "description" : "The Destination Name",
+                  "type" : "string"
+                },
+                "gcp_service_account_key" : {
+                  "title" : "Service Account Key",
+                  "description" : "The Service account key that can be used as credentials for the PubSub publisher/subscriber",
+                  "type" : "binary",
+                  "x-group" : "credentials"
+                },
+                "kafka_topic" : {
+                  "title" : "Topic Names",
+                  "description" : "Comma separated list of Kafka topic names",
+                  "type" : "string"
+                },
+                "processors" : {
+                  "type" : "array",
+                  "items" : {
+                    "oneOf" : [ {
+                      "type" : "object",
+                      "required" : [ "throttle" ],
+                      "properties" : {
+                        "throttle" : {
+                          "$ref" : "#/$defs/processors/throttle"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "log" ],
+                      "properties" : {
+                        "log" : {
+                          "$ref" : "#/$defs/processors/log"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_extract" ],
+                      "properties" : {
+                        "jsonpath_extract" : {
+                          "$ref" : "#/$defs/processors/jsonpath_extract"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_remove" ],
+                      "properties" : {
+                        "jsonpath_remove" : {
+                          "$ref" : "#/$defs/processors/jsonpath_remove"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_rename" ],
+                      "properties" : {
+                        "jsonpath_rename" : {
+                          "$ref" : "#/$defs/processors/jsonpath_rename"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_set" ],
+                      "properties" : {
+                        "jsonpath_set" : {
+                          "$ref" : "#/$defs/processors/jsonpath_set"
+                        }
+                      }
+                    } ]
+                  }
+                },
+                "error_handler" : {
+                  "type" : "object",
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "dead_letter_queue" ],
+                    "properties" : {
+                      "dead_letter_queue" : {
+                        "$ref" : "#/$defs/error_handler/dead_letter_queue"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "log" ],
+                    "properties" : {
+                      "log" : {
+                        "$ref" : "#/$defs/error_handler/log"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "stop" ],
+                    "properties" : {
+                      "stop" : {
+                        "$ref" : "#/$defs/error_handler/stop"
+                      }
+                    }
+                  } ]
+                }
+              },
+              "$defs" : {
+                "processors" : {
+                  "throttle" : {
+                    "title" : "Throttle Action",
+                    "description" : "The Throttle action allows to ensure that a specific sink does not get overloaded.",
+                    "required" : [ "messages" ],
+                    "properties" : {
+                      "messages" : {
+                        "title" : "Messages Number",
+                        "description" : "The number of messages to send in the time period set",
+                        "type" : "integer",
+                        "example" : 10
+                      },
+                      "timePeriod" : {
+                        "title" : "Time Period",
+                        "description" : "Sets the time period during which the maximum request count is valid for, in milliseconds",
+                        "type" : "string",
+                        "default" : "1000"
+                      }
+                    },
+                    "type" : "object"
+                  },
+                  "log" : {
+                    "title" : "Log",
+                    "description" : "Log payload.",
+                    "type" : "object",
+                    "properties" : {
+                      "multiLine" : {
+                        "title" : "Multi Line",
+                        "description" : "Multi Line",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showProperties" : {
+                        "title" : "Show Properties",
+                        "description" : "Show Properties",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showHeaders" : {
+                        "title" : "Show Headers",
+                        "description" : "Show Headers",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      }
+                    }
+                  },
+                  "jsonpath_extract" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_remove" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_rename" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "newKey" : {
+                        "title" : "NewKey",
+                        "description" : "NewKey",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_set" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "title" : "Value",
+                        "description" : "Value",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "dead_letter_queue" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "topic" ],
+                    "properties" : {
+                      "topic" : {
+                        "type" : "string",
+                        "title" : "Dead Letter Topic Name",
+                        "description" : "The name of the Kafka topic used as dead letter queue"
+                      }
+                    }
+                  },
+                  "log" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  },
+                  "stop" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  }
+                }
+              }
+            }
+          }
+        }
+      google_pubsub_source_0.1.json: |-
+        {
+          "channels" : {
+            "stable" : {
+              "shard_metadata" : {
+                "connector_revision" : "8",
+                "connector_type" : "source",
+                "connector_image" : "quay.io/rhoas/cos-connector-google-pubsub:0.1.8",
+                "operators" : [ {
+                  "type" : "camel-connector-operator",
+                  "version" : "[1.0.0,2.0.0)"
+                } ],
+                "kamelets" : {
+                  "adapter" : {
+                    "name" : "google-pubsub-source",
+                    "prefix" : "gcp"
+                  },
+                  "kafka" : {
+                    "name" : "cos-kafka-sink",
+                    "prefix" : "kafka"
+                  },
+                  "processors" : {
+                    "throttle" : "throttle-action",
+                    "jsonpath_set" : "cos-jsonpath-set-action",
+                    "log" : "cos-log-action",
+                    "jsonpath_rename" : "cos-jsonpath-rename-action",
+                    "jsonpath_extract" : "cos-jsonpath-extract-action",
+                    "jsonpath_remove" : "cos-jsonpath-remove-action"
+                  }
+                }
+              }
+            }
+          },
+          "connector_type" : {
+            "id" : "google_pubsub_source_0.1",
+            "kind" : "ConnectorType",
+            "icon_href" : "TODO",
+            "name" : "Google Cloud Pubsub Source",
+            "description" : "Google Cloud Pubsub Source",
+            "version" : "0.1",
+            "labels" : [ "source" ],
+            "capabilities" : [ "error_handler", "processors" ],
+            "channels" : [ "stable" ],
+            "schema" : {
+              "type" : "object",
+              "required" : [ "gcp_project_id", "gcp_subscription_name", "gcp_service_account_key", "kafka_topic" ],
+              "properties" : {
+                "gcp_project_id" : {
+                  "title" : "Project Id",
+                  "description" : "The Google Cloud PubSub Project Id",
+                  "type" : "string"
+                },
+                "gcp_subscription_name" : {
+                  "title" : "Subscription Name",
+                  "description" : "The Subscription Name",
+                  "type" : "string"
+                },
+                "gcp_service_account_key" : {
+                  "title" : "Service Account Key",
+                  "description" : "The Service account key that can be used as credentials for the PubSub publisher/subscriber",
+                  "type" : "binary",
+                  "x-group" : "credentials"
+                },
+                "gcp_synchronous_pull" : {
+                  "title" : "Synchronous Pull",
+                  "description" : "If Synchronously pull batches of messages is enabled or not",
+                  "type" : "boolean",
+                  "default" : false
+                },
+                "gcp_max_messages_per_poll" : {
+                  "title" : "Max Messages Per Poll",
+                  "description" : "The max number of messages to receive from the server in a single API call",
+                  "type" : "integer",
+                  "default" : 1
+                },
+                "gcp_concurrent_consumers" : {
+                  "title" : "Concurrent Consumers",
+                  "description" : "The number of parallel streams consuming from the subscription",
+                  "type" : "integer",
+                  "default" : 1
+                },
+                "kafka_topic" : {
+                  "title" : "Topic Names",
+                  "description" : "Comma separated list of Kafka topic names",
+                  "type" : "string"
+                },
+                "processors" : {
+                  "type" : "array",
+                  "items" : {
+                    "oneOf" : [ {
+                      "type" : "object",
+                      "required" : [ "throttle" ],
+                      "properties" : {
+                        "throttle" : {
+                          "$ref" : "#/$defs/processors/throttle"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "log" ],
+                      "properties" : {
+                        "log" : {
+                          "$ref" : "#/$defs/processors/log"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_extract" ],
+                      "properties" : {
+                        "jsonpath_extract" : {
+                          "$ref" : "#/$defs/processors/jsonpath_extract"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_remove" ],
+                      "properties" : {
+                        "jsonpath_remove" : {
+                          "$ref" : "#/$defs/processors/jsonpath_remove"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_rename" ],
+                      "properties" : {
+                        "jsonpath_rename" : {
+                          "$ref" : "#/$defs/processors/jsonpath_rename"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_set" ],
+                      "properties" : {
+                        "jsonpath_set" : {
+                          "$ref" : "#/$defs/processors/jsonpath_set"
+                        }
+                      }
+                    } ]
+                  }
+                },
+                "error_handler" : {
+                  "type" : "object",
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "dead_letter_queue" ],
+                    "properties" : {
+                      "dead_letter_queue" : {
+                        "$ref" : "#/$defs/error_handler/dead_letter_queue"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "log" ],
+                    "properties" : {
+                      "log" : {
+                        "$ref" : "#/$defs/error_handler/log"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "stop" ],
+                    "properties" : {
+                      "stop" : {
+                        "$ref" : "#/$defs/error_handler/stop"
+                      }
+                    }
+                  } ]
+                }
+              },
+              "$defs" : {
+                "processors" : {
+                  "throttle" : {
+                    "title" : "Throttle Action",
+                    "description" : "The Throttle action allows to ensure that a specific sink does not get overloaded.",
+                    "required" : [ "messages" ],
+                    "properties" : {
+                      "messages" : {
+                        "title" : "Messages Number",
+                        "description" : "The number of messages to send in the time period set",
+                        "type" : "integer",
+                        "example" : 10
+                      },
+                      "timePeriod" : {
+                        "title" : "Time Period",
+                        "description" : "Sets the time period during which the maximum request count is valid for, in milliseconds",
+                        "type" : "string",
+                        "default" : "1000"
+                      }
+                    },
+                    "type" : "object"
+                  },
+                  "log" : {
+                    "title" : "Log",
+                    "description" : "Log payload.",
+                    "type" : "object",
+                    "properties" : {
+                      "multiLine" : {
+                        "title" : "Multi Line",
+                        "description" : "Multi Line",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showProperties" : {
+                        "title" : "Show Properties",
+                        "description" : "Show Properties",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showHeaders" : {
+                        "title" : "Show Headers",
+                        "description" : "Show Headers",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      }
+                    }
+                  },
+                  "jsonpath_extract" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_remove" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_rename" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "newKey" : {
+                        "title" : "NewKey",
+                        "description" : "NewKey",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_set" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "title" : "Value",
+                        "description" : "Value",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "dead_letter_queue" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "topic" ],
+                    "properties" : {
+                      "topic" : {
+                        "type" : "string",
+                        "title" : "Dead Letter Topic Name",
+                        "description" : "The name of the Kafka topic used as dead letter queue"
+                      }
+                    }
+                  },
+                  "log" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  },
+                  "stop" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  }
+                }
+              }
+            }
+          }
+        }
+      google_storage_sink_0.1.json: |-
+        {
+          "channels" : {
+            "stable" : {
+              "shard_metadata" : {
+                "connector_revision" : "8",
+                "connector_type" : "sink",
+                "connector_image" : "quay.io/rhoas/cos-connector-google-storage:0.1.8",
+                "operators" : [ {
+                  "type" : "camel-connector-operator",
+                  "version" : "[1.0.0,2.0.0)"
+                } ],
+                "kamelets" : {
+                  "adapter" : {
+                    "name" : "google-storage-sink",
+                    "prefix" : "gcp"
+                  },
+                  "kafka" : {
+                    "name" : "cos-kafka-source",
+                    "prefix" : "kafka"
+                  },
+                  "processors" : {
+                    "throttle" : "throttle-action",
+                    "jsonpath_set" : "cos-jsonpath-set-action",
+                    "log" : "cos-log-action",
+                    "jsonpath_rename" : "cos-jsonpath-rename-action",
+                    "jsonpath_extract" : "cos-jsonpath-extract-action",
+                    "jsonpath_remove" : "cos-jsonpath-remove-action"
+                  }
+                }
+              }
+            }
+          },
+          "connector_type" : {
+            "id" : "google_storage_sink_0.1",
+            "kind" : "ConnectorType",
+            "icon_href" : "TODO",
+            "name" : "Google Cloud Storage Sink",
+            "description" : "Google Cloud Storage Sink",
+            "version" : "0.1",
+            "labels" : [ "sink" ],
+            "capabilities" : [ "error_handler", "processors" ],
+            "channels" : [ "stable" ],
+            "schema" : {
+              "type" : "object",
+              "required" : [ "gcp_bucket_name_or_arn", "gcp_service_account_key", "kafka_topic" ],
+              "properties" : {
+                "gcp_bucket_name_or_arn" : {
+                  "title" : "Bucket Name Or ARN",
+                  "description" : "The Bucket Name or Bucket ARN",
+                  "type" : "string"
+                },
+                "gcp_service_account_key" : {
+                  "title" : "Service Account Key",
+                  "description" : "The Service account key that can be used as credentials for the Google Cloud Storage access.",
+                  "type" : "binary",
+                  "x-group" : "credentials"
+                },
+                "gcp_auto_create_bucket" : {
+                  "title" : "Autocreate Bucket",
+                  "description" : "Setting the autocreation of the Google Cloud Storage bucket bucketNameOrArn.",
+                  "type" : "boolean",
+                  "default" : false
+                },
+                "kafka_topic" : {
+                  "title" : "Topic Names",
+                  "description" : "Comma separated list of Kafka topic names",
+                  "type" : "string"
+                },
+                "processors" : {
+                  "type" : "array",
+                  "items" : {
+                    "oneOf" : [ {
+                      "type" : "object",
+                      "required" : [ "throttle" ],
+                      "properties" : {
+                        "throttle" : {
+                          "$ref" : "#/$defs/processors/throttle"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "log" ],
+                      "properties" : {
+                        "log" : {
+                          "$ref" : "#/$defs/processors/log"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_extract" ],
+                      "properties" : {
+                        "jsonpath_extract" : {
+                          "$ref" : "#/$defs/processors/jsonpath_extract"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_remove" ],
+                      "properties" : {
+                        "jsonpath_remove" : {
+                          "$ref" : "#/$defs/processors/jsonpath_remove"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_rename" ],
+                      "properties" : {
+                        "jsonpath_rename" : {
+                          "$ref" : "#/$defs/processors/jsonpath_rename"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_set" ],
+                      "properties" : {
+                        "jsonpath_set" : {
+                          "$ref" : "#/$defs/processors/jsonpath_set"
+                        }
+                      }
+                    } ]
+                  }
+                },
+                "error_handler" : {
+                  "type" : "object",
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "dead_letter_queue" ],
+                    "properties" : {
+                      "dead_letter_queue" : {
+                        "$ref" : "#/$defs/error_handler/dead_letter_queue"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "log" ],
+                    "properties" : {
+                      "log" : {
+                        "$ref" : "#/$defs/error_handler/log"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "stop" ],
+                    "properties" : {
+                      "stop" : {
+                        "$ref" : "#/$defs/error_handler/stop"
+                      }
+                    }
+                  } ]
+                }
+              },
+              "$defs" : {
+                "processors" : {
+                  "throttle" : {
+                    "title" : "Throttle Action",
+                    "description" : "The Throttle action allows to ensure that a specific sink does not get overloaded.",
+                    "required" : [ "messages" ],
+                    "properties" : {
+                      "messages" : {
+                        "title" : "Messages Number",
+                        "description" : "The number of messages to send in the time period set",
+                        "type" : "integer",
+                        "example" : 10
+                      },
+                      "timePeriod" : {
+                        "title" : "Time Period",
+                        "description" : "Sets the time period during which the maximum request count is valid for, in milliseconds",
+                        "type" : "string",
+                        "default" : "1000"
+                      }
+                    },
+                    "type" : "object"
+                  },
+                  "log" : {
+                    "title" : "Log",
+                    "description" : "Log payload.",
+                    "type" : "object",
+                    "properties" : {
+                      "multiLine" : {
+                        "title" : "Multi Line",
+                        "description" : "Multi Line",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showProperties" : {
+                        "title" : "Show Properties",
+                        "description" : "Show Properties",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showHeaders" : {
+                        "title" : "Show Headers",
+                        "description" : "Show Headers",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      }
+                    }
+                  },
+                  "jsonpath_extract" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_remove" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_rename" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "newKey" : {
+                        "title" : "NewKey",
+                        "description" : "NewKey",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_set" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "title" : "Value",
+                        "description" : "Value",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "dead_letter_queue" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "topic" ],
+                    "properties" : {
+                      "topic" : {
+                        "type" : "string",
+                        "title" : "Dead Letter Topic Name",
+                        "description" : "The name of the Kafka topic used as dead letter queue"
+                      }
+                    }
+                  },
+                  "log" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  },
+                  "stop" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  }
+                }
+              }
+            }
+          }
+        }
+      google_storage_source_0.1.json: |-
+        {
+          "channels" : {
+            "stable" : {
+              "shard_metadata" : {
+                "connector_revision" : "8",
+                "connector_type" : "source",
+                "connector_image" : "quay.io/rhoas/cos-connector-google-storage:0.1.8",
+                "operators" : [ {
+                  "type" : "camel-connector-operator",
+                  "version" : "[1.0.0,2.0.0)"
+                } ],
+                "kamelets" : {
+                  "adapter" : {
+                    "name" : "google-storage-source",
+                    "prefix" : "gcp"
+                  },
+                  "kafka" : {
+                    "name" : "cos-kafka-sink",
+                    "prefix" : "kafka"
+                  },
+                  "processors" : {
+                    "throttle" : "throttle-action",
+                    "jsonpath_set" : "cos-jsonpath-set-action",
+                    "log" : "cos-log-action",
+                    "jsonpath_rename" : "cos-jsonpath-rename-action",
+                    "jsonpath_extract" : "cos-jsonpath-extract-action",
+                    "jsonpath_remove" : "cos-jsonpath-remove-action"
+                  }
+                }
+              }
+            }
+          },
+          "connector_type" : {
+            "id" : "google_storage_source_0.1",
+            "kind" : "ConnectorType",
+            "icon_href" : "TODO",
+            "name" : "Google Cloud Storage Source",
+            "description" : "Google Cloud Storage Source",
+            "version" : "0.1",
+            "labels" : [ "source" ],
+            "capabilities" : [ "error_handler", "processors" ],
+            "channels" : [ "stable" ],
+            "schema" : {
+              "type" : "object",
+              "required" : [ "gcp_bucket_name_or_arn", "gcp_service_account_key", "kafka_topic" ],
+              "properties" : {
+                "gcp_bucket_name_or_arn" : {
+                  "title" : "Bucket Name Or ARN",
+                  "description" : "The Bucket Name or Bucket ARN",
+                  "type" : "string"
+                },
+                "gcp_service_account_key" : {
+                  "title" : "Service Account Key",
+                  "description" : "The Service account key that can be used as credentials for the Google Cloud Storage access.",
+                  "type" : "binary",
+                  "x-group" : "credentials"
+                },
+                "gcp_delete_after_read" : {
+                  "title" : "Auto-delete Objects",
+                  "description" : "Delete objects after consuming them",
+                  "type" : "boolean",
+                  "default" : true
+                },
+                "gcp_auto_create_bucket" : {
+                  "title" : "Autocreate Bucket",
+                  "description" : "Setting the autocreation of the Google Cloud Storage bucket bucketNameOrArn.",
+                  "type" : "boolean",
+                  "default" : false
+                },
+                "kafka_topic" : {
+                  "title" : "Topic Names",
+                  "description" : "Comma separated list of Kafka topic names",
+                  "type" : "string"
+                },
+                "processors" : {
+                  "type" : "array",
+                  "items" : {
+                    "oneOf" : [ {
+                      "type" : "object",
+                      "required" : [ "throttle" ],
+                      "properties" : {
+                        "throttle" : {
+                          "$ref" : "#/$defs/processors/throttle"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "log" ],
+                      "properties" : {
+                        "log" : {
+                          "$ref" : "#/$defs/processors/log"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_extract" ],
+                      "properties" : {
+                        "jsonpath_extract" : {
+                          "$ref" : "#/$defs/processors/jsonpath_extract"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_remove" ],
+                      "properties" : {
+                        "jsonpath_remove" : {
+                          "$ref" : "#/$defs/processors/jsonpath_remove"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_rename" ],
+                      "properties" : {
+                        "jsonpath_rename" : {
+                          "$ref" : "#/$defs/processors/jsonpath_rename"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_set" ],
+                      "properties" : {
+                        "jsonpath_set" : {
+                          "$ref" : "#/$defs/processors/jsonpath_set"
+                        }
+                      }
+                    } ]
+                  }
+                },
+                "error_handler" : {
+                  "type" : "object",
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "dead_letter_queue" ],
+                    "properties" : {
+                      "dead_letter_queue" : {
+                        "$ref" : "#/$defs/error_handler/dead_letter_queue"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "log" ],
+                    "properties" : {
+                      "log" : {
+                        "$ref" : "#/$defs/error_handler/log"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "stop" ],
+                    "properties" : {
+                      "stop" : {
+                        "$ref" : "#/$defs/error_handler/stop"
+                      }
+                    }
+                  } ]
+                }
+              },
+              "$defs" : {
+                "processors" : {
+                  "throttle" : {
+                    "title" : "Throttle Action",
+                    "description" : "The Throttle action allows to ensure that a specific sink does not get overloaded.",
+                    "required" : [ "messages" ],
+                    "properties" : {
+                      "messages" : {
+                        "title" : "Messages Number",
+                        "description" : "The number of messages to send in the time period set",
+                        "type" : "integer",
+                        "example" : 10
+                      },
+                      "timePeriod" : {
+                        "title" : "Time Period",
+                        "description" : "Sets the time period during which the maximum request count is valid for, in milliseconds",
+                        "type" : "string",
+                        "default" : "1000"
+                      }
+                    },
+                    "type" : "object"
+                  },
+                  "log" : {
+                    "title" : "Log",
+                    "description" : "Log payload.",
+                    "type" : "object",
+                    "properties" : {
+                      "multiLine" : {
+                        "title" : "Multi Line",
+                        "description" : "Multi Line",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showProperties" : {
+                        "title" : "Show Properties",
+                        "description" : "Show Properties",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showHeaders" : {
+                        "title" : "Show Headers",
+                        "description" : "Show Headers",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      }
+                    }
+                  },
+                  "jsonpath_extract" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_remove" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_rename" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "newKey" : {
+                        "title" : "NewKey",
+                        "description" : "NewKey",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_set" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "title" : "Value",
+                        "description" : "Value",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "dead_letter_queue" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "topic" ],
+                    "properties" : {
+                      "topic" : {
+                        "type" : "string",
+                        "title" : "Dead Letter Topic Name",
+                        "description" : "The name of the Kafka topic used as dead letter queue"
+                      }
+                    }
+                  },
+                  "log" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  },
+                  "stop" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  }
+                }
+              }
+            }
+          }
+        }
+    kind: ConfigMap
+    metadata:
+      creationTimestamp: null
+      name: connector-catalog-camel-gcp
+  - apiVersion: v1
+    data:
+      http_sink_0.1.json: |-
+        {
+          "channels" : {
+            "stable" : {
+              "shard_metadata" : {
+                "connector_revision" : "8",
+                "connector_type" : "sink",
+                "connector_image" : "quay.io/rhoas/cos-connector-http:0.1.8",
+                "operators" : [ {
+                  "type" : "camel-connector-operator",
+                  "version" : "[1.0.0,2.0.0)"
+                } ],
+                "kamelets" : {
+                  "adapter" : {
+                    "name" : "http-sink",
+                    "prefix" : "http"
+                  },
+                  "kafka" : {
+                    "name" : "cos-kafka-source",
+                    "prefix" : "kafka"
+                  },
+                  "processors" : {
+                    "throttle" : "throttle-action",
+                    "jsonpath_set" : "cos-jsonpath-set-action",
+                    "log" : "cos-log-action",
+                    "jsonpath_rename" : "cos-jsonpath-rename-action",
+                    "jsonpath_extract" : "cos-jsonpath-extract-action",
+                    "jsonpath_remove" : "cos-jsonpath-remove-action"
+                  }
+                }
+              }
+            }
+          },
+          "connector_type" : {
+            "id" : "http_sink_0.1",
+            "kind" : "ConnectorType",
+            "icon_href" : "TODO",
+            "name" : "HTTP Sink",
+            "description" : "HTTP Sink",
+            "version" : "0.1",
+            "labels" : [ "sink" ],
+            "capabilities" : [ "error_handler", "processors" ],
+            "channels" : [ "stable" ],
+            "schema" : {
+              "type" : "object",
+              "required" : [ "http_url", "kafka_topic" ],
+              "properties" : {
+                "http_url" : {
+                  "title" : "URL",
+                  "description" : "The URL to send data to",
+                  "type" : "string",
+                  "example" : "https://my-service/path",
+                  "pattern" : "^(http|https)://.*"
+                },
+                "http_method" : {
+                  "title" : "Method",
+                  "description" : "The HTTP method to use",
+                  "type" : "string",
+                  "default" : "POST"
+                },
+                "kafka_topic" : {
+                  "title" : "Topic Names",
+                  "description" : "Comma separated list of Kafka topic names",
+                  "type" : "string"
+                },
+                "processors" : {
+                  "type" : "array",
+                  "items" : {
+                    "oneOf" : [ {
+                      "type" : "object",
+                      "required" : [ "throttle" ],
+                      "properties" : {
+                        "throttle" : {
+                          "$ref" : "#/$defs/processors/throttle"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "log" ],
+                      "properties" : {
+                        "log" : {
+                          "$ref" : "#/$defs/processors/log"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_extract" ],
+                      "properties" : {
+                        "jsonpath_extract" : {
+                          "$ref" : "#/$defs/processors/jsonpath_extract"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_remove" ],
+                      "properties" : {
+                        "jsonpath_remove" : {
+                          "$ref" : "#/$defs/processors/jsonpath_remove"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_rename" ],
+                      "properties" : {
+                        "jsonpath_rename" : {
+                          "$ref" : "#/$defs/processors/jsonpath_rename"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_set" ],
+                      "properties" : {
+                        "jsonpath_set" : {
+                          "$ref" : "#/$defs/processors/jsonpath_set"
+                        }
+                      }
+                    } ]
+                  }
+                },
+                "error_handler" : {
+                  "type" : "object",
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "dead_letter_queue" ],
+                    "properties" : {
+                      "dead_letter_queue" : {
+                        "$ref" : "#/$defs/error_handler/dead_letter_queue"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "log" ],
+                    "properties" : {
+                      "log" : {
+                        "$ref" : "#/$defs/error_handler/log"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "stop" ],
+                    "properties" : {
+                      "stop" : {
+                        "$ref" : "#/$defs/error_handler/stop"
+                      }
+                    }
+                  } ]
+                }
+              },
+              "$defs" : {
+                "processors" : {
+                  "throttle" : {
+                    "title" : "Throttle Action",
+                    "description" : "The Throttle action allows to ensure that a specific sink does not get overloaded.",
+                    "required" : [ "messages" ],
+                    "properties" : {
+                      "messages" : {
+                        "title" : "Messages Number",
+                        "description" : "The number of messages to send in the time period set",
+                        "type" : "integer",
+                        "example" : 10
+                      },
+                      "timePeriod" : {
+                        "title" : "Time Period",
+                        "description" : "Sets the time period during which the maximum request count is valid for, in milliseconds",
+                        "type" : "string",
+                        "default" : "1000"
+                      }
+                    },
+                    "type" : "object"
+                  },
+                  "log" : {
+                    "title" : "Log",
+                    "description" : "Log payload.",
+                    "type" : "object",
+                    "properties" : {
+                      "multiLine" : {
+                        "title" : "Multi Line",
+                        "description" : "Multi Line",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showProperties" : {
+                        "title" : "Show Properties",
+                        "description" : "Show Properties",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showHeaders" : {
+                        "title" : "Show Headers",
+                        "description" : "Show Headers",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      }
+                    }
+                  },
+                  "jsonpath_extract" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_remove" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_rename" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "newKey" : {
+                        "title" : "NewKey",
+                        "description" : "NewKey",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_set" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "title" : "Value",
+                        "description" : "Value",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "dead_letter_queue" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "topic" ],
+                    "properties" : {
+                      "topic" : {
+                        "type" : "string",
+                        "title" : "Dead Letter Topic Name",
+                        "description" : "The name of the Kafka topic used as dead letter queue"
+                      }
+                    }
+                  },
+                  "log" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  },
+                  "stop" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  }
+                }
+              }
+            }
+          }
+        }
+      jms_amqp_10_sink_0.1.json: |-
+        {
+          "channels" : {
+            "stable" : {
+              "shard_metadata" : {
+                "connector_revision" : "8",
+                "connector_type" : "sink",
+                "connector_image" : "quay.io/rhoas/cos-connector-jms-amqp-10:0.1.8",
+                "operators" : [ {
+                  "type" : "camel-connector-operator",
+                  "version" : "[1.0.0,2.0.0)"
+                } ],
+                "kamelets" : {
+                  "adapter" : {
+                    "name" : "jms-amqp-10-sink",
+                    "prefix" : "jms-amqp"
+                  },
+                  "kafka" : {
+                    "name" : "cos-kafka-source",
+                    "prefix" : "kafka"
+                  },
+                  "processors" : {
+                    "throttle" : "throttle-action",
+                    "jsonpath_set" : "cos-jsonpath-set-action",
+                    "log" : "cos-log-action",
+                    "jsonpath_rename" : "cos-jsonpath-rename-action",
+                    "jsonpath_extract" : "cos-jsonpath-extract-action",
+                    "jsonpath_remove" : "cos-jsonpath-remove-action"
+                  }
+                }
+              }
+            }
+          },
+          "connector_type" : {
+            "id" : "jms_amqp_10_sink_0.1",
+            "kind" : "ConnectorType",
+            "icon_href" : "TODO",
+            "name" : "JMS AMQP 1.0 Sink",
+            "description" : "JMS AMQP 1.0 Sink",
+            "version" : "0.1",
+            "labels" : [ "sink" ],
+            "capabilities" : [ "error_handler", "processors" ],
+            "channels" : [ "stable" ],
+            "schema" : {
+              "type" : "object",
+              "required" : [ "jms_amqp_destination_name", "jms_amqp_remote_u_r_i", "kafka_topic" ],
+              "properties" : {
+                "jms_amqp_destination_type" : {
+                  "title" : "Destination Type",
+                  "description" : "The JMS destination type (i.e.: queue or topic)",
+                  "type" : "string",
+                  "default" : "queue"
+                },
+                "jms_amqp_destination_name" : {
+                  "title" : "Destination Name",
+                  "description" : "The JMS destination name",
+                  "type" : "string"
+                },
+                "jms_amqp_remote_u_r_i" : {
+                  "title" : "Broker URL",
+                  "description" : "The JMS URL",
+                  "type" : "string",
+                  "example" : "amqp://my-host:31616"
+                },
+                "kafka_topic" : {
+                  "title" : "Topic Names",
+                  "description" : "Comma separated list of Kafka topic names",
+                  "type" : "string"
+                },
+                "processors" : {
+                  "type" : "array",
+                  "items" : {
+                    "oneOf" : [ {
+                      "type" : "object",
+                      "required" : [ "throttle" ],
+                      "properties" : {
+                        "throttle" : {
+                          "$ref" : "#/$defs/processors/throttle"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "log" ],
+                      "properties" : {
+                        "log" : {
+                          "$ref" : "#/$defs/processors/log"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_extract" ],
+                      "properties" : {
+                        "jsonpath_extract" : {
+                          "$ref" : "#/$defs/processors/jsonpath_extract"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_remove" ],
+                      "properties" : {
+                        "jsonpath_remove" : {
+                          "$ref" : "#/$defs/processors/jsonpath_remove"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_rename" ],
+                      "properties" : {
+                        "jsonpath_rename" : {
+                          "$ref" : "#/$defs/processors/jsonpath_rename"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_set" ],
+                      "properties" : {
+                        "jsonpath_set" : {
+                          "$ref" : "#/$defs/processors/jsonpath_set"
+                        }
+                      }
+                    } ]
+                  }
+                },
+                "error_handler" : {
+                  "type" : "object",
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "dead_letter_queue" ],
+                    "properties" : {
+                      "dead_letter_queue" : {
+                        "$ref" : "#/$defs/error_handler/dead_letter_queue"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "log" ],
+                    "properties" : {
+                      "log" : {
+                        "$ref" : "#/$defs/error_handler/log"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "stop" ],
+                    "properties" : {
+                      "stop" : {
+                        "$ref" : "#/$defs/error_handler/stop"
+                      }
+                    }
+                  } ]
+                }
+              },
+              "$defs" : {
+                "processors" : {
+                  "throttle" : {
+                    "title" : "Throttle Action",
+                    "description" : "The Throttle action allows to ensure that a specific sink does not get overloaded.",
+                    "required" : [ "messages" ],
+                    "properties" : {
+                      "messages" : {
+                        "title" : "Messages Number",
+                        "description" : "The number of messages to send in the time period set",
+                        "type" : "integer",
+                        "example" : 10
+                      },
+                      "timePeriod" : {
+                        "title" : "Time Period",
+                        "description" : "Sets the time period during which the maximum request count is valid for, in milliseconds",
+                        "type" : "string",
+                        "default" : "1000"
+                      }
+                    },
+                    "type" : "object"
+                  },
+                  "log" : {
+                    "title" : "Log",
+                    "description" : "Log payload.",
+                    "type" : "object",
+                    "properties" : {
+                      "multiLine" : {
+                        "title" : "Multi Line",
+                        "description" : "Multi Line",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showProperties" : {
+                        "title" : "Show Properties",
+                        "description" : "Show Properties",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showHeaders" : {
+                        "title" : "Show Headers",
+                        "description" : "Show Headers",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      }
+                    }
+                  },
+                  "jsonpath_extract" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_remove" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_rename" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "newKey" : {
+                        "title" : "NewKey",
+                        "description" : "NewKey",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_set" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "title" : "Value",
+                        "description" : "Value",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "dead_letter_queue" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "topic" ],
+                    "properties" : {
+                      "topic" : {
+                        "type" : "string",
+                        "title" : "Dead Letter Topic Name",
+                        "description" : "The name of the Kafka topic used as dead letter queue"
+                      }
+                    }
+                  },
+                  "log" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  },
+                  "stop" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  }
+                }
+              }
+            }
+          }
+        }
+      jms_amqp_10_source_0.1.json: |-
+        {
+          "channels" : {
+            "stable" : {
+              "shard_metadata" : {
+                "connector_revision" : "8",
+                "connector_type" : "source",
+                "connector_image" : "quay.io/rhoas/cos-connector-jms-amqp-10:0.1.8",
+                "operators" : [ {
+                  "type" : "camel-connector-operator",
+                  "version" : "[1.0.0,2.0.0)"
+                } ],
+                "kamelets" : {
+                  "adapter" : {
+                    "name" : "jms-amqp-10-source",
+                    "prefix" : "jms-amqp"
+                  },
+                  "kafka" : {
+                    "name" : "cos-kafka-sink",
+                    "prefix" : "kafka"
+                  },
+                  "processors" : {
+                    "throttle" : "throttle-action",
+                    "jsonpath_set" : "cos-jsonpath-set-action",
+                    "log" : "cos-log-action",
+                    "jsonpath_rename" : "cos-jsonpath-rename-action",
+                    "jsonpath_extract" : "cos-jsonpath-extract-action",
+                    "jsonpath_remove" : "cos-jsonpath-remove-action"
+                  }
+                }
+              }
+            }
+          },
+          "connector_type" : {
+            "id" : "jms_amqp_10_source_0.1",
+            "kind" : "ConnectorType",
+            "icon_href" : "TODO",
+            "name" : "JMS AMQP 1.0 Source",
+            "description" : "JMS AMQP 1.0 Source",
+            "version" : "0.1",
+            "labels" : [ "source" ],
+            "capabilities" : [ "error_handler", "processors" ],
+            "channels" : [ "stable" ],
+            "schema" : {
+              "type" : "object",
+              "required" : [ "jms_amqp_destination_name", "jms_amqp_remote_u_r_i", "kafka_topic" ],
+              "properties" : {
+                "jms_amqp_destination_type" : {
+                  "title" : "Destination Type",
+                  "description" : "The JMS destination type (i.e.: queue or topic)",
+                  "type" : "string",
+                  "default" : "queue"
+                },
+                "jms_amqp_destination_name" : {
+                  "title" : "Destination Name",
+                  "description" : "The JMS destination name",
+                  "type" : "string"
+                },
+                "jms_amqp_remote_u_r_i" : {
+                  "title" : "Broker URL",
+                  "description" : "The JMS URL",
+                  "type" : "string",
+                  "example" : "amqp://my-host:31616"
+                },
+                "kafka_topic" : {
+                  "title" : "Topic Names",
+                  "description" : "Comma separated list of Kafka topic names",
+                  "type" : "string"
+                },
+                "processors" : {
+                  "type" : "array",
+                  "items" : {
+                    "oneOf" : [ {
+                      "type" : "object",
+                      "required" : [ "throttle" ],
+                      "properties" : {
+                        "throttle" : {
+                          "$ref" : "#/$defs/processors/throttle"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "log" ],
+                      "properties" : {
+                        "log" : {
+                          "$ref" : "#/$defs/processors/log"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_extract" ],
+                      "properties" : {
+                        "jsonpath_extract" : {
+                          "$ref" : "#/$defs/processors/jsonpath_extract"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_remove" ],
+                      "properties" : {
+                        "jsonpath_remove" : {
+                          "$ref" : "#/$defs/processors/jsonpath_remove"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_rename" ],
+                      "properties" : {
+                        "jsonpath_rename" : {
+                          "$ref" : "#/$defs/processors/jsonpath_rename"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_set" ],
+                      "properties" : {
+                        "jsonpath_set" : {
+                          "$ref" : "#/$defs/processors/jsonpath_set"
+                        }
+                      }
+                    } ]
+                  }
+                },
+                "error_handler" : {
+                  "type" : "object",
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "dead_letter_queue" ],
+                    "properties" : {
+                      "dead_letter_queue" : {
+                        "$ref" : "#/$defs/error_handler/dead_letter_queue"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "log" ],
+                    "properties" : {
+                      "log" : {
+                        "$ref" : "#/$defs/error_handler/log"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "stop" ],
+                    "properties" : {
+                      "stop" : {
+                        "$ref" : "#/$defs/error_handler/stop"
+                      }
+                    }
+                  } ]
+                }
+              },
+              "$defs" : {
+                "processors" : {
+                  "throttle" : {
+                    "title" : "Throttle Action",
+                    "description" : "The Throttle action allows to ensure that a specific sink does not get overloaded.",
+                    "required" : [ "messages" ],
+                    "properties" : {
+                      "messages" : {
+                        "title" : "Messages Number",
+                        "description" : "The number of messages to send in the time period set",
+                        "type" : "integer",
+                        "example" : 10
+                      },
+                      "timePeriod" : {
+                        "title" : "Time Period",
+                        "description" : "Sets the time period during which the maximum request count is valid for, in milliseconds",
+                        "type" : "string",
+                        "default" : "1000"
+                      }
+                    },
+                    "type" : "object"
+                  },
+                  "log" : {
+                    "title" : "Log",
+                    "description" : "Log payload.",
+                    "type" : "object",
+                    "properties" : {
+                      "multiLine" : {
+                        "title" : "Multi Line",
+                        "description" : "Multi Line",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showProperties" : {
+                        "title" : "Show Properties",
+                        "description" : "Show Properties",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showHeaders" : {
+                        "title" : "Show Headers",
+                        "description" : "Show Headers",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      }
+                    }
+                  },
+                  "jsonpath_extract" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_remove" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_rename" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "newKey" : {
+                        "title" : "NewKey",
+                        "description" : "NewKey",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_set" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "title" : "Value",
+                        "description" : "Value",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "dead_letter_queue" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "topic" ],
+                    "properties" : {
+                      "topic" : {
+                        "type" : "string",
+                        "title" : "Dead Letter Topic Name",
+                        "description" : "The name of the Kafka topic used as dead letter queue"
+                      }
+                    }
+                  },
+                  "log" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  },
+                  "stop" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  }
+                }
+              }
+            }
+          }
+        }
+      jms_apache_artemis_sink_0.1.json: |-
+        {
+          "channels" : {
+            "stable" : {
+              "shard_metadata" : {
+                "connector_revision" : "8",
+                "connector_type" : "sink",
+                "connector_image" : "quay.io/rhoas/cos-connector-jms-apache-artemis:0.1.8",
+                "operators" : [ {
+                  "type" : "camel-connector-operator",
+                  "version" : "[1.0.0,2.0.0)"
+                } ],
+                "kamelets" : {
+                  "adapter" : {
+                    "name" : "jms-apache-artemis-sink",
+                    "prefix" : "jms-artemis"
+                  },
+                  "kafka" : {
+                    "name" : "cos-kafka-source",
+                    "prefix" : "kafka"
+                  },
+                  "processors" : {
+                    "throttle" : "throttle-action",
+                    "jsonpath_set" : "cos-jsonpath-set-action",
+                    "log" : "cos-log-action",
+                    "jsonpath_rename" : "cos-jsonpath-rename-action",
+                    "jsonpath_extract" : "cos-jsonpath-extract-action",
+                    "jsonpath_remove" : "cos-jsonpath-remove-action"
+                  }
+                }
+              }
+            }
+          },
+          "connector_type" : {
+            "id" : "jms_apache_artemis_sink_0.1",
+            "kind" : "ConnectorType",
+            "icon_href" : "TODO",
+            "name" : "JMS Apache Artemis Sink",
+            "description" : "JMS Apache Artemis Sink",
+            "version" : "0.1",
+            "labels" : [ "sink" ],
+            "capabilities" : [ "error_handler", "processors" ],
+            "channels" : [ "stable" ],
+            "schema" : {
+              "type" : "object",
+              "required" : [ "jms_artemis_destination_name", "jms_artemis_broker_u_r_l", "kafka_topic" ],
+              "properties" : {
+                "jms_artemis_destination_type" : {
+                  "title" : "Destination Type",
+                  "description" : "The JMS destination type (i.e.: queue or topic)",
+                  "type" : "string",
+                  "default" : "queue"
+                },
+                "jms_artemis_destination_name" : {
+                  "title" : "Destination Name",
+                  "description" : "The JMS destination name",
+                  "type" : "string",
+                  "example" : "person"
+                },
+                "jms_artemis_broker_u_r_l" : {
+                  "title" : "Broker URL",
+                  "description" : "The JMS URL",
+                  "type" : "string",
+                  "example" : "tcp://my-host:61616"
+                },
+                "kafka_topic" : {
+                  "title" : "Topic Names",
+                  "description" : "Comma separated list of Kafka topic names",
+                  "type" : "string"
+                },
+                "processors" : {
+                  "type" : "array",
+                  "items" : {
+                    "oneOf" : [ {
+                      "type" : "object",
+                      "required" : [ "throttle" ],
+                      "properties" : {
+                        "throttle" : {
+                          "$ref" : "#/$defs/processors/throttle"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "log" ],
+                      "properties" : {
+                        "log" : {
+                          "$ref" : "#/$defs/processors/log"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_extract" ],
+                      "properties" : {
+                        "jsonpath_extract" : {
+                          "$ref" : "#/$defs/processors/jsonpath_extract"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_remove" ],
+                      "properties" : {
+                        "jsonpath_remove" : {
+                          "$ref" : "#/$defs/processors/jsonpath_remove"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_rename" ],
+                      "properties" : {
+                        "jsonpath_rename" : {
+                          "$ref" : "#/$defs/processors/jsonpath_rename"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_set" ],
+                      "properties" : {
+                        "jsonpath_set" : {
+                          "$ref" : "#/$defs/processors/jsonpath_set"
+                        }
+                      }
+                    } ]
+                  }
+                },
+                "error_handler" : {
+                  "type" : "object",
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "dead_letter_queue" ],
+                    "properties" : {
+                      "dead_letter_queue" : {
+                        "$ref" : "#/$defs/error_handler/dead_letter_queue"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "log" ],
+                    "properties" : {
+                      "log" : {
+                        "$ref" : "#/$defs/error_handler/log"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "stop" ],
+                    "properties" : {
+                      "stop" : {
+                        "$ref" : "#/$defs/error_handler/stop"
+                      }
+                    }
+                  } ]
+                }
+              },
+              "$defs" : {
+                "processors" : {
+                  "throttle" : {
+                    "title" : "Throttle Action",
+                    "description" : "The Throttle action allows to ensure that a specific sink does not get overloaded.",
+                    "required" : [ "messages" ],
+                    "properties" : {
+                      "messages" : {
+                        "title" : "Messages Number",
+                        "description" : "The number of messages to send in the time period set",
+                        "type" : "integer",
+                        "example" : 10
+                      },
+                      "timePeriod" : {
+                        "title" : "Time Period",
+                        "description" : "Sets the time period during which the maximum request count is valid for, in milliseconds",
+                        "type" : "string",
+                        "default" : "1000"
+                      }
+                    },
+                    "type" : "object"
+                  },
+                  "log" : {
+                    "title" : "Log",
+                    "description" : "Log payload.",
+                    "type" : "object",
+                    "properties" : {
+                      "multiLine" : {
+                        "title" : "Multi Line",
+                        "description" : "Multi Line",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showProperties" : {
+                        "title" : "Show Properties",
+                        "description" : "Show Properties",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showHeaders" : {
+                        "title" : "Show Headers",
+                        "description" : "Show Headers",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      }
+                    }
+                  },
+                  "jsonpath_extract" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_remove" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_rename" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "newKey" : {
+                        "title" : "NewKey",
+                        "description" : "NewKey",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_set" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "title" : "Value",
+                        "description" : "Value",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "dead_letter_queue" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "topic" ],
+                    "properties" : {
+                      "topic" : {
+                        "type" : "string",
+                        "title" : "Dead Letter Topic Name",
+                        "description" : "The name of the Kafka topic used as dead letter queue"
+                      }
+                    }
+                  },
+                  "log" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  },
+                  "stop" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  }
+                }
+              }
+            }
+          }
+        }
+      jms_apache_artemis_source_0.1.json: |-
+        {
+          "channels" : {
+            "stable" : {
+              "shard_metadata" : {
+                "connector_revision" : "8",
+                "connector_type" : "source",
+                "connector_image" : "quay.io/rhoas/cos-connector-jms-apache-artemis:0.1.8",
+                "operators" : [ {
+                  "type" : "camel-connector-operator",
+                  "version" : "[1.0.0,2.0.0)"
+                } ],
+                "kamelets" : {
+                  "adapter" : {
+                    "name" : "jms-apache-artemis-source",
+                    "prefix" : "jms-artemis"
+                  },
+                  "kafka" : {
+                    "name" : "cos-kafka-sink",
+                    "prefix" : "kafka"
+                  },
+                  "processors" : {
+                    "throttle" : "throttle-action",
+                    "jsonpath_set" : "cos-jsonpath-set-action",
+                    "log" : "cos-log-action",
+                    "jsonpath_rename" : "cos-jsonpath-rename-action",
+                    "jsonpath_extract" : "cos-jsonpath-extract-action",
+                    "jsonpath_remove" : "cos-jsonpath-remove-action"
+                  }
+                }
+              }
+            }
+          },
+          "connector_type" : {
+            "id" : "jms_apache_artemis_source_0.1",
+            "kind" : "ConnectorType",
+            "icon_href" : "TODO",
+            "name" : "JMS Apache Artemis Source",
+            "description" : "JMS Apache Artemis Source",
+            "version" : "0.1",
+            "labels" : [ "source" ],
+            "capabilities" : [ "error_handler", "processors" ],
+            "channels" : [ "stable" ],
+            "schema" : {
+              "type" : "object",
+              "required" : [ "jms_artemis_destination_name", "jms_artemis_broker_u_r_l", "kafka_topic" ],
+              "properties" : {
+                "jms_artemis_destination_type" : {
+                  "title" : "Destination Type",
+                  "description" : "The JMS destination type (i.e.: queue or topic)",
+                  "type" : "string",
+                  "default" : "queue"
+                },
+                "jms_artemis_destination_name" : {
+                  "title" : "Destination Name",
+                  "description" : "The JMS destination name",
+                  "type" : "string"
+                },
+                "jms_artemis_broker_u_r_l" : {
+                  "title" : "Broker URL",
+                  "description" : "The JMS URL",
+                  "type" : "string",
+                  "example" : "tcp://k3s-node-master.usersys.redhat.com:31616"
+                },
+                "kafka_topic" : {
+                  "title" : "Topic Names",
+                  "description" : "Comma separated list of Kafka topic names",
+                  "type" : "string"
+                },
+                "processors" : {
+                  "type" : "array",
+                  "items" : {
+                    "oneOf" : [ {
+                      "type" : "object",
+                      "required" : [ "throttle" ],
+                      "properties" : {
+                        "throttle" : {
+                          "$ref" : "#/$defs/processors/throttle"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "log" ],
+                      "properties" : {
+                        "log" : {
+                          "$ref" : "#/$defs/processors/log"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_extract" ],
+                      "properties" : {
+                        "jsonpath_extract" : {
+                          "$ref" : "#/$defs/processors/jsonpath_extract"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_remove" ],
+                      "properties" : {
+                        "jsonpath_remove" : {
+                          "$ref" : "#/$defs/processors/jsonpath_remove"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_rename" ],
+                      "properties" : {
+                        "jsonpath_rename" : {
+                          "$ref" : "#/$defs/processors/jsonpath_rename"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_set" ],
+                      "properties" : {
+                        "jsonpath_set" : {
+                          "$ref" : "#/$defs/processors/jsonpath_set"
+                        }
+                      }
+                    } ]
+                  }
+                },
+                "error_handler" : {
+                  "type" : "object",
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "dead_letter_queue" ],
+                    "properties" : {
+                      "dead_letter_queue" : {
+                        "$ref" : "#/$defs/error_handler/dead_letter_queue"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "log" ],
+                    "properties" : {
+                      "log" : {
+                        "$ref" : "#/$defs/error_handler/log"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "stop" ],
+                    "properties" : {
+                      "stop" : {
+                        "$ref" : "#/$defs/error_handler/stop"
+                      }
+                    }
+                  } ]
+                }
+              },
+              "$defs" : {
+                "processors" : {
+                  "throttle" : {
+                    "title" : "Throttle Action",
+                    "description" : "The Throttle action allows to ensure that a specific sink does not get overloaded.",
+                    "required" : [ "messages" ],
+                    "properties" : {
+                      "messages" : {
+                        "title" : "Messages Number",
+                        "description" : "The number of messages to send in the time period set",
+                        "type" : "integer",
+                        "example" : 10
+                      },
+                      "timePeriod" : {
+                        "title" : "Time Period",
+                        "description" : "Sets the time period during which the maximum request count is valid for, in milliseconds",
+                        "type" : "string",
+                        "default" : "1000"
+                      }
+                    },
+                    "type" : "object"
+                  },
+                  "log" : {
+                    "title" : "Log",
+                    "description" : "Log payload.",
+                    "type" : "object",
+                    "properties" : {
+                      "multiLine" : {
+                        "title" : "Multi Line",
+                        "description" : "Multi Line",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showProperties" : {
+                        "title" : "Show Properties",
+                        "description" : "Show Properties",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showHeaders" : {
+                        "title" : "Show Headers",
+                        "description" : "Show Headers",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      }
+                    }
+                  },
+                  "jsonpath_extract" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_remove" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_rename" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "newKey" : {
+                        "title" : "NewKey",
+                        "description" : "NewKey",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_set" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "title" : "Value",
+                        "description" : "Value",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "dead_letter_queue" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "topic" ],
+                    "properties" : {
+                      "topic" : {
+                        "type" : "string",
+                        "title" : "Dead Letter Topic Name",
+                        "description" : "The name of the Kafka topic used as dead letter queue"
+                      }
+                    }
+                  },
+                  "log" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  },
+                  "stop" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  }
+                }
+              }
+            }
+          }
+        }
+    kind: ConfigMap
+    metadata:
+      creationTimestamp: null
+      name: connector-catalog-camel-messaging
+  - apiVersion: v1
+    data:
+      injector_source_0.1.json: |-
+        {
+          "channels" : {
+            "stable" : {
+              "shard_metadata" : {
+                "connector_revision" : "8",
+                "connector_type" : "source",
+                "connector_image" : "quay.io/rhoas/cos-connector-injector:0.1.8",
+                "operators" : [ {
+                  "type" : "camel-connector-operator",
+                  "version" : "[1.0.0,2.0.0)"
+                } ],
+                "kamelets" : {
+                  "adapter" : {
+                    "name" : "cos-injector-source",
+                    "prefix" : "injector"
+                  },
+                  "kafka" : {
+                    "name" : "cos-kafka-sink",
+                    "prefix" : "kafka"
+                  },
+                  "processors" : {
+                    "throttle" : "throttle-action",
+                    "jsonpath_set" : "cos-jsonpath-set-action",
+                    "log" : "cos-log-action",
+                    "jsonpath_rename" : "cos-jsonpath-rename-action",
+                    "jsonpath_extract" : "cos-jsonpath-extract-action",
+                    "jsonpath_remove" : "cos-jsonpath-remove-action"
+                  }
+                }
+              }
+            }
+          },
+          "connector_type" : {
+            "id" : "injector_source_0.1",
+            "kind" : "ConnectorType",
+            "icon_href" : "TODO",
+            "name" : "Injector Source",
+            "description" : "Injector Source",
+            "version" : "0.1",
+            "labels" : [ "source" ],
+            "capabilities" : [ "error_handler", "processors" ],
+            "channels" : [ "stable" ],
+            "schema" : {
+              "type" : "object",
+              "required" : [ "injector_delay", "kafka_topic" ],
+              "properties" : {
+                "injector_delay" : {
+                  "title" : "Delay",
+                  "description" : "Delay",
+                  "type" : "string",
+                  "x-group" : "common"
+                },
+                "injector_multi_line" : {
+                  "title" : "Multi Line",
+                  "description" : "Multi Line",
+                  "type" : "boolean",
+                  "default" : false,
+                  "x-group" : "common"
+                },
+                "injector_show_all" : {
+                  "title" : "Show All",
+                  "description" : "Show All",
+                  "type" : "boolean",
+                  "default" : false,
+                  "x-group" : "common"
+                },
+                "kafka_topic" : {
+                  "title" : "Topic Names",
+                  "description" : "Comma separated list of Kafka topic names",
+                  "type" : "string"
+                },
+                "processors" : {
+                  "type" : "array",
+                  "items" : {
+                    "oneOf" : [ {
+                      "type" : "object",
+                      "required" : [ "throttle" ],
+                      "properties" : {
+                        "throttle" : {
+                          "$ref" : "#/$defs/processors/throttle"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "log" ],
+                      "properties" : {
+                        "log" : {
+                          "$ref" : "#/$defs/processors/log"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_extract" ],
+                      "properties" : {
+                        "jsonpath_extract" : {
+                          "$ref" : "#/$defs/processors/jsonpath_extract"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_remove" ],
+                      "properties" : {
+                        "jsonpath_remove" : {
+                          "$ref" : "#/$defs/processors/jsonpath_remove"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_rename" ],
+                      "properties" : {
+                        "jsonpath_rename" : {
+                          "$ref" : "#/$defs/processors/jsonpath_rename"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_set" ],
+                      "properties" : {
+                        "jsonpath_set" : {
+                          "$ref" : "#/$defs/processors/jsonpath_set"
+                        }
+                      }
+                    } ]
+                  }
+                },
+                "error_handler" : {
+                  "type" : "object",
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "dead_letter_queue" ],
+                    "properties" : {
+                      "dead_letter_queue" : {
+                        "$ref" : "#/$defs/error_handler/dead_letter_queue"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "log" ],
+                    "properties" : {
+                      "log" : {
+                        "$ref" : "#/$defs/error_handler/log"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "stop" ],
+                    "properties" : {
+                      "stop" : {
+                        "$ref" : "#/$defs/error_handler/stop"
+                      }
+                    }
+                  } ]
+                }
+              },
+              "$defs" : {
+                "processors" : {
+                  "throttle" : {
+                    "title" : "Throttle Action",
+                    "description" : "The Throttle action allows to ensure that a specific sink does not get overloaded.",
+                    "required" : [ "messages" ],
+                    "properties" : {
+                      "messages" : {
+                        "title" : "Messages Number",
+                        "description" : "The number of messages to send in the time period set",
+                        "type" : "integer",
+                        "example" : 10
+                      },
+                      "timePeriod" : {
+                        "title" : "Time Period",
+                        "description" : "Sets the time period during which the maximum request count is valid for, in milliseconds",
+                        "type" : "string",
+                        "default" : "1000"
+                      }
+                    },
+                    "type" : "object"
+                  },
+                  "log" : {
+                    "title" : "Log",
+                    "description" : "Log payload.",
+                    "type" : "object",
+                    "properties" : {
+                      "multiLine" : {
+                        "title" : "Multi Line",
+                        "description" : "Multi Line",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showProperties" : {
+                        "title" : "Show Properties",
+                        "description" : "Show Properties",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showHeaders" : {
+                        "title" : "Show Headers",
+                        "description" : "Show Headers",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      }
+                    }
+                  },
+                  "jsonpath_extract" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_remove" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_rename" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "newKey" : {
+                        "title" : "NewKey",
+                        "description" : "NewKey",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_set" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "title" : "Value",
+                        "description" : "Value",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "dead_letter_queue" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "topic" ],
+                    "properties" : {
+                      "topic" : {
+                        "type" : "string",
+                        "title" : "Dead Letter Topic Name",
+                        "description" : "The name of the Kafka topic used as dead letter queue"
+                      }
+                    }
+                  },
+                  "log" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  },
+                  "stop" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  }
+                }
+              }
+            }
+          }
+        }
+      log_sink_0.1.json: |-
+        {
+          "channels" : {
+            "stable" : {
+              "shard_metadata" : {
+                "connector_revision" : "8",
+                "connector_type" : "sink",
+                "connector_image" : "quay.io/rhoas/cos-connector-log:0.1.8",
+                "operators" : [ {
+                  "type" : "camel-connector-operator",
+                  "version" : "[1.0.0,2.0.0)"
+                } ],
+                "kamelets" : {
+                  "adapter" : {
+                    "name" : "cos-log-sink",
+                    "prefix" : "log"
+                  },
+                  "kafka" : {
+                    "name" : "cos-kafka-source",
+                    "prefix" : "kafka"
+                  },
+                  "processors" : {
+                    "throttle" : "throttle-action",
+                    "jsonpath_set" : "cos-jsonpath-set-action",
+                    "log" : "cos-log-action",
+                    "jsonpath_rename" : "cos-jsonpath-rename-action",
+                    "jsonpath_extract" : "cos-jsonpath-extract-action",
+                    "jsonpath_remove" : "cos-jsonpath-remove-action"
+                  }
+                }
+              }
+            }
+          },
+          "connector_type" : {
+            "id" : "log_sink_0.1",
+            "kind" : "ConnectorType",
+            "icon_href" : "TODO",
+            "name" : "Log Sink",
+            "description" : "Log Sink",
+            "version" : "0.1",
+            "labels" : [ "sink" ],
+            "capabilities" : [ "error_handler", "processors" ],
+            "channels" : [ "stable" ],
+            "schema" : {
+              "type" : "object",
+              "properties" : {
+                "log_multi_line" : {
+                  "title" : "Multi Line",
+                  "description" : "Multi Line",
+                  "type" : "boolean",
+                  "default" : false,
+                  "x-group" : "common"
+                },
+                "log_show_all" : {
+                  "title" : "Show All",
+                  "description" : "Show All",
+                  "type" : "boolean",
+                  "default" : false,
+                  "x-group" : "common"
+                },
+                "kafka_topic" : {
+                  "title" : "Topic Names",
+                  "description" : "Comma separated list of Kafka topic names",
+                  "type" : "string"
+                },
+                "processors" : {
+                  "type" : "array",
+                  "items" : {
+                    "oneOf" : [ {
+                      "type" : "object",
+                      "required" : [ "throttle" ],
+                      "properties" : {
+                        "throttle" : {
+                          "$ref" : "#/$defs/processors/throttle"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "log" ],
+                      "properties" : {
+                        "log" : {
+                          "$ref" : "#/$defs/processors/log"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_extract" ],
+                      "properties" : {
+                        "jsonpath_extract" : {
+                          "$ref" : "#/$defs/processors/jsonpath_extract"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_remove" ],
+                      "properties" : {
+                        "jsonpath_remove" : {
+                          "$ref" : "#/$defs/processors/jsonpath_remove"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_rename" ],
+                      "properties" : {
+                        "jsonpath_rename" : {
+                          "$ref" : "#/$defs/processors/jsonpath_rename"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_set" ],
+                      "properties" : {
+                        "jsonpath_set" : {
+                          "$ref" : "#/$defs/processors/jsonpath_set"
+                        }
+                      }
+                    } ]
+                  }
+                },
+                "error_handler" : {
+                  "type" : "object",
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "dead_letter_queue" ],
+                    "properties" : {
+                      "dead_letter_queue" : {
+                        "$ref" : "#/$defs/error_handler/dead_letter_queue"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "log" ],
+                    "properties" : {
+                      "log" : {
+                        "$ref" : "#/$defs/error_handler/log"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "stop" ],
+                    "properties" : {
+                      "stop" : {
+                        "$ref" : "#/$defs/error_handler/stop"
+                      }
+                    }
+                  } ]
+                }
+              },
+              "required" : [ "kafka_topic" ],
+              "$defs" : {
+                "processors" : {
+                  "throttle" : {
+                    "title" : "Throttle Action",
+                    "description" : "The Throttle action allows to ensure that a specific sink does not get overloaded.",
+                    "required" : [ "messages" ],
+                    "properties" : {
+                      "messages" : {
+                        "title" : "Messages Number",
+                        "description" : "The number of messages to send in the time period set",
+                        "type" : "integer",
+                        "example" : 10
+                      },
+                      "timePeriod" : {
+                        "title" : "Time Period",
+                        "description" : "Sets the time period during which the maximum request count is valid for, in milliseconds",
+                        "type" : "string",
+                        "default" : "1000"
+                      }
+                    },
+                    "type" : "object"
+                  },
+                  "log" : {
+                    "title" : "Log",
+                    "description" : "Log payload.",
+                    "type" : "object",
+                    "properties" : {
+                      "multiLine" : {
+                        "title" : "Multi Line",
+                        "description" : "Multi Line",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showProperties" : {
+                        "title" : "Show Properties",
+                        "description" : "Show Properties",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showHeaders" : {
+                        "title" : "Show Headers",
+                        "description" : "Show Headers",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      }
+                    }
+                  },
+                  "jsonpath_extract" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_remove" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_rename" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "newKey" : {
+                        "title" : "NewKey",
+                        "description" : "NewKey",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_set" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "title" : "Value",
+                        "description" : "Value",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "dead_letter_queue" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "topic" ],
+                    "properties" : {
+                      "topic" : {
+                        "type" : "string",
+                        "title" : "Dead Letter Topic Name",
+                        "description" : "The name of the Kafka topic used as dead letter queue"
+                      }
+                    }
+                  },
+                  "log" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  },
+                  "stop" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  }
+                }
+              }
+            }
+          }
+        }
+      timer_source_0.1.json: |-
+        {
+          "channels" : {
+            "stable" : {
+              "shard_metadata" : {
+                "connector_revision" : "8",
+                "connector_type" : "source",
+                "connector_image" : "quay.io/rhoas/cos-connector-data-generator:0.1.8",
+                "operators" : [ {
+                  "type" : "camel-connector-operator",
+                  "version" : "[1.0.0,2.0.0)"
+                } ],
+                "kamelets" : {
+                  "adapter" : {
+                    "name" : "timer-source",
+                    "prefix" : "timer"
+                  },
+                  "kafka" : {
+                    "name" : "cos-kafka-sink",
+                    "prefix" : "kafka"
+                  },
+                  "processors" : {
+                    "throttle" : "throttle-action",
+                    "jsonpath_set" : "cos-jsonpath-set-action",
+                    "log" : "cos-log-action",
+                    "jsonpath_rename" : "cos-jsonpath-rename-action",
+                    "jsonpath_extract" : "cos-jsonpath-extract-action",
+                    "jsonpath_remove" : "cos-jsonpath-remove-action"
+                  }
+                }
+              }
+            }
+          },
+          "connector_type" : {
+            "id" : "timer_source_0.1",
+            "kind" : "ConnectorType",
+            "icon_href" : "TODO",
+            "name" : "Data Generator Source",
+            "description" : "Data Generator Source",
+            "version" : "0.1",
+            "labels" : [ "source" ],
+            "capabilities" : [ "error_handler", "processors" ],
+            "channels" : [ "stable" ],
+            "schema" : {
+              "type" : "object",
+              "required" : [ "timer_message", "kafka_topic" ],
+              "properties" : {
+                "timer_period" : {
+                  "title" : "Period",
+                  "description" : "The interval between two events in milliseconds",
+                  "type" : "integer",
+                  "default" : 1000
+                },
+                "timer_message" : {
+                  "title" : "Message",
+                  "description" : "The message to generate",
+                  "type" : "string",
+                  "example" : "hello world"
+                },
+                "timer_content_type" : {
+                  "title" : "Content Type",
+                  "description" : "The content type of the message being generated",
+                  "type" : "string",
+                  "default" : "text/plain"
+                },
+                "kafka_topic" : {
+                  "title" : "Topic Names",
+                  "description" : "Comma separated list of Kafka topic names",
+                  "type" : "string"
+                },
+                "processors" : {
+                  "type" : "array",
+                  "items" : {
+                    "oneOf" : [ {
+                      "type" : "object",
+                      "required" : [ "throttle" ],
+                      "properties" : {
+                        "throttle" : {
+                          "$ref" : "#/$defs/processors/throttle"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "log" ],
+                      "properties" : {
+                        "log" : {
+                          "$ref" : "#/$defs/processors/log"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_extract" ],
+                      "properties" : {
+                        "jsonpath_extract" : {
+                          "$ref" : "#/$defs/processors/jsonpath_extract"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_remove" ],
+                      "properties" : {
+                        "jsonpath_remove" : {
+                          "$ref" : "#/$defs/processors/jsonpath_remove"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_rename" ],
+                      "properties" : {
+                        "jsonpath_rename" : {
+                          "$ref" : "#/$defs/processors/jsonpath_rename"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_set" ],
+                      "properties" : {
+                        "jsonpath_set" : {
+                          "$ref" : "#/$defs/processors/jsonpath_set"
+                        }
+                      }
+                    } ]
+                  }
+                },
+                "error_handler" : {
+                  "type" : "object",
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "dead_letter_queue" ],
+                    "properties" : {
+                      "dead_letter_queue" : {
+                        "$ref" : "#/$defs/error_handler/dead_letter_queue"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "log" ],
+                    "properties" : {
+                      "log" : {
+                        "$ref" : "#/$defs/error_handler/log"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "stop" ],
+                    "properties" : {
+                      "stop" : {
+                        "$ref" : "#/$defs/error_handler/stop"
+                      }
+                    }
+                  } ]
+                }
+              },
+              "$defs" : {
+                "processors" : {
+                  "throttle" : {
+                    "title" : "Throttle Action",
+                    "description" : "The Throttle action allows to ensure that a specific sink does not get overloaded.",
+                    "required" : [ "messages" ],
+                    "properties" : {
+                      "messages" : {
+                        "title" : "Messages Number",
+                        "description" : "The number of messages to send in the time period set",
+                        "type" : "integer",
+                        "example" : 10
+                      },
+                      "timePeriod" : {
+                        "title" : "Time Period",
+                        "description" : "Sets the time period during which the maximum request count is valid for, in milliseconds",
+                        "type" : "string",
+                        "default" : "1000"
+                      }
+                    },
+                    "type" : "object"
+                  },
+                  "log" : {
+                    "title" : "Log",
+                    "description" : "Log payload.",
+                    "type" : "object",
+                    "properties" : {
+                      "multiLine" : {
+                        "title" : "Multi Line",
+                        "description" : "Multi Line",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showProperties" : {
+                        "title" : "Show Properties",
+                        "description" : "Show Properties",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showHeaders" : {
+                        "title" : "Show Headers",
+                        "description" : "Show Headers",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      }
+                    }
+                  },
+                  "jsonpath_extract" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_remove" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_rename" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "newKey" : {
+                        "title" : "NewKey",
+                        "description" : "NewKey",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_set" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "title" : "Value",
+                        "description" : "Value",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "dead_letter_queue" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "topic" ],
+                    "properties" : {
+                      "topic" : {
+                        "type" : "string",
+                        "title" : "Dead Letter Topic Name",
+                        "description" : "The name of the Kafka topic used as dead letter queue"
+                      }
+                    }
+                  },
+                  "log" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  },
+                  "stop" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  }
+                }
+              }
+            }
+          }
+        }
+    kind: ConfigMap
+    metadata:
+      creationTimestamp: null
+      name: connector-catalog-camel-misc
+  - apiVersion: v1
+    data:
+      cassandra_sink_0.1.json: |-
+        {
+          "channels" : {
+            "stable" : {
+              "shard_metadata" : {
+                "connector_revision" : "8",
+                "connector_type" : "sink",
+                "connector_image" : "quay.io/rhoas/cos-connector-cassandra:0.1.8",
+                "operators" : [ {
+                  "type" : "camel-connector-operator",
+                  "version" : "[1.0.0,2.0.0)"
+                } ],
+                "kamelets" : {
+                  "adapter" : {
+                    "name" : "cassandra-sink",
+                    "prefix" : "cassandra"
+                  },
+                  "kafka" : {
+                    "name" : "cos-kafka-source",
+                    "prefix" : "kafka"
+                  },
+                  "processors" : {
+                    "throttle" : "throttle-action",
+                    "jsonpath_set" : "cos-jsonpath-set-action",
+                    "log" : "cos-log-action",
+                    "jsonpath_rename" : "cos-jsonpath-rename-action",
+                    "jsonpath_extract" : "cos-jsonpath-extract-action",
+                    "jsonpath_remove" : "cos-jsonpath-remove-action"
+                  }
+                },
+                "annotations" : {
+                  "trait.camel.apache.org/container.request-memory" : "256m",
+                  "trait.camel.apache.org/container.request-cpu" : "1"
+                },
+                "consumes" : "application/json",
+                "produces" : "application/json"
+              }
+            }
+          },
+          "connector_type" : {
+            "id" : "cassandra_sink_0.1",
+            "kind" : "ConnectorType",
+            "icon_href" : "TODO",
+            "name" : "Cassandra Sink",
+            "description" : "Cassandra Sink",
+            "version" : "0.1",
+            "labels" : [ "sink" ],
+            "capabilities" : [ "data_shape", "error_handler", "processors" ],
+            "channels" : [ "stable" ],
+            "schema" : {
+              "type" : "object",
+              "required" : [ "cassandra_connection_host", "cassandra_connection_port", "cassandra_keyspace", "cassandra_query", "kafka_topic" ],
+              "properties" : {
+                "cassandra_connection_host" : {
+                  "title" : "Connection Host",
+                  "description" : "Hostname(s) cassandra server(s). Multiple hosts can be separated by comma.",
+                  "type" : "string",
+                  "example" : "localhost"
+                },
+                "cassandra_connection_port" : {
+                  "title" : "Connection Port",
+                  "description" : "Port number of cassandra server(s)",
+                  "type" : "string",
+                  "example" : 9042
+                },
+                "cassandra_keyspace" : {
+                  "title" : "Keyspace",
+                  "description" : "Keyspace to use",
+                  "type" : "string",
+                  "example" : "customers"
+                },
+                "cassandra_username" : {
+                  "title" : "Username",
+                  "description" : "The username to use for accessing a secured Cassandra Cluster",
+                  "type" : "string",
+                  "x-group" : "credentials"
+                },
+                "cassandra_password" : {
+                  "title" : "Password",
+                  "x-group" : "credentials",
+                  "oneOf" : [ {
+                    "title" : "Password",
+                    "description" : "The password to use for accessing a secured Cassandra Cluster",
+                    "type" : "string",
+                    "format" : "password"
+                  }, {
+                    "description" : "An opaque reference to the cassandra_password",
+                    "type" : "object",
+                    "properties" : { }
+                  } ]
+                },
+                "cassandra_consistency_level" : {
+                  "title" : "Consistency Level",
+                  "description" : "Consistency level to use. The value can be one of ANY, ONE, TWO, THREE, QUORUM, ALL, LOCAL_QUORUM, EACH_QUORUM, SERIAL, LOCAL_SERIAL, LOCAL_ONE",
+                  "type" : "string",
+                  "default" : "ANY"
+                },
+                "cassandra_prepare_statements" : {
+                  "title" : "Prepare Statements",
+                  "description" : "Whether to use PreparedStatements or regular Statements as the query.",
+                  "type" : "boolean",
+                  "default" : true
+                },
+                "cassandra_query" : {
+                  "title" : "Query",
+                  "description" : "The query to execute against the Cassandra cluster table",
+                  "type" : "string"
+                },
+                "kafka_topic" : {
+                  "title" : "Topic Names",
+                  "description" : "Comma separated list of Kafka topic names",
+                  "type" : "string"
+                },
+                "processors" : {
+                  "type" : "array",
+                  "items" : {
+                    "oneOf" : [ {
+                      "type" : "object",
+                      "required" : [ "throttle" ],
+                      "properties" : {
+                        "throttle" : {
+                          "$ref" : "#/$defs/processors/throttle"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "log" ],
+                      "properties" : {
+                        "log" : {
+                          "$ref" : "#/$defs/processors/log"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_extract" ],
+                      "properties" : {
+                        "jsonpath_extract" : {
+                          "$ref" : "#/$defs/processors/jsonpath_extract"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_remove" ],
+                      "properties" : {
+                        "jsonpath_remove" : {
+                          "$ref" : "#/$defs/processors/jsonpath_remove"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_rename" ],
+                      "properties" : {
+                        "jsonpath_rename" : {
+                          "$ref" : "#/$defs/processors/jsonpath_rename"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_set" ],
+                      "properties" : {
+                        "jsonpath_set" : {
+                          "$ref" : "#/$defs/processors/jsonpath_set"
+                        }
+                      }
+                    } ]
+                  }
+                },
+                "data_shape" : {
+                  "type" : "object",
+                  "additionalProperties" : false,
+                  "properties" : {
+                    "consumes" : {
+                      "$ref" : "#/$defs/data_shape/consumes"
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "type" : "object",
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "dead_letter_queue" ],
+                    "properties" : {
+                      "dead_letter_queue" : {
+                        "$ref" : "#/$defs/error_handler/dead_letter_queue"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "log" ],
+                    "properties" : {
+                      "log" : {
+                        "$ref" : "#/$defs/error_handler/log"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "stop" ],
+                    "properties" : {
+                      "stop" : {
+                        "$ref" : "#/$defs/error_handler/stop"
+                      }
+                    }
+                  } ]
+                }
+              },
+              "$defs" : {
+                "processors" : {
+                  "throttle" : {
+                    "title" : "Throttle Action",
+                    "description" : "The Throttle action allows to ensure that a specific sink does not get overloaded.",
+                    "required" : [ "messages" ],
+                    "properties" : {
+                      "messages" : {
+                        "title" : "Messages Number",
+                        "description" : "The number of messages to send in the time period set",
+                        "type" : "integer",
+                        "example" : 10
+                      },
+                      "timePeriod" : {
+                        "title" : "Time Period",
+                        "description" : "Sets the time period during which the maximum request count is valid for, in milliseconds",
+                        "type" : "string",
+                        "default" : "1000"
+                      }
+                    },
+                    "type" : "object"
+                  },
+                  "log" : {
+                    "title" : "Log",
+                    "description" : "Log payload.",
+                    "type" : "object",
+                    "properties" : {
+                      "multiLine" : {
+                        "title" : "Multi Line",
+                        "description" : "Multi Line",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showProperties" : {
+                        "title" : "Show Properties",
+                        "description" : "Show Properties",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showHeaders" : {
+                        "title" : "Show Headers",
+                        "description" : "Show Headers",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      }
+                    }
+                  },
+                  "jsonpath_extract" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_remove" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_rename" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "newKey" : {
+                        "title" : "NewKey",
+                        "description" : "NewKey",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_set" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "title" : "Value",
+                        "description" : "Value",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  }
+                },
+                "data_shape" : {
+                  "consumes" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "format" ],
+                    "properties" : {
+                      "format" : {
+                        "type" : "string",
+                        "default" : "application/json",
+                        "enum" : [ "application/json", "avro/binary" ]
+                      }
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "dead_letter_queue" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "topic" ],
+                    "properties" : {
+                      "topic" : {
+                        "type" : "string",
+                        "title" : "Dead Letter Topic Name",
+                        "description" : "The name of the Kafka topic used as dead letter queue"
+                      }
+                    }
+                  },
+                  "log" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  },
+                  "stop" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  }
+                }
+              }
+            }
+          }
+        }
+      cassandra_source_0.1.json: |-
+        {
+          "channels" : {
+            "stable" : {
+              "shard_metadata" : {
+                "connector_revision" : "8",
+                "connector_type" : "source",
+                "connector_image" : "quay.io/rhoas/cos-connector-cassandra:0.1.8",
+                "operators" : [ {
+                  "type" : "camel-connector-operator",
+                  "version" : "[1.0.0,2.0.0)"
+                } ],
+                "kamelets" : {
+                  "adapter" : {
+                    "name" : "cassandra-source",
+                    "prefix" : "cassandra"
+                  },
+                  "kafka" : {
+                    "name" : "cos-kafka-sink",
+                    "prefix" : "kafka"
+                  },
+                  "processors" : {
+                    "throttle" : "throttle-action",
+                    "jsonpath_set" : "cos-jsonpath-set-action",
+                    "log" : "cos-log-action",
+                    "jsonpath_rename" : "cos-jsonpath-rename-action",
+                    "jsonpath_extract" : "cos-jsonpath-extract-action",
+                    "jsonpath_remove" : "cos-jsonpath-remove-action"
+                  }
+                },
+                "annotations" : {
+                  "trait.camel.apache.org/container.request-memory" : "256m",
+                  "trait.camel.apache.org/container.request-cpu" : "1"
+                },
+                "consumes" : "application/json",
+                "produces" : "application/json"
+              }
+            }
+          },
+          "connector_type" : {
+            "id" : "cassandra_source_0.1",
+            "kind" : "ConnectorType",
+            "icon_href" : "TODO",
+            "name" : "Cassandra Source",
+            "description" : "Cassandra Source",
+            "version" : "0.1",
+            "labels" : [ "source" ],
+            "capabilities" : [ "data_shape", "error_handler", "processors" ],
+            "channels" : [ "stable" ],
+            "schema" : {
+              "type" : "object",
+              "required" : [ "cassandra_connection_host", "cassandra_connection_port", "cassandra_keyspace", "cassandra_query", "kafka_topic" ],
+              "properties" : {
+                "cassandra_connection_host" : {
+                  "title" : "Connection Host",
+                  "description" : "Hostname(s) cassandra server(s). Multiple hosts can be separated by comma.",
+                  "type" : "string",
+                  "example" : "localhost"
+                },
+                "cassandra_connection_port" : {
+                  "title" : "Connection Port",
+                  "description" : "Port number of cassandra server(s)",
+                  "type" : "string",
+                  "example" : 9042
+                },
+                "cassandra_keyspace" : {
+                  "title" : "Keyspace",
+                  "description" : "Keyspace to use",
+                  "type" : "string",
+                  "example" : "customers"
+                },
+                "cassandra_username" : {
+                  "title" : "Username",
+                  "description" : "The username to use for accessing a secured Cassandra Cluster",
+                  "type" : "string",
+                  "x-group" : "credentials"
+                },
+                "cassandra_password" : {
+                  "title" : "Password",
+                  "x-group" : "credentials",
+                  "oneOf" : [ {
+                    "title" : "Password",
+                    "description" : "The password to use for accessing a secured Cassandra Cluster",
+                    "type" : "string",
+                    "format" : "password"
+                  }, {
+                    "description" : "An opaque reference to the cassandra_password",
+                    "type" : "object",
+                    "properties" : { }
+                  } ]
+                },
+                "cassandra_result_strategy" : {
+                  "title" : "Result Strategy",
+                  "description" : "The strategy to convert the result set of the query. Possible values are ALL, ONE, LIMIT_10, LIMIT_100...",
+                  "type" : "string",
+                  "default" : "ALL"
+                },
+                "cassandra_consistency_level" : {
+                  "title" : "Consistency Level",
+                  "description" : "Consistency level to use. The value can be one of ANY, ONE, TWO, THREE, QUORUM, ALL, LOCAL_QUORUM, EACH_QUORUM, SERIAL, LOCAL_SERIAL, LOCAL_ONE",
+                  "type" : "string",
+                  "default" : "QUORUM"
+                },
+                "cassandra_query" : {
+                  "title" : "Query",
+                  "description" : "The query to execute against the Cassandra cluster table",
+                  "type" : "string"
+                },
+                "kafka_topic" : {
+                  "title" : "Topic Names",
+                  "description" : "Comma separated list of Kafka topic names",
+                  "type" : "string"
+                },
+                "processors" : {
+                  "type" : "array",
+                  "items" : {
+                    "oneOf" : [ {
+                      "type" : "object",
+                      "required" : [ "throttle" ],
+                      "properties" : {
+                        "throttle" : {
+                          "$ref" : "#/$defs/processors/throttle"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "log" ],
+                      "properties" : {
+                        "log" : {
+                          "$ref" : "#/$defs/processors/log"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_extract" ],
+                      "properties" : {
+                        "jsonpath_extract" : {
+                          "$ref" : "#/$defs/processors/jsonpath_extract"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_remove" ],
+                      "properties" : {
+                        "jsonpath_remove" : {
+                          "$ref" : "#/$defs/processors/jsonpath_remove"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_rename" ],
+                      "properties" : {
+                        "jsonpath_rename" : {
+                          "$ref" : "#/$defs/processors/jsonpath_rename"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_set" ],
+                      "properties" : {
+                        "jsonpath_set" : {
+                          "$ref" : "#/$defs/processors/jsonpath_set"
+                        }
+                      }
+                    } ]
+                  }
+                },
+                "data_shape" : {
+                  "type" : "object",
+                  "additionalProperties" : false,
+                  "properties" : {
+                    "produces" : {
+                      "$ref" : "#/$defs/data_shape/produces"
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "type" : "object",
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "dead_letter_queue" ],
+                    "properties" : {
+                      "dead_letter_queue" : {
+                        "$ref" : "#/$defs/error_handler/dead_letter_queue"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "log" ],
+                    "properties" : {
+                      "log" : {
+                        "$ref" : "#/$defs/error_handler/log"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "stop" ],
+                    "properties" : {
+                      "stop" : {
+                        "$ref" : "#/$defs/error_handler/stop"
+                      }
+                    }
+                  } ]
+                }
+              },
+              "$defs" : {
+                "processors" : {
+                  "throttle" : {
+                    "title" : "Throttle Action",
+                    "description" : "The Throttle action allows to ensure that a specific sink does not get overloaded.",
+                    "required" : [ "messages" ],
+                    "properties" : {
+                      "messages" : {
+                        "title" : "Messages Number",
+                        "description" : "The number of messages to send in the time period set",
+                        "type" : "integer",
+                        "example" : 10
+                      },
+                      "timePeriod" : {
+                        "title" : "Time Period",
+                        "description" : "Sets the time period during which the maximum request count is valid for, in milliseconds",
+                        "type" : "string",
+                        "default" : "1000"
+                      }
+                    },
+                    "type" : "object"
+                  },
+                  "log" : {
+                    "title" : "Log",
+                    "description" : "Log payload.",
+                    "type" : "object",
+                    "properties" : {
+                      "multiLine" : {
+                        "title" : "Multi Line",
+                        "description" : "Multi Line",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showProperties" : {
+                        "title" : "Show Properties",
+                        "description" : "Show Properties",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showHeaders" : {
+                        "title" : "Show Headers",
+                        "description" : "Show Headers",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      }
+                    }
+                  },
+                  "jsonpath_extract" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_remove" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_rename" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "newKey" : {
+                        "title" : "NewKey",
+                        "description" : "NewKey",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_set" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "title" : "Value",
+                        "description" : "Value",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  }
+                },
+                "data_shape" : {
+                  "produces" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "format" ],
+                    "properties" : {
+                      "format" : {
+                        "type" : "string",
+                        "default" : "application/json",
+                        "enum" : [ "application/json", "avro/binary" ]
+                      }
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "dead_letter_queue" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "topic" ],
+                    "properties" : {
+                      "topic" : {
+                        "type" : "string",
+                        "title" : "Dead Letter Topic Name",
+                        "description" : "The name of the Kafka topic used as dead letter queue"
+                      }
+                    }
+                  },
+                  "log" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  },
+                  "stop" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  }
+                }
+              }
+            }
+          }
+        }
+      elasticsearch_sink_0.1.json: |-
+        {
+          "channels" : {
+            "stable" : {
+              "shard_metadata" : {
+                "connector_revision" : "8",
+                "connector_type" : "sink",
+                "connector_image" : "quay.io/rhoas/cos-connector-elasticsearch:0.1.8",
+                "operators" : [ {
+                  "type" : "camel-connector-operator",
+                  "version" : "[1.0.0,2.0.0)"
+                } ],
+                "kamelets" : {
+                  "adapter" : {
+                    "name" : "elasticsearch-index-sink",
+                    "prefix" : "elasticsearch"
+                  },
+                  "kafka" : {
+                    "name" : "cos-kafka-source",
+                    "prefix" : "kafka"
+                  },
+                  "processors" : {
+                    "throttle" : "throttle-action",
+                    "jsonpath_set" : "cos-jsonpath-set-action",
+                    "log" : "cos-log-action",
+                    "jsonpath_rename" : "cos-jsonpath-rename-action",
+                    "jsonpath_extract" : "cos-jsonpath-extract-action",
+                    "jsonpath_remove" : "cos-jsonpath-remove-action"
+                  }
+                },
+                "consumes" : "application/json",
+                "produces" : "application/json"
+              }
+            }
+          },
+          "connector_type" : {
+            "id" : "elasticsearch_sink_0.1",
+            "kind" : "ConnectorType",
+            "icon_href" : "TODO",
+            "name" : "Elasticsearch Sink",
+            "description" : "Elasticsearch Sink",
+            "version" : "0.1",
+            "labels" : [ "sink" ],
+            "capabilities" : [ "data_shape", "error_handler", "processors" ],
+            "channels" : [ "stable" ],
+            "schema" : {
+              "type" : "object",
+              "required" : [ "elasticsearch_cluster_name", "elasticsearch_host_addresses", "kafka_topic" ],
+              "properties" : {
+                "elasticsearch_user" : {
+                  "title" : "Username",
+                  "description" : "Username to connect to ElasticSearch.",
+                  "type" : "string",
+                  "x-group" : "credentials"
+                },
+                "elasticsearch_password" : {
+                  "title" : "Password",
+                  "x-group" : "credentials",
+                  "oneOf" : [ {
+                    "title" : "Password",
+                    "description" : "Password to connect to ElasticSearch.",
+                    "type" : "string",
+                    "format" : "password"
+                  }, {
+                    "description" : "An opaque reference to the elasticsearch_password",
+                    "type" : "object",
+                    "properties" : { }
+                  } ]
+                },
+                "elasticsearch_enable_s_s_l" : {
+                  "title" : "Enable SSL",
+                  "description" : "Do we want to connect using SSL?",
+                  "type" : "boolean",
+                  "default" : true
+                },
+                "elasticsearch_host_addresses" : {
+                  "title" : "Host Addresses",
+                  "description" : "Comma separated list with ip:port formatted remote transport addresses to use.",
+                  "type" : "string",
+                  "example" : "quickstart-es-http:9200"
+                },
+                "elasticsearch_cluster_name" : {
+                  "title" : "ElasticSearch Cluster Name",
+                  "description" : "Name of the cluster.",
+                  "type" : "string",
+                  "example" : "quickstart"
+                },
+                "elasticsearch_index_name" : {
+                  "title" : "Index in ElasticSearch",
+                  "description" : "The name of the index to act against.",
+                  "type" : "string",
+                  "example" : "data"
+                },
+                "kafka_topic" : {
+                  "title" : "Topic Names",
+                  "description" : "Comma separated list of Kafka topic names",
+                  "type" : "string"
+                },
+                "processors" : {
+                  "type" : "array",
+                  "items" : {
+                    "oneOf" : [ {
+                      "type" : "object",
+                      "required" : [ "throttle" ],
+                      "properties" : {
+                        "throttle" : {
+                          "$ref" : "#/$defs/processors/throttle"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "log" ],
+                      "properties" : {
+                        "log" : {
+                          "$ref" : "#/$defs/processors/log"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_extract" ],
+                      "properties" : {
+                        "jsonpath_extract" : {
+                          "$ref" : "#/$defs/processors/jsonpath_extract"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_remove" ],
+                      "properties" : {
+                        "jsonpath_remove" : {
+                          "$ref" : "#/$defs/processors/jsonpath_remove"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_rename" ],
+                      "properties" : {
+                        "jsonpath_rename" : {
+                          "$ref" : "#/$defs/processors/jsonpath_rename"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_set" ],
+                      "properties" : {
+                        "jsonpath_set" : {
+                          "$ref" : "#/$defs/processors/jsonpath_set"
+                        }
+                      }
+                    } ]
+                  }
+                },
+                "data_shape" : {
+                  "type" : "object",
+                  "additionalProperties" : false,
+                  "properties" : {
+                    "consumes" : {
+                      "$ref" : "#/$defs/data_shape/consumes"
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "type" : "object",
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "dead_letter_queue" ],
+                    "properties" : {
+                      "dead_letter_queue" : {
+                        "$ref" : "#/$defs/error_handler/dead_letter_queue"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "log" ],
+                    "properties" : {
+                      "log" : {
+                        "$ref" : "#/$defs/error_handler/log"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "stop" ],
+                    "properties" : {
+                      "stop" : {
+                        "$ref" : "#/$defs/error_handler/stop"
+                      }
+                    }
+                  } ]
+                }
+              },
+              "$defs" : {
+                "processors" : {
+                  "throttle" : {
+                    "title" : "Throttle Action",
+                    "description" : "The Throttle action allows to ensure that a specific sink does not get overloaded.",
+                    "required" : [ "messages" ],
+                    "properties" : {
+                      "messages" : {
+                        "title" : "Messages Number",
+                        "description" : "The number of messages to send in the time period set",
+                        "type" : "integer",
+                        "example" : 10
+                      },
+                      "timePeriod" : {
+                        "title" : "Time Period",
+                        "description" : "Sets the time period during which the maximum request count is valid for, in milliseconds",
+                        "type" : "string",
+                        "default" : "1000"
+                      }
+                    },
+                    "type" : "object"
+                  },
+                  "log" : {
+                    "title" : "Log",
+                    "description" : "Log payload.",
+                    "type" : "object",
+                    "properties" : {
+                      "multiLine" : {
+                        "title" : "Multi Line",
+                        "description" : "Multi Line",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showProperties" : {
+                        "title" : "Show Properties",
+                        "description" : "Show Properties",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showHeaders" : {
+                        "title" : "Show Headers",
+                        "description" : "Show Headers",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      }
+                    }
+                  },
+                  "jsonpath_extract" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_remove" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_rename" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "newKey" : {
+                        "title" : "NewKey",
+                        "description" : "NewKey",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_set" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "title" : "Value",
+                        "description" : "Value",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  }
+                },
+                "data_shape" : {
+                  "consumes" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "format" ],
+                    "properties" : {
+                      "format" : {
+                        "type" : "string",
+                        "default" : "application/json",
+                        "enum" : [ "application/json", "avro/binary" ]
+                      }
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "dead_letter_queue" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "topic" ],
+                    "properties" : {
+                      "topic" : {
+                        "type" : "string",
+                        "title" : "Dead Letter Topic Name",
+                        "description" : "The name of the Kafka topic used as dead letter queue"
+                      }
+                    }
+                  },
+                  "log" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  },
+                  "stop" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  }
+                }
+              }
+            }
+          }
+        }
+      mongodb_sink_0.1.json: |-
+        {
+          "channels" : {
+            "stable" : {
+              "shard_metadata" : {
+                "connector_revision" : "8",
+                "connector_type" : "sink",
+                "connector_image" : "quay.io/rhoas/cos-connector-mongodb:0.1.8",
+                "operators" : [ {
+                  "type" : "camel-connector-operator",
+                  "version" : "[1.0.0,2.0.0)"
+                } ],
+                "kamelets" : {
+                  "adapter" : {
+                    "name" : "mongodb-sink",
+                    "prefix" : "mongodb"
+                  },
+                  "kafka" : {
+                    "name" : "cos-kafka-source",
+                    "prefix" : "kafka"
+                  },
+                  "processors" : {
+                    "throttle" : "throttle-action",
+                    "jsonpath_set" : "cos-jsonpath-set-action",
+                    "log" : "cos-log-action",
+                    "jsonpath_rename" : "cos-jsonpath-rename-action",
+                    "jsonpath_extract" : "cos-jsonpath-extract-action",
+                    "jsonpath_remove" : "cos-jsonpath-remove-action"
+                  }
+                },
+                "annotations" : {
+                  "trait.camel.apache.org/container.request-memory" : "256m",
+                  "trait.camel.apache.org/container.request-cpu" : "1"
+                },
+                "consumes" : "application/json",
+                "produces" : "application/json"
+              }
+            }
+          },
+          "connector_type" : {
+            "id" : "mongodb_sink_0.1",
+            "kind" : "ConnectorType",
+            "icon_href" : "TODO",
+            "name" : "MongoDB Sink",
+            "description" : "MongoDB Sink",
+            "version" : "0.1",
+            "labels" : [ "sink" ],
+            "capabilities" : [ "data_shape", "error_handler", "processors" ],
+            "channels" : [ "stable" ],
+            "schema" : {
+              "type" : "object",
+              "required" : [ "mongodb_hosts", "mongodb_collection", "mongodb_database", "kafka_topic" ],
+              "properties" : {
+                "mongodb_hosts" : {
+                  "title" : "MongoDB Hosts",
+                  "description" : "Comma separated list of MongoDB Host Addresses in host:port format.",
+                  "type" : "string"
+                },
+                "mongodb_collection" : {
+                  "title" : "MongoDB Collection",
+                  "description" : "Sets the name of the MongoDB collection to bind to this endpoint.",
+                  "type" : "string"
+                },
+                "mongodb_password" : {
+                  "title" : "MongoDB Password",
+                  "x-group" : "credentials",
+                  "oneOf" : [ {
+                    "title" : "MongoDB Password",
+                    "description" : "User password for accessing MongoDB.",
+                    "type" : "string",
+                    "format" : "password"
+                  }, {
+                    "description" : "An opaque reference to the mongodb_password",
+                    "type" : "object",
+                    "properties" : { }
+                  } ]
+                },
+                "mongodb_username" : {
+                  "title" : "MongoDB Username",
+                  "description" : "Username for accessing MongoDB.",
+                  "type" : "string",
+                  "x-group" : "credentials"
+                },
+                "mongodb_database" : {
+                  "title" : "MongoDB Database",
+                  "description" : "Sets the name of the MongoDB database to target.",
+                  "type" : "string"
+                },
+                "mongodb_write_concern" : {
+                  "title" : "Write Concern",
+                  "description" : "Configure the level of acknowledgment requested from MongoDB for write operations, possible values are ACKNOWLEDGED, W1, W2, W3, UNACKNOWLEDGED, JOURNALED, MAJORITY.",
+                  "type" : "string"
+                },
+                "mongodb_create_collection" : {
+                  "title" : "Collection",
+                  "description" : "Create collection during initialisation if it doesn't exist.",
+                  "type" : "boolean",
+                  "default" : false
+                },
+                "kafka_topic" : {
+                  "title" : "Topic Names",
+                  "description" : "Comma separated list of Kafka topic names",
+                  "type" : "string"
+                },
+                "processors" : {
+                  "type" : "array",
+                  "items" : {
+                    "oneOf" : [ {
+                      "type" : "object",
+                      "required" : [ "throttle" ],
+                      "properties" : {
+                        "throttle" : {
+                          "$ref" : "#/$defs/processors/throttle"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "log" ],
+                      "properties" : {
+                        "log" : {
+                          "$ref" : "#/$defs/processors/log"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_extract" ],
+                      "properties" : {
+                        "jsonpath_extract" : {
+                          "$ref" : "#/$defs/processors/jsonpath_extract"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_remove" ],
+                      "properties" : {
+                        "jsonpath_remove" : {
+                          "$ref" : "#/$defs/processors/jsonpath_remove"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_rename" ],
+                      "properties" : {
+                        "jsonpath_rename" : {
+                          "$ref" : "#/$defs/processors/jsonpath_rename"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_set" ],
+                      "properties" : {
+                        "jsonpath_set" : {
+                          "$ref" : "#/$defs/processors/jsonpath_set"
+                        }
+                      }
+                    } ]
+                  }
+                },
+                "data_shape" : {
+                  "type" : "object",
+                  "additionalProperties" : false,
+                  "properties" : {
+                    "consumes" : {
+                      "$ref" : "#/$defs/data_shape/consumes"
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "type" : "object",
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "dead_letter_queue" ],
+                    "properties" : {
+                      "dead_letter_queue" : {
+                        "$ref" : "#/$defs/error_handler/dead_letter_queue"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "log" ],
+                    "properties" : {
+                      "log" : {
+                        "$ref" : "#/$defs/error_handler/log"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "stop" ],
+                    "properties" : {
+                      "stop" : {
+                        "$ref" : "#/$defs/error_handler/stop"
+                      }
+                    }
+                  } ]
+                }
+              },
+              "$defs" : {
+                "processors" : {
+                  "throttle" : {
+                    "title" : "Throttle Action",
+                    "description" : "The Throttle action allows to ensure that a specific sink does not get overloaded.",
+                    "required" : [ "messages" ],
+                    "properties" : {
+                      "messages" : {
+                        "title" : "Messages Number",
+                        "description" : "The number of messages to send in the time period set",
+                        "type" : "integer",
+                        "example" : 10
+                      },
+                      "timePeriod" : {
+                        "title" : "Time Period",
+                        "description" : "Sets the time period during which the maximum request count is valid for, in milliseconds",
+                        "type" : "string",
+                        "default" : "1000"
+                      }
+                    },
+                    "type" : "object"
+                  },
+                  "log" : {
+                    "title" : "Log",
+                    "description" : "Log payload.",
+                    "type" : "object",
+                    "properties" : {
+                      "multiLine" : {
+                        "title" : "Multi Line",
+                        "description" : "Multi Line",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showProperties" : {
+                        "title" : "Show Properties",
+                        "description" : "Show Properties",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showHeaders" : {
+                        "title" : "Show Headers",
+                        "description" : "Show Headers",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      }
+                    }
+                  },
+                  "jsonpath_extract" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_remove" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_rename" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "newKey" : {
+                        "title" : "NewKey",
+                        "description" : "NewKey",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_set" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "title" : "Value",
+                        "description" : "Value",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  }
+                },
+                "data_shape" : {
+                  "consumes" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "format" ],
+                    "properties" : {
+                      "format" : {
+                        "type" : "string",
+                        "default" : "application/json",
+                        "enum" : [ "application/json", "avro/binary" ]
+                      }
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "dead_letter_queue" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "topic" ],
+                    "properties" : {
+                      "topic" : {
+                        "type" : "string",
+                        "title" : "Dead Letter Topic Name",
+                        "description" : "The name of the Kafka topic used as dead letter queue"
+                      }
+                    }
+                  },
+                  "log" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  },
+                  "stop" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  }
+                }
+              }
+            }
+          }
+        }
+      mongodb_source_0.1.json: |-
+        {
+          "channels" : {
+            "stable" : {
+              "shard_metadata" : {
+                "connector_revision" : "8",
+                "connector_type" : "source",
+                "connector_image" : "quay.io/rhoas/cos-connector-mongodb:0.1.8",
+                "operators" : [ {
+                  "type" : "camel-connector-operator",
+                  "version" : "[1.0.0,2.0.0)"
+                } ],
+                "kamelets" : {
+                  "adapter" : {
+                    "name" : "mongodb-source",
+                    "prefix" : "mongodb"
+                  },
+                  "kafka" : {
+                    "name" : "cos-kafka-sink",
+                    "prefix" : "kafka"
+                  },
+                  "processors" : {
+                    "throttle" : "throttle-action",
+                    "jsonpath_set" : "cos-jsonpath-set-action",
+                    "log" : "cos-log-action",
+                    "jsonpath_rename" : "cos-jsonpath-rename-action",
+                    "jsonpath_extract" : "cos-jsonpath-extract-action",
+                    "jsonpath_remove" : "cos-jsonpath-remove-action"
+                  }
+                },
+                "annotations" : {
+                  "trait.camel.apache.org/container.request-memory" : "256m",
+                  "trait.camel.apache.org/container.request-cpu" : "1"
+                }
+              }
+            }
+          },
+          "connector_type" : {
+            "id" : "mongodb_source_0.1",
+            "kind" : "ConnectorType",
+            "icon_href" : "TODO",
+            "name" : "MongoDB Source",
+            "description" : "MongoDB Source",
+            "version" : "0.1",
+            "labels" : [ "source" ],
+            "capabilities" : [ "error_handler", "processors" ],
+            "channels" : [ "stable" ],
+            "schema" : {
+              "type" : "object",
+              "required" : [ "mongodb_hosts", "mongodb_collection", "mongodb_database", "kafka_topic" ],
+              "properties" : {
+                "mongodb_hosts" : {
+                  "title" : "MongoDB Hosts",
+                  "description" : "Comma separated list of MongoDB Host Addresses in host:port format.",
+                  "type" : "string"
+                },
+                "mongodb_collection" : {
+                  "title" : "MongoDB Collection",
+                  "description" : "Sets the name of the MongoDB collection to bind to this endpoint.",
+                  "type" : "string"
+                },
+                "mongodb_password" : {
+                  "title" : "MongoDB Password",
+                  "x-group" : "credentials",
+                  "oneOf" : [ {
+                    "title" : "MongoDB Password",
+                    "description" : "User password for accessing MongoDB.",
+                    "type" : "string",
+                    "format" : "password"
+                  }, {
+                    "description" : "An opaque reference to the mongodb_password",
+                    "type" : "object",
+                    "properties" : { }
+                  } ]
+                },
+                "mongodb_username" : {
+                  "title" : "MongoDB Username",
+                  "description" : "Username for accessing MongoDB. The username must be present in the MongoDB's authentication database (authenticationDatabase). By default, the MongoDB authenticationDatabase is 'admin'.",
+                  "type" : "string",
+                  "x-group" : "credentials"
+                },
+                "mongodb_database" : {
+                  "title" : "MongoDB Database",
+                  "description" : "Sets the name of the MongoDB database to target.",
+                  "type" : "string"
+                },
+                "mongodb_persistent_tail_tracking" : {
+                  "title" : "MongoDB Persistent Tail Tracking",
+                  "description" : "Enable persistent tail tracking, which is a mechanism to keep track of the last consumed message across system restarts. The next time the system is up, the endpoint will recover the cursor from the point where it last stopped slurping records.",
+                  "type" : "boolean",
+                  "default" : false
+                },
+                "mongodb_tail_track_increasing_field" : {
+                  "title" : "MongoDB Tail Track Increasing Field",
+                  "description" : "Correlation field in the incoming record which is of increasing nature and will be used to position the tailing cursor every time it is generated.",
+                  "type" : "string"
+                },
+                "kafka_topic" : {
+                  "title" : "Topic Names",
+                  "description" : "Comma separated list of Kafka topic names",
+                  "type" : "string"
+                },
+                "processors" : {
+                  "type" : "array",
+                  "items" : {
+                    "oneOf" : [ {
+                      "type" : "object",
+                      "required" : [ "throttle" ],
+                      "properties" : {
+                        "throttle" : {
+                          "$ref" : "#/$defs/processors/throttle"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "log" ],
+                      "properties" : {
+                        "log" : {
+                          "$ref" : "#/$defs/processors/log"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_extract" ],
+                      "properties" : {
+                        "jsonpath_extract" : {
+                          "$ref" : "#/$defs/processors/jsonpath_extract"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_remove" ],
+                      "properties" : {
+                        "jsonpath_remove" : {
+                          "$ref" : "#/$defs/processors/jsonpath_remove"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_rename" ],
+                      "properties" : {
+                        "jsonpath_rename" : {
+                          "$ref" : "#/$defs/processors/jsonpath_rename"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_set" ],
+                      "properties" : {
+                        "jsonpath_set" : {
+                          "$ref" : "#/$defs/processors/jsonpath_set"
+                        }
+                      }
+                    } ]
+                  }
+                },
+                "error_handler" : {
+                  "type" : "object",
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "dead_letter_queue" ],
+                    "properties" : {
+                      "dead_letter_queue" : {
+                        "$ref" : "#/$defs/error_handler/dead_letter_queue"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "log" ],
+                    "properties" : {
+                      "log" : {
+                        "$ref" : "#/$defs/error_handler/log"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "stop" ],
+                    "properties" : {
+                      "stop" : {
+                        "$ref" : "#/$defs/error_handler/stop"
+                      }
+                    }
+                  } ]
+                }
+              },
+              "$defs" : {
+                "processors" : {
+                  "throttle" : {
+                    "title" : "Throttle Action",
+                    "description" : "The Throttle action allows to ensure that a specific sink does not get overloaded.",
+                    "required" : [ "messages" ],
+                    "properties" : {
+                      "messages" : {
+                        "title" : "Messages Number",
+                        "description" : "The number of messages to send in the time period set",
+                        "type" : "integer",
+                        "example" : 10
+                      },
+                      "timePeriod" : {
+                        "title" : "Time Period",
+                        "description" : "Sets the time period during which the maximum request count is valid for, in milliseconds",
+                        "type" : "string",
+                        "default" : "1000"
+                      }
+                    },
+                    "type" : "object"
+                  },
+                  "log" : {
+                    "title" : "Log",
+                    "description" : "Log payload.",
+                    "type" : "object",
+                    "properties" : {
+                      "multiLine" : {
+                        "title" : "Multi Line",
+                        "description" : "Multi Line",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showProperties" : {
+                        "title" : "Show Properties",
+                        "description" : "Show Properties",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showHeaders" : {
+                        "title" : "Show Headers",
+                        "description" : "Show Headers",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      }
+                    }
+                  },
+                  "jsonpath_extract" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_remove" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_rename" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "newKey" : {
+                        "title" : "NewKey",
+                        "description" : "NewKey",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_set" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "title" : "Value",
+                        "description" : "Value",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "dead_letter_queue" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "topic" ],
+                    "properties" : {
+                      "topic" : {
+                        "type" : "string",
+                        "title" : "Dead Letter Topic Name",
+                        "description" : "The name of the Kafka topic used as dead letter queue"
+                      }
+                    }
+                  },
+                  "log" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  },
+                  "stop" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  }
+                }
+              }
+            }
+          }
+        }
+    kind: ConfigMap
+    metadata:
+      creationTimestamp: null
+      name: connector-catalog-camel-nosql
+  - apiVersion: v1
+    data:
+      jira_source_0.1.json: |-
+        {
+          "channels" : {
+            "stable" : {
+              "shard_metadata" : {
+                "connector_revision" : "8",
+                "connector_type" : "source",
+                "connector_image" : "quay.io/rhoas/cos-connector-jira:0.1.8",
+                "operators" : [ {
+                  "type" : "camel-connector-operator",
+                  "version" : "[1.0.0,2.0.0)"
+                } ],
+                "kamelets" : {
+                  "adapter" : {
+                    "name" : "jira-source",
+                    "prefix" : "jira"
+                  },
+                  "kafka" : {
+                    "name" : "cos-kafka-sink",
+                    "prefix" : "kafka"
+                  },
+                  "processors" : {
+                    "throttle" : "throttle-action",
+                    "jsonpath_set" : "cos-jsonpath-set-action",
+                    "log" : "cos-log-action",
+                    "jsonpath_rename" : "cos-jsonpath-rename-action",
+                    "jsonpath_extract" : "cos-jsonpath-extract-action",
+                    "jsonpath_remove" : "cos-jsonpath-remove-action"
+                  }
+                },
+                "consumes" : "application/json",
+                "produces" : "application/json"
+              }
+            }
+          },
+          "connector_type" : {
+            "id" : "jira_source_0.1",
+            "kind" : "ConnectorType",
+            "icon_href" : "TODO",
+            "name" : "Jira Source",
+            "description" : "Jira Source",
+            "version" : "0.1",
+            "labels" : [ "source" ],
+            "capabilities" : [ "data_shape", "error_handler", "processors" ],
+            "channels" : [ "stable" ],
+            "schema" : {
+              "type" : "object",
+              "required" : [ "jira_jira_url", "jira_username", "jira_password", "kafka_topic" ],
+              "properties" : {
+                "jira_jira_url" : {
+                  "title" : "Jira URL",
+                  "description" : "The URL of your instance of Jira",
+                  "type" : "string",
+                  "example" : "http://my_jira.com:8081"
+                },
+                "jira_username" : {
+                  "title" : "Username",
+                  "description" : "The username to access Jira",
+                  "type" : "string",
+                  "x-group" : "credentials"
+                },
+                "jira_password" : {
+                  "title" : "Password",
+                  "x-group" : "credentials",
+                  "oneOf" : [ {
+                    "title" : "Password",
+                    "description" : "The password to access Jira",
+                    "type" : "string",
+                    "format" : "password"
+                  }, {
+                    "description" : "An opaque reference to the jira_password",
+                    "type" : "object",
+                    "properties" : { }
+                  } ]
+                },
+                "jira_jql" : {
+                  "title" : "JQL",
+                  "description" : "A query to filter issues",
+                  "type" : "string",
+                  "example" : "project=MyProject"
+                },
+                "kafka_topic" : {
+                  "title" : "Topic Names",
+                  "description" : "Comma separated list of Kafka topic names",
+                  "type" : "string"
+                },
+                "processors" : {
+                  "type" : "array",
+                  "items" : {
+                    "oneOf" : [ {
+                      "type" : "object",
+                      "required" : [ "throttle" ],
+                      "properties" : {
+                        "throttle" : {
+                          "$ref" : "#/$defs/processors/throttle"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "log" ],
+                      "properties" : {
+                        "log" : {
+                          "$ref" : "#/$defs/processors/log"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_extract" ],
+                      "properties" : {
+                        "jsonpath_extract" : {
+                          "$ref" : "#/$defs/processors/jsonpath_extract"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_remove" ],
+                      "properties" : {
+                        "jsonpath_remove" : {
+                          "$ref" : "#/$defs/processors/jsonpath_remove"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_rename" ],
+                      "properties" : {
+                        "jsonpath_rename" : {
+                          "$ref" : "#/$defs/processors/jsonpath_rename"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_set" ],
+                      "properties" : {
+                        "jsonpath_set" : {
+                          "$ref" : "#/$defs/processors/jsonpath_set"
+                        }
+                      }
+                    } ]
+                  }
+                },
+                "data_shape" : {
+                  "type" : "object",
+                  "additionalProperties" : false,
+                  "properties" : {
+                    "produces" : {
+                      "$ref" : "#/$defs/data_shape/produces"
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "type" : "object",
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "dead_letter_queue" ],
+                    "properties" : {
+                      "dead_letter_queue" : {
+                        "$ref" : "#/$defs/error_handler/dead_letter_queue"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "log" ],
+                    "properties" : {
+                      "log" : {
+                        "$ref" : "#/$defs/error_handler/log"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "stop" ],
+                    "properties" : {
+                      "stop" : {
+                        "$ref" : "#/$defs/error_handler/stop"
+                      }
+                    }
+                  } ]
+                }
+              },
+              "$defs" : {
+                "processors" : {
+                  "throttle" : {
+                    "title" : "Throttle Action",
+                    "description" : "The Throttle action allows to ensure that a specific sink does not get overloaded.",
+                    "required" : [ "messages" ],
+                    "properties" : {
+                      "messages" : {
+                        "title" : "Messages Number",
+                        "description" : "The number of messages to send in the time period set",
+                        "type" : "integer",
+                        "example" : 10
+                      },
+                      "timePeriod" : {
+                        "title" : "Time Period",
+                        "description" : "Sets the time period during which the maximum request count is valid for, in milliseconds",
+                        "type" : "string",
+                        "default" : "1000"
+                      }
+                    },
+                    "type" : "object"
+                  },
+                  "log" : {
+                    "title" : "Log",
+                    "description" : "Log payload.",
+                    "type" : "object",
+                    "properties" : {
+                      "multiLine" : {
+                        "title" : "Multi Line",
+                        "description" : "Multi Line",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showProperties" : {
+                        "title" : "Show Properties",
+                        "description" : "Show Properties",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showHeaders" : {
+                        "title" : "Show Headers",
+                        "description" : "Show Headers",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      }
+                    }
+                  },
+                  "jsonpath_extract" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_remove" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_rename" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "newKey" : {
+                        "title" : "NewKey",
+                        "description" : "NewKey",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_set" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "title" : "Value",
+                        "description" : "Value",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  }
+                },
+                "data_shape" : {
+                  "produces" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "format" ],
+                    "properties" : {
+                      "format" : {
+                        "type" : "string",
+                        "default" : "application/json",
+                        "enum" : [ "application/json", "avro/binary" ]
+                      }
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "dead_letter_queue" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "topic" ],
+                    "properties" : {
+                      "topic" : {
+                        "type" : "string",
+                        "title" : "Dead Letter Topic Name",
+                        "description" : "The name of the Kafka topic used as dead letter queue"
+                      }
+                    }
+                  },
+                  "log" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  },
+                  "stop" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  }
+                }
+              }
+            }
+          }
+        }
+      salesforce_source_0.1.json: |-
+        {
+          "channels" : {
+            "stable" : {
+              "shard_metadata" : {
+                "connector_revision" : "7",
+                "connector_type" : "source",
+                "connector_image" : "quay.io/rhoas/cos-connector-salesforce:0.1.7",
+                "operators" : [ {
+                  "type" : "camel-connector-operator",
+                  "version" : "[1.0.0,2.0.0)"
+                } ],
+                "kamelets" : {
+                  "adapter" : {
+                    "name" : "cos-salesforce-streaming-source",
+                    "prefix" : "salesforce"
+                  },
+                  "kafka" : {
+                    "name" : "cos-kafka-sink",
+                    "prefix" : "kafka"
+                  },
+                  "processors" : {
+                    "throttle" : "throttle-action",
+                    "jsonpath_set" : "cos-jsonpath-set-action",
+                    "log" : "cos-log-action",
+                    "jsonpath_rename" : "cos-jsonpath-rename-action",
+                    "jsonpath_extract" : "cos-jsonpath-extract-action",
+                    "jsonpath_remove" : "cos-jsonpath-remove-action"
+                  }
+                },
+                "consumes" : "application/json",
+                "produces" : "application/json"
+              }
+            }
+          },
+          "connector_type" : {
+            "id" : "salesforce_source_0.1",
+            "kind" : "ConnectorType",
+            "icon_href" : "TODO",
+            "name" : "Salesforce Streaming Source",
+            "description" : "Salesforce Source",
+            "version" : "0.1",
+            "labels" : [ "source" ],
+            "capabilities" : [ "data_shape", "error_handler", "processors" ],
+            "channels" : [ "stable" ],
+            "schema" : {
+              "type" : "object",
+              "required" : [ "salesforce_object_name", "salesforce_client_id", "salesforce_client_secret", "salesforce_user_name", "salesforce_password", "kafka_topic" ],
+              "properties" : {
+                "salesforce_object_name" : {
+                  "title" : "objectName",
+                  "description" : "The sObjectName",
+                  "type" : "string"
+                },
+                "salesforce_login_url" : {
+                  "title" : "Login URL",
+                  "description" : "The Salesforce instance login URL",
+                  "type" : "string",
+                  "default" : "https://login.salesforce.com"
+                },
+                "salesforce_client_id" : {
+                  "title" : "Consumer Key",
+                  "description" : "The Salesforce application consumer key",
+                  "type" : "string",
+                  "x-group" : "credentials"
+                },
+                "salesforce_client_secret" : {
+                  "title" : "Consumer Secret",
+                  "x-group" : "credentials",
+                  "oneOf" : [ {
+                    "title" : "Consumer Secret",
+                    "description" : "The Salesforce application consumer secret",
+                    "type" : "string",
+                    "format" : "password"
+                  }, {
+                    "description" : "An opaque reference to the salesforce_client_secret",
+                    "type" : "object",
+                    "properties" : { }
+                  } ]
+                },
+                "salesforce_user_name" : {
+                  "title" : "Username",
+                  "description" : "The Salesforce username",
+                  "type" : "string",
+                  "x-group" : "credentials"
+                },
+                "salesforce_password" : {
+                  "title" : "Password",
+                  "x-group" : "credentials",
+                  "oneOf" : [ {
+                    "title" : "Password",
+                    "description" : "The Salesforce user password",
+                    "type" : "string",
+                    "format" : "password"
+                  }, {
+                    "description" : "An opaque reference to the salesforce_password",
+                    "type" : "object",
+                    "properties" : { }
+                  } ]
+                },
+                "kafka_topic" : {
+                  "title" : "Topic Names",
+                  "description" : "Comma separated list of Kafka topic names",
+                  "type" : "string"
+                },
+                "processors" : {
+                  "type" : "array",
+                  "items" : {
+                    "oneOf" : [ {
+                      "type" : "object",
+                      "required" : [ "throttle" ],
+                      "properties" : {
+                        "throttle" : {
+                          "$ref" : "#/$defs/processors/throttle"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "log" ],
+                      "properties" : {
+                        "log" : {
+                          "$ref" : "#/$defs/processors/log"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_extract" ],
+                      "properties" : {
+                        "jsonpath_extract" : {
+                          "$ref" : "#/$defs/processors/jsonpath_extract"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_remove" ],
+                      "properties" : {
+                        "jsonpath_remove" : {
+                          "$ref" : "#/$defs/processors/jsonpath_remove"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_rename" ],
+                      "properties" : {
+                        "jsonpath_rename" : {
+                          "$ref" : "#/$defs/processors/jsonpath_rename"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_set" ],
+                      "properties" : {
+                        "jsonpath_set" : {
+                          "$ref" : "#/$defs/processors/jsonpath_set"
+                        }
+                      }
+                    } ]
+                  }
+                },
+                "data_shape" : {
+                  "type" : "object",
+                  "additionalProperties" : false,
+                  "properties" : {
+                    "produces" : {
+                      "$ref" : "#/$defs/data_shape/produces"
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "type" : "object",
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "dead_letter_queue" ],
+                    "properties" : {
+                      "dead_letter_queue" : {
+                        "$ref" : "#/$defs/error_handler/dead_letter_queue"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "log" ],
+                    "properties" : {
+                      "log" : {
+                        "$ref" : "#/$defs/error_handler/log"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "stop" ],
+                    "properties" : {
+                      "stop" : {
+                        "$ref" : "#/$defs/error_handler/stop"
+                      }
+                    }
+                  } ]
+                }
+              },
+              "$defs" : {
+                "processors" : {
+                  "throttle" : {
+                    "title" : "Throttle Action",
+                    "description" : "The Throttle action allows to ensure that a specific sink does not get overloaded.",
+                    "required" : [ "messages" ],
+                    "properties" : {
+                      "messages" : {
+                        "title" : "Messages Number",
+                        "description" : "The number of messages to send in the time period set",
+                        "type" : "integer",
+                        "example" : 10
+                      },
+                      "timePeriod" : {
+                        "title" : "Time Period",
+                        "description" : "Sets the time period during which the maximum request count is valid for, in milliseconds",
+                        "type" : "string",
+                        "default" : "1000"
+                      }
+                    },
+                    "type" : "object"
+                  },
+                  "log" : {
+                    "title" : "Log",
+                    "description" : "Log payload.",
+                    "type" : "object",
+                    "properties" : {
+                      "multiLine" : {
+                        "title" : "Multi Line",
+                        "description" : "Multi Line",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showProperties" : {
+                        "title" : "Show Properties",
+                        "description" : "Show Properties",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showHeaders" : {
+                        "title" : "Show Headers",
+                        "description" : "Show Headers",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      }
+                    }
+                  },
+                  "jsonpath_extract" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_remove" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_rename" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "newKey" : {
+                        "title" : "NewKey",
+                        "description" : "NewKey",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_set" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "title" : "Value",
+                        "description" : "Value",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  }
+                },
+                "data_shape" : {
+                  "produces" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "format" ],
+                    "properties" : {
+                      "format" : {
+                        "type" : "string",
+                        "default" : "application/json",
+                        "enum" : [ "application/json" ]
+                      }
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "dead_letter_queue" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "topic" ],
+                    "properties" : {
+                      "topic" : {
+                        "type" : "string",
+                        "title" : "Dead Letter Topic Name",
+                        "description" : "The name of the Kafka topic used as dead letter queue"
+                      }
+                    }
+                  },
+                  "log" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  },
+                  "stop" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  }
+                }
+              }
+            }
+          }
+        }
+      salesforce_streaming_source_0.1.json: |-
+        {
+          "channels" : {
+            "stable" : {
+              "shard_metadata" : {
+                "connector_revision" : "8",
+                "connector_type" : "source",
+                "connector_image" : "quay.io/rhoas/cos-connector-salesforce:0.1.8",
+                "operators" : [ {
+                  "type" : "camel-connector-operator",
+                  "version" : "[1.0.0,2.0.0)"
+                } ],
+                "kamelets" : {
+                  "adapter" : {
+                    "name" : "cos-salesforce-streaming-source",
+                    "prefix" : "salesforce"
+                  },
+                  "kafka" : {
+                    "name" : "cos-kafka-sink",
+                    "prefix" : "kafka"
+                  },
+                  "processors" : {
+                    "throttle" : "throttle-action",
+                    "jsonpath_set" : "cos-jsonpath-set-action",
+                    "log" : "cos-log-action",
+                    "jsonpath_rename" : "cos-jsonpath-rename-action",
+                    "jsonpath_extract" : "cos-jsonpath-extract-action",
+                    "jsonpath_remove" : "cos-jsonpath-remove-action"
+                  }
+                },
+                "consumes" : "application/json",
+                "produces" : "application/json"
+              }
+            }
+          },
+          "connector_type" : {
+            "id" : "salesforce_streaming_source_0.1",
+            "kind" : "ConnectorType",
+            "icon_href" : "TODO",
+            "name" : "Salesforce Streaming Source",
+            "description" : "Salesforce Source",
+            "version" : "0.1",
+            "labels" : [ "source" ],
+            "capabilities" : [ "data_shape", "error_handler", "processors" ],
+            "channels" : [ "stable" ],
+            "schema" : {
+              "type" : "object",
+              "required" : [ "salesforce_object_name", "salesforce_client_id", "salesforce_client_secret", "salesforce_user_name", "salesforce_password", "kafka_topic" ],
+              "properties" : {
+                "salesforce_object_name" : {
+                  "title" : "objectName",
+                  "description" : "The sObjectName",
+                  "type" : "string"
+                },
+                "salesforce_login_url" : {
+                  "title" : "Login URL",
+                  "description" : "The Salesforce instance login URL",
+                  "type" : "string",
+                  "default" : "https://login.salesforce.com"
+                },
+                "salesforce_client_id" : {
+                  "title" : "Consumer Key",
+                  "description" : "The Salesforce application consumer key",
+                  "type" : "string",
+                  "x-group" : "credentials"
+                },
+                "salesforce_client_secret" : {
+                  "title" : "Consumer Secret",
+                  "x-group" : "credentials",
+                  "oneOf" : [ {
+                    "title" : "Consumer Secret",
+                    "description" : "The Salesforce application consumer secret",
+                    "type" : "string",
+                    "format" : "password"
+                  }, {
+                    "description" : "An opaque reference to the salesforce_client_secret",
+                    "type" : "object",
+                    "properties" : { }
+                  } ]
+                },
+                "salesforce_user_name" : {
+                  "title" : "Username",
+                  "description" : "The Salesforce username",
+                  "type" : "string",
+                  "x-group" : "credentials"
+                },
+                "salesforce_password" : {
+                  "title" : "Password",
+                  "x-group" : "credentials",
+                  "oneOf" : [ {
+                    "title" : "Password",
+                    "description" : "The Salesforce user password",
+                    "type" : "string",
+                    "format" : "password"
+                  }, {
+                    "description" : "An opaque reference to the salesforce_password",
+                    "type" : "object",
+                    "properties" : { }
+                  } ]
+                },
+                "kafka_topic" : {
+                  "title" : "Topic Names",
+                  "description" : "Comma separated list of Kafka topic names",
+                  "type" : "string"
+                },
+                "processors" : {
+                  "type" : "array",
+                  "items" : {
+                    "oneOf" : [ {
+                      "type" : "object",
+                      "required" : [ "throttle" ],
+                      "properties" : {
+                        "throttle" : {
+                          "$ref" : "#/$defs/processors/throttle"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "log" ],
+                      "properties" : {
+                        "log" : {
+                          "$ref" : "#/$defs/processors/log"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_extract" ],
+                      "properties" : {
+                        "jsonpath_extract" : {
+                          "$ref" : "#/$defs/processors/jsonpath_extract"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_remove" ],
+                      "properties" : {
+                        "jsonpath_remove" : {
+                          "$ref" : "#/$defs/processors/jsonpath_remove"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_rename" ],
+                      "properties" : {
+                        "jsonpath_rename" : {
+                          "$ref" : "#/$defs/processors/jsonpath_rename"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_set" ],
+                      "properties" : {
+                        "jsonpath_set" : {
+                          "$ref" : "#/$defs/processors/jsonpath_set"
+                        }
+                      }
+                    } ]
+                  }
+                },
+                "data_shape" : {
+                  "type" : "object",
+                  "additionalProperties" : false,
+                  "properties" : {
+                    "produces" : {
+                      "$ref" : "#/$defs/data_shape/produces"
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "type" : "object",
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "dead_letter_queue" ],
+                    "properties" : {
+                      "dead_letter_queue" : {
+                        "$ref" : "#/$defs/error_handler/dead_letter_queue"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "log" ],
+                    "properties" : {
+                      "log" : {
+                        "$ref" : "#/$defs/error_handler/log"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "stop" ],
+                    "properties" : {
+                      "stop" : {
+                        "$ref" : "#/$defs/error_handler/stop"
+                      }
+                    }
+                  } ]
+                }
+              },
+              "$defs" : {
+                "processors" : {
+                  "throttle" : {
+                    "title" : "Throttle Action",
+                    "description" : "The Throttle action allows to ensure that a specific sink does not get overloaded.",
+                    "required" : [ "messages" ],
+                    "properties" : {
+                      "messages" : {
+                        "title" : "Messages Number",
+                        "description" : "The number of messages to send in the time period set",
+                        "type" : "integer",
+                        "example" : 10
+                      },
+                      "timePeriod" : {
+                        "title" : "Time Period",
+                        "description" : "Sets the time period during which the maximum request count is valid for, in milliseconds",
+                        "type" : "string",
+                        "default" : "1000"
+                      }
+                    },
+                    "type" : "object"
+                  },
+                  "log" : {
+                    "title" : "Log",
+                    "description" : "Log payload.",
+                    "type" : "object",
+                    "properties" : {
+                      "multiLine" : {
+                        "title" : "Multi Line",
+                        "description" : "Multi Line",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showProperties" : {
+                        "title" : "Show Properties",
+                        "description" : "Show Properties",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showHeaders" : {
+                        "title" : "Show Headers",
+                        "description" : "Show Headers",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      }
+                    }
+                  },
+                  "jsonpath_extract" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_remove" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_rename" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "newKey" : {
+                        "title" : "NewKey",
+                        "description" : "NewKey",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_set" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "title" : "Value",
+                        "description" : "Value",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  }
+                },
+                "data_shape" : {
+                  "produces" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "format" ],
+                    "properties" : {
+                      "format" : {
+                        "type" : "string",
+                        "default" : "application/json",
+                        "enum" : [ "application/json" ]
+                      }
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "dead_letter_queue" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "topic" ],
+                    "properties" : {
+                      "topic" : {
+                        "type" : "string",
+                        "title" : "Dead Letter Topic Name",
+                        "description" : "The name of the Kafka topic used as dead letter queue"
+                      }
+                    }
+                  },
+                  "log" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  },
+                  "stop" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  }
+                }
+              }
+            }
+          }
+        }
+    kind: ConfigMap
+    metadata:
+      creationTimestamp: null
+      name: connector-catalog-camel-saas
+  - apiVersion: v1
+    data:
+      slack_sink_0.1.json: |-
+        {
+          "channels" : {
+            "stable" : {
+              "shard_metadata" : {
+                "connector_revision" : "8",
+                "connector_type" : "sink",
+                "connector_image" : "quay.io/rhoas/cos-connector-slack:0.1.8",
+                "operators" : [ {
+                  "type" : "camel-connector-operator",
+                  "version" : "[1.0.0,2.0.0)"
+                } ],
+                "kamelets" : {
+                  "adapter" : {
+                    "name" : "slack-sink",
+                    "prefix" : "slack"
+                  },
+                  "kafka" : {
+                    "name" : "cos-kafka-source",
+                    "prefix" : "kafka"
+                  },
+                  "processors" : {
+                    "throttle" : "throttle-action",
+                    "jsonpath_set" : "cos-jsonpath-set-action",
+                    "log" : "cos-log-action",
+                    "jsonpath_rename" : "cos-jsonpath-rename-action",
+                    "jsonpath_extract" : "cos-jsonpath-extract-action",
+                    "jsonpath_remove" : "cos-jsonpath-remove-action"
+                  }
+                }
+              }
+            }
+          },
+          "connector_type" : {
+            "id" : "slack_sink_0.1",
+            "kind" : "ConnectorType",
+            "icon_href" : "TODO",
+            "name" : "Slack Sink",
+            "description" : "Slack Sink",
+            "version" : "0.1",
+            "labels" : [ "sink" ],
+            "capabilities" : [ "error_handler", "processors" ],
+            "channels" : [ "stable" ],
+            "schema" : {
+              "type" : "object",
+              "required" : [ "slack_channel", "slack_webhook_url", "kafka_topic" ],
+              "properties" : {
+                "slack_channel" : {
+                  "title" : "Channel",
+                  "description" : "The Slack channel to send messages to.",
+                  "type" : "string",
+                  "example" : "#myroom"
+                },
+                "slack_webhook_url" : {
+                  "title" : "Webhook URL",
+                  "x-group" : "credentials",
+                  "oneOf" : [ {
+                    "title" : "Webhook URL",
+                    "description" : "The webhook URL used by the Slack channel to handle incoming messages.",
+                    "type" : "string",
+                    "format" : "password"
+                  }, {
+                    "description" : "An opaque reference to the slack_webhook_url",
+                    "type" : "object",
+                    "properties" : { }
+                  } ]
+                },
+                "slack_icon_emoji" : {
+                  "title" : "Icon Emoji",
+                  "description" : "Use a Slack emoji as an avatar.",
+                  "type" : "string"
+                },
+                "slack_icon_url" : {
+                  "title" : "Icon URL",
+                  "description" : "The avatar that the component will use when sending message to a channel or user.",
+                  "type" : "string"
+                },
+                "slack_username" : {
+                  "title" : "Username",
+                  "description" : "This is the username that the bot will have when sending messages to a channel or user.",
+                  "type" : "string"
+                },
+                "kafka_topic" : {
+                  "title" : "Topic Names",
+                  "description" : "Comma separated list of Kafka topic names",
+                  "type" : "string"
+                },
+                "processors" : {
+                  "type" : "array",
+                  "items" : {
+                    "oneOf" : [ {
+                      "type" : "object",
+                      "required" : [ "throttle" ],
+                      "properties" : {
+                        "throttle" : {
+                          "$ref" : "#/$defs/processors/throttle"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "log" ],
+                      "properties" : {
+                        "log" : {
+                          "$ref" : "#/$defs/processors/log"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_extract" ],
+                      "properties" : {
+                        "jsonpath_extract" : {
+                          "$ref" : "#/$defs/processors/jsonpath_extract"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_remove" ],
+                      "properties" : {
+                        "jsonpath_remove" : {
+                          "$ref" : "#/$defs/processors/jsonpath_remove"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_rename" ],
+                      "properties" : {
+                        "jsonpath_rename" : {
+                          "$ref" : "#/$defs/processors/jsonpath_rename"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_set" ],
+                      "properties" : {
+                        "jsonpath_set" : {
+                          "$ref" : "#/$defs/processors/jsonpath_set"
+                        }
+                      }
+                    } ]
+                  }
+                },
+                "error_handler" : {
+                  "type" : "object",
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "dead_letter_queue" ],
+                    "properties" : {
+                      "dead_letter_queue" : {
+                        "$ref" : "#/$defs/error_handler/dead_letter_queue"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "log" ],
+                    "properties" : {
+                      "log" : {
+                        "$ref" : "#/$defs/error_handler/log"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "stop" ],
+                    "properties" : {
+                      "stop" : {
+                        "$ref" : "#/$defs/error_handler/stop"
+                      }
+                    }
+                  } ]
+                }
+              },
+              "$defs" : {
+                "processors" : {
+                  "throttle" : {
+                    "title" : "Throttle Action",
+                    "description" : "The Throttle action allows to ensure that a specific sink does not get overloaded.",
+                    "required" : [ "messages" ],
+                    "properties" : {
+                      "messages" : {
+                        "title" : "Messages Number",
+                        "description" : "The number of messages to send in the time period set",
+                        "type" : "integer",
+                        "example" : 10
+                      },
+                      "timePeriod" : {
+                        "title" : "Time Period",
+                        "description" : "Sets the time period during which the maximum request count is valid for, in milliseconds",
+                        "type" : "string",
+                        "default" : "1000"
+                      }
+                    },
+                    "type" : "object"
+                  },
+                  "log" : {
+                    "title" : "Log",
+                    "description" : "Log payload.",
+                    "type" : "object",
+                    "properties" : {
+                      "multiLine" : {
+                        "title" : "Multi Line",
+                        "description" : "Multi Line",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showProperties" : {
+                        "title" : "Show Properties",
+                        "description" : "Show Properties",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showHeaders" : {
+                        "title" : "Show Headers",
+                        "description" : "Show Headers",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      }
+                    }
+                  },
+                  "jsonpath_extract" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_remove" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_rename" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "newKey" : {
+                        "title" : "NewKey",
+                        "description" : "NewKey",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_set" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "title" : "Value",
+                        "description" : "Value",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "dead_letter_queue" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "topic" ],
+                    "properties" : {
+                      "topic" : {
+                        "type" : "string",
+                        "title" : "Dead Letter Topic Name",
+                        "description" : "The name of the Kafka topic used as dead letter queue"
+                      }
+                    }
+                  },
+                  "log" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  },
+                  "stop" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  }
+                }
+              }
+            }
+          }
+        }
+      slack_source_0.1.json: |-
+        {
+          "channels" : {
+            "stable" : {
+              "shard_metadata" : {
+                "connector_revision" : "8",
+                "connector_type" : "source",
+                "connector_image" : "quay.io/rhoas/cos-connector-slack:0.1.8",
+                "operators" : [ {
+                  "type" : "camel-connector-operator",
+                  "version" : "[1.0.0,2.0.0)"
+                } ],
+                "kamelets" : {
+                  "adapter" : {
+                    "name" : "cos-slack-source",
+                    "prefix" : "slack"
+                  },
+                  "kafka" : {
+                    "name" : "cos-kafka-sink",
+                    "prefix" : "kafka"
+                  },
+                  "processors" : {
+                    "throttle" : "throttle-action",
+                    "jsonpath_set" : "cos-jsonpath-set-action",
+                    "log" : "cos-log-action",
+                    "jsonpath_rename" : "cos-jsonpath-rename-action",
+                    "jsonpath_extract" : "cos-jsonpath-extract-action",
+                    "jsonpath_remove" : "cos-jsonpath-remove-action"
+                  }
+                },
+                "consumes" : "application/json",
+                "consumes_class" : "com.slack.api.model.Message",
+                "produces" : "application/json"
+              }
+            }
+          },
+          "connector_type" : {
+            "id" : "slack_source_0.1",
+            "kind" : "ConnectorType",
+            "icon_href" : "TODO",
+            "name" : "Slack Source",
+            "description" : "Slack Source",
+            "version" : "0.1",
+            "labels" : [ "source" ],
+            "capabilities" : [ "data_shape", "error_handler", "processors" ],
+            "channels" : [ "stable" ],
+            "schema" : {
+              "type" : "object",
+              "required" : [ "slack_channel", "slack_token", "kafka_topic" ],
+              "properties" : {
+                "slack_channel" : {
+                  "title" : "Channel",
+                  "description" : "The Slack channel to receive messages from",
+                  "type" : "string",
+                  "example" : "#myroom"
+                },
+                "slack_token" : {
+                  "title" : "Token",
+                  "x-group" : "credentials",
+                  "oneOf" : [ {
+                    "title" : "Token",
+                    "description" : "The token to access Slack. A Slack app is needed. This app needs to have channels:history and channels:read permissions. The Bot User OAuth Access Token is the kind of token needed.",
+                    "type" : "string",
+                    "format" : "password"
+                  }, {
+                    "description" : "An opaque reference to the slack_token",
+                    "type" : "object",
+                    "properties" : { }
+                  } ]
+                },
+                "slack_delay" : {
+                  "title" : "Delay",
+                  "description" : "The delay between polls",
+                  "type" : "string",
+                  "example" : "1s"
+                },
+                "kafka_topic" : {
+                  "title" : "Topic Names",
+                  "description" : "Comma separated list of Kafka topic names",
+                  "type" : "string"
+                },
+                "processors" : {
+                  "type" : "array",
+                  "items" : {
+                    "oneOf" : [ {
+                      "type" : "object",
+                      "required" : [ "throttle" ],
+                      "properties" : {
+                        "throttle" : {
+                          "$ref" : "#/$defs/processors/throttle"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "log" ],
+                      "properties" : {
+                        "log" : {
+                          "$ref" : "#/$defs/processors/log"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_extract" ],
+                      "properties" : {
+                        "jsonpath_extract" : {
+                          "$ref" : "#/$defs/processors/jsonpath_extract"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_remove" ],
+                      "properties" : {
+                        "jsonpath_remove" : {
+                          "$ref" : "#/$defs/processors/jsonpath_remove"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_rename" ],
+                      "properties" : {
+                        "jsonpath_rename" : {
+                          "$ref" : "#/$defs/processors/jsonpath_rename"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_set" ],
+                      "properties" : {
+                        "jsonpath_set" : {
+                          "$ref" : "#/$defs/processors/jsonpath_set"
+                        }
+                      }
+                    } ]
+                  }
+                },
+                "data_shape" : {
+                  "type" : "object",
+                  "additionalProperties" : false,
+                  "properties" : {
+                    "produces" : {
+                      "$ref" : "#/$defs/data_shape/produces"
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "type" : "object",
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "dead_letter_queue" ],
+                    "properties" : {
+                      "dead_letter_queue" : {
+                        "$ref" : "#/$defs/error_handler/dead_letter_queue"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "log" ],
+                    "properties" : {
+                      "log" : {
+                        "$ref" : "#/$defs/error_handler/log"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "stop" ],
+                    "properties" : {
+                      "stop" : {
+                        "$ref" : "#/$defs/error_handler/stop"
+                      }
+                    }
+                  } ]
+                }
+              },
+              "$defs" : {
+                "processors" : {
+                  "throttle" : {
+                    "title" : "Throttle Action",
+                    "description" : "The Throttle action allows to ensure that a specific sink does not get overloaded.",
+                    "required" : [ "messages" ],
+                    "properties" : {
+                      "messages" : {
+                        "title" : "Messages Number",
+                        "description" : "The number of messages to send in the time period set",
+                        "type" : "integer",
+                        "example" : 10
+                      },
+                      "timePeriod" : {
+                        "title" : "Time Period",
+                        "description" : "Sets the time period during which the maximum request count is valid for, in milliseconds",
+                        "type" : "string",
+                        "default" : "1000"
+                      }
+                    },
+                    "type" : "object"
+                  },
+                  "log" : {
+                    "title" : "Log",
+                    "description" : "Log payload.",
+                    "type" : "object",
+                    "properties" : {
+                      "multiLine" : {
+                        "title" : "Multi Line",
+                        "description" : "Multi Line",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showProperties" : {
+                        "title" : "Show Properties",
+                        "description" : "Show Properties",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showHeaders" : {
+                        "title" : "Show Headers",
+                        "description" : "Show Headers",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      }
+                    }
+                  },
+                  "jsonpath_extract" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_remove" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_rename" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "newKey" : {
+                        "title" : "NewKey",
+                        "description" : "NewKey",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_set" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "title" : "Value",
+                        "description" : "Value",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  }
+                },
+                "data_shape" : {
+                  "produces" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "format" ],
+                    "properties" : {
+                      "format" : {
+                        "type" : "string",
+                        "default" : "application/json",
+                        "enum" : [ "application/json" ]
+                      }
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "dead_letter_queue" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "topic" ],
+                    "properties" : {
+                      "topic" : {
+                        "type" : "string",
+                        "title" : "Dead Letter Topic Name",
+                        "description" : "The name of the Kafka topic used as dead letter queue"
+                      }
+                    }
+                  },
+                  "log" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  },
+                  "stop" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  }
+                }
+              }
+            }
+          }
+        }
+      telegram_sink_0.1.json: |-
+        {
+          "channels" : {
+            "stable" : {
+              "shard_metadata" : {
+                "connector_revision" : "8",
+                "connector_type" : "sink",
+                "connector_image" : "quay.io/rhoas/cos-connector-telegram:0.1.8",
+                "operators" : [ {
+                  "type" : "camel-connector-operator",
+                  "version" : "[1.0.0,2.0.0)"
+                } ],
+                "kamelets" : {
+                  "adapter" : {
+                    "name" : "telegram-sink",
+                    "prefix" : "telegram"
+                  },
+                  "kafka" : {
+                    "name" : "cos-kafka-source",
+                    "prefix" : "kafka"
+                  },
+                  "processors" : {
+                    "throttle" : "throttle-action",
+                    "jsonpath_set" : "cos-jsonpath-set-action",
+                    "log" : "cos-log-action",
+                    "jsonpath_rename" : "cos-jsonpath-rename-action",
+                    "jsonpath_extract" : "cos-jsonpath-extract-action",
+                    "jsonpath_remove" : "cos-jsonpath-remove-action"
+                  }
+                }
+              }
+            }
+          },
+          "connector_type" : {
+            "id" : "telegram_sink_0.1",
+            "kind" : "ConnectorType",
+            "icon_href" : "TODO",
+            "name" : "Telegram Sink",
+            "description" : "Telegram Sink",
+            "version" : "0.1",
+            "labels" : [ "sink" ],
+            "capabilities" : [ "error_handler", "processors" ],
+            "channels" : [ "stable" ],
+            "schema" : {
+              "type" : "object",
+              "required" : [ "telegram_authorization_token", "kafka_topic" ],
+              "properties" : {
+                "telegram_authorization_token" : {
+                  "title" : "Token",
+                  "x-group" : "credentials",
+                  "oneOf" : [ {
+                    "title" : "Token",
+                    "description" : "The token to access your bot on Telegram. You you can obtain it from the Telegram @botfather.",
+                    "type" : "string",
+                    "format" : "password"
+                  }, {
+                    "description" : "An opaque reference to the telegram_authorization_token",
+                    "type" : "object",
+                    "properties" : { }
+                  } ]
+                },
+                "telegram_chat_id" : {
+                  "title" : "Chat ID",
+                  "description" : "The Chat ID where messages should be sent by default",
+                  "type" : "string"
+                },
+                "kafka_topic" : {
+                  "title" : "Topic Names",
+                  "description" : "Comma separated list of Kafka topic names",
+                  "type" : "string"
+                },
+                "processors" : {
+                  "type" : "array",
+                  "items" : {
+                    "oneOf" : [ {
+                      "type" : "object",
+                      "required" : [ "throttle" ],
+                      "properties" : {
+                        "throttle" : {
+                          "$ref" : "#/$defs/processors/throttle"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "log" ],
+                      "properties" : {
+                        "log" : {
+                          "$ref" : "#/$defs/processors/log"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_extract" ],
+                      "properties" : {
+                        "jsonpath_extract" : {
+                          "$ref" : "#/$defs/processors/jsonpath_extract"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_remove" ],
+                      "properties" : {
+                        "jsonpath_remove" : {
+                          "$ref" : "#/$defs/processors/jsonpath_remove"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_rename" ],
+                      "properties" : {
+                        "jsonpath_rename" : {
+                          "$ref" : "#/$defs/processors/jsonpath_rename"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_set" ],
+                      "properties" : {
+                        "jsonpath_set" : {
+                          "$ref" : "#/$defs/processors/jsonpath_set"
+                        }
+                      }
+                    } ]
+                  }
+                },
+                "error_handler" : {
+                  "type" : "object",
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "dead_letter_queue" ],
+                    "properties" : {
+                      "dead_letter_queue" : {
+                        "$ref" : "#/$defs/error_handler/dead_letter_queue"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "log" ],
+                    "properties" : {
+                      "log" : {
+                        "$ref" : "#/$defs/error_handler/log"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "stop" ],
+                    "properties" : {
+                      "stop" : {
+                        "$ref" : "#/$defs/error_handler/stop"
+                      }
+                    }
+                  } ]
+                }
+              },
+              "$defs" : {
+                "processors" : {
+                  "throttle" : {
+                    "title" : "Throttle Action",
+                    "description" : "The Throttle action allows to ensure that a specific sink does not get overloaded.",
+                    "required" : [ "messages" ],
+                    "properties" : {
+                      "messages" : {
+                        "title" : "Messages Number",
+                        "description" : "The number of messages to send in the time period set",
+                        "type" : "integer",
+                        "example" : 10
+                      },
+                      "timePeriod" : {
+                        "title" : "Time Period",
+                        "description" : "Sets the time period during which the maximum request count is valid for, in milliseconds",
+                        "type" : "string",
+                        "default" : "1000"
+                      }
+                    },
+                    "type" : "object"
+                  },
+                  "log" : {
+                    "title" : "Log",
+                    "description" : "Log payload.",
+                    "type" : "object",
+                    "properties" : {
+                      "multiLine" : {
+                        "title" : "Multi Line",
+                        "description" : "Multi Line",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showProperties" : {
+                        "title" : "Show Properties",
+                        "description" : "Show Properties",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showHeaders" : {
+                        "title" : "Show Headers",
+                        "description" : "Show Headers",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      }
+                    }
+                  },
+                  "jsonpath_extract" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_remove" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_rename" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "newKey" : {
+                        "title" : "NewKey",
+                        "description" : "NewKey",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_set" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "title" : "Value",
+                        "description" : "Value",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "dead_letter_queue" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "topic" ],
+                    "properties" : {
+                      "topic" : {
+                        "type" : "string",
+                        "title" : "Dead Letter Topic Name",
+                        "description" : "The name of the Kafka topic used as dead letter queue"
+                      }
+                    }
+                  },
+                  "log" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  },
+                  "stop" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  }
+                }
+              }
+            }
+          }
+        }
+      telegram_source_0.1.json: |-
+        {
+          "channels" : {
+            "stable" : {
+              "shard_metadata" : {
+                "connector_revision" : "8",
+                "connector_type" : "source",
+                "connector_image" : "quay.io/rhoas/cos-connector-telegram:0.1.8",
+                "operators" : [ {
+                  "type" : "camel-connector-operator",
+                  "version" : "[1.0.0,2.0.0)"
+                } ],
+                "kamelets" : {
+                  "adapter" : {
+                    "name" : "telegram-source",
+                    "prefix" : "telegram"
+                  },
+                  "kafka" : {
+                    "name" : "cos-kafka-sink",
+                    "prefix" : "kafka"
+                  },
+                  "processors" : {
+                    "throttle" : "throttle-action",
+                    "jsonpath_set" : "cos-jsonpath-set-action",
+                    "log" : "cos-log-action",
+                    "jsonpath_rename" : "cos-jsonpath-rename-action",
+                    "jsonpath_extract" : "cos-jsonpath-extract-action",
+                    "jsonpath_remove" : "cos-jsonpath-remove-action"
+                  }
+                },
+                "consumes" : "application/json",
+                "produces" : "application/json"
+              }
+            }
+          },
+          "connector_type" : {
+            "id" : "telegram_source_0.1",
+            "kind" : "ConnectorType",
+            "icon_href" : "TODO",
+            "name" : "Telegram Source",
+            "description" : "Telegram Source",
+            "version" : "0.1",
+            "labels" : [ "source" ],
+            "capabilities" : [ "data_shape", "error_handler", "processors" ],
+            "channels" : [ "stable" ],
+            "schema" : {
+              "type" : "object",
+              "required" : [ "telegram_authorization_token", "kafka_topic" ],
+              "properties" : {
+                "telegram_authorization_token" : {
+                  "title" : "Token",
+                  "x-group" : "credentials",
+                  "oneOf" : [ {
+                    "title" : "Token",
+                    "description" : "The token to access your bot on Telegram. You you can obtain it from the Telegram @botfather.",
+                    "type" : "string",
+                    "format" : "password"
+                  }, {
+                    "description" : "An opaque reference to the telegram_authorization_token",
+                    "type" : "object",
+                    "properties" : { }
+                  } ]
+                },
+                "kafka_topic" : {
+                  "title" : "Topic Names",
+                  "description" : "Comma separated list of Kafka topic names",
+                  "type" : "string"
+                },
+                "processors" : {
+                  "type" : "array",
+                  "items" : {
+                    "oneOf" : [ {
+                      "type" : "object",
+                      "required" : [ "throttle" ],
+                      "properties" : {
+                        "throttle" : {
+                          "$ref" : "#/$defs/processors/throttle"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "log" ],
+                      "properties" : {
+                        "log" : {
+                          "$ref" : "#/$defs/processors/log"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_extract" ],
+                      "properties" : {
+                        "jsonpath_extract" : {
+                          "$ref" : "#/$defs/processors/jsonpath_extract"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_remove" ],
+                      "properties" : {
+                        "jsonpath_remove" : {
+                          "$ref" : "#/$defs/processors/jsonpath_remove"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_rename" ],
+                      "properties" : {
+                        "jsonpath_rename" : {
+                          "$ref" : "#/$defs/processors/jsonpath_rename"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_set" ],
+                      "properties" : {
+                        "jsonpath_set" : {
+                          "$ref" : "#/$defs/processors/jsonpath_set"
+                        }
+                      }
+                    } ]
+                  }
+                },
+                "data_shape" : {
+                  "type" : "object",
+                  "additionalProperties" : false,
+                  "properties" : {
+                    "produces" : {
+                      "$ref" : "#/$defs/data_shape/produces"
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "type" : "object",
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "dead_letter_queue" ],
+                    "properties" : {
+                      "dead_letter_queue" : {
+                        "$ref" : "#/$defs/error_handler/dead_letter_queue"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "log" ],
+                    "properties" : {
+                      "log" : {
+                        "$ref" : "#/$defs/error_handler/log"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "stop" ],
+                    "properties" : {
+                      "stop" : {
+                        "$ref" : "#/$defs/error_handler/stop"
+                      }
+                    }
+                  } ]
+                }
+              },
+              "$defs" : {
+                "processors" : {
+                  "throttle" : {
+                    "title" : "Throttle Action",
+                    "description" : "The Throttle action allows to ensure that a specific sink does not get overloaded.",
+                    "required" : [ "messages" ],
+                    "properties" : {
+                      "messages" : {
+                        "title" : "Messages Number",
+                        "description" : "The number of messages to send in the time period set",
+                        "type" : "integer",
+                        "example" : 10
+                      },
+                      "timePeriod" : {
+                        "title" : "Time Period",
+                        "description" : "Sets the time period during which the maximum request count is valid for, in milliseconds",
+                        "type" : "string",
+                        "default" : "1000"
+                      }
+                    },
+                    "type" : "object"
+                  },
+                  "log" : {
+                    "title" : "Log",
+                    "description" : "Log payload.",
+                    "type" : "object",
+                    "properties" : {
+                      "multiLine" : {
+                        "title" : "Multi Line",
+                        "description" : "Multi Line",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showProperties" : {
+                        "title" : "Show Properties",
+                        "description" : "Show Properties",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showHeaders" : {
+                        "title" : "Show Headers",
+                        "description" : "Show Headers",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      }
+                    }
+                  },
+                  "jsonpath_extract" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_remove" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_rename" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "newKey" : {
+                        "title" : "NewKey",
+                        "description" : "NewKey",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_set" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "title" : "Value",
+                        "description" : "Value",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  }
+                },
+                "data_shape" : {
+                  "produces" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "format" ],
+                    "properties" : {
+                      "format" : {
+                        "type" : "string",
+                        "default" : "application/json",
+                        "enum" : [ "application/json", "avro/binary" ]
+                      }
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "dead_letter_queue" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "topic" ],
+                    "properties" : {
+                      "topic" : {
+                        "type" : "string",
+                        "title" : "Dead Letter Topic Name",
+                        "description" : "The name of the Kafka topic used as dead letter queue"
+                      }
+                    }
+                  },
+                  "log" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  },
+                  "stop" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  }
+                }
+              }
+            }
+          }
+        }
+    kind: ConfigMap
+    metadata:
+      creationTimestamp: null
+      name: connector-catalog-camel-social
+  - apiVersion: v1
+    data:
+      aws_redshift_sink_0.1.json: |-
+        {
+          "channels" : {
+            "stable" : {
+              "shard_metadata" : {
+                "connector_revision" : "8",
+                "connector_type" : "sink",
+                "connector_image" : "quay.io/rhoas/cos-connector-aws-redshift:0.1.8",
+                "operators" : [ {
+                  "type" : "camel-connector-operator",
+                  "version" : "[1.0.0,2.0.0)"
+                } ],
+                "kamelets" : {
+                  "adapter" : {
+                    "name" : "aws-redshift-sink",
+                    "prefix" : "sql"
+                  },
+                  "kafka" : {
+                    "name" : "cos-kafka-source",
+                    "prefix" : "kafka"
+                  },
+                  "processors" : {
+                    "throttle" : "throttle-action",
+                    "jsonpath_set" : "cos-jsonpath-set-action",
+                    "log" : "cos-log-action",
+                    "jsonpath_rename" : "cos-jsonpath-rename-action",
+                    "jsonpath_extract" : "cos-jsonpath-extract-action",
+                    "jsonpath_remove" : "cos-jsonpath-remove-action"
+                  }
+                },
+                "consumes" : "application/json",
+                "produces" : "application/json"
+              }
+            }
+          },
+          "connector_type" : {
+            "id" : "aws_redshift_sink_0.1",
+            "kind" : "ConnectorType",
+            "icon_href" : "TODO",
+            "name" : "AWS Redshift Sink",
+            "description" : "AWS Redshift Sink",
+            "version" : "0.1",
+            "labels" : [ "sink" ],
+            "capabilities" : [ "data_shape", "error_handler", "processors" ],
+            "channels" : [ "stable" ],
+            "schema" : {
+              "type" : "object",
+              "required" : [ "sql_server_name", "sql_username", "sql_password", "sql_query", "sql_database_name", "kafka_topic" ],
+              "properties" : {
+                "sql_server_name" : {
+                  "title" : "Server Name",
+                  "description" : "Server Name for the data source",
+                  "type" : "string",
+                  "example" : "localhost"
+                },
+                "sql_server_port" : {
+                  "title" : "Server Port",
+                  "description" : "Server Port for the data source",
+                  "type" : "string",
+                  "default" : 5439
+                },
+                "sql_username" : {
+                  "title" : "Username",
+                  "description" : "The username to use for accessing a secured AWS Redshift Database",
+                  "type" : "string",
+                  "x-group" : "credentials"
+                },
+                "sql_password" : {
+                  "title" : "Password",
+                  "x-group" : "credentials",
+                  "oneOf" : [ {
+                    "title" : "Password",
+                    "description" : "The password to use for accessing a secured AWS Redshift Database",
+                    "type" : "string",
+                    "format" : "password"
+                  }, {
+                    "description" : "An opaque reference to the sql_password",
+                    "type" : "object",
+                    "properties" : { }
+                  } ]
+                },
+                "sql_query" : {
+                  "title" : "Query",
+                  "description" : "The Query to execute against the AWS Redshift Database",
+                  "type" : "string",
+                  "example" : "INSERT INTO accounts (username,city) VALUES (:#username,:#city)"
+                },
+                "sql_database_name" : {
+                  "title" : "Database Name",
+                  "description" : "The Database Name we are pointing",
+                  "type" : "string"
+                },
+                "kafka_topic" : {
+                  "title" : "Topic Names",
+                  "description" : "Comma separated list of Kafka topic names",
+                  "type" : "string"
+                },
+                "processors" : {
+                  "type" : "array",
+                  "items" : {
+                    "oneOf" : [ {
+                      "type" : "object",
+                      "required" : [ "throttle" ],
+                      "properties" : {
+                        "throttle" : {
+                          "$ref" : "#/$defs/processors/throttle"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "log" ],
+                      "properties" : {
+                        "log" : {
+                          "$ref" : "#/$defs/processors/log"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_extract" ],
+                      "properties" : {
+                        "jsonpath_extract" : {
+                          "$ref" : "#/$defs/processors/jsonpath_extract"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_remove" ],
+                      "properties" : {
+                        "jsonpath_remove" : {
+                          "$ref" : "#/$defs/processors/jsonpath_remove"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_rename" ],
+                      "properties" : {
+                        "jsonpath_rename" : {
+                          "$ref" : "#/$defs/processors/jsonpath_rename"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_set" ],
+                      "properties" : {
+                        "jsonpath_set" : {
+                          "$ref" : "#/$defs/processors/jsonpath_set"
+                        }
+                      }
+                    } ]
+                  }
+                },
+                "data_shape" : {
+                  "type" : "object",
+                  "additionalProperties" : false,
+                  "properties" : {
+                    "consumes" : {
+                      "$ref" : "#/$defs/data_shape/consumes"
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "type" : "object",
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "dead_letter_queue" ],
+                    "properties" : {
+                      "dead_letter_queue" : {
+                        "$ref" : "#/$defs/error_handler/dead_letter_queue"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "log" ],
+                    "properties" : {
+                      "log" : {
+                        "$ref" : "#/$defs/error_handler/log"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "stop" ],
+                    "properties" : {
+                      "stop" : {
+                        "$ref" : "#/$defs/error_handler/stop"
+                      }
+                    }
+                  } ]
+                }
+              },
+              "$defs" : {
+                "processors" : {
+                  "throttle" : {
+                    "title" : "Throttle Action",
+                    "description" : "The Throttle action allows to ensure that a specific sink does not get overloaded.",
+                    "required" : [ "messages" ],
+                    "properties" : {
+                      "messages" : {
+                        "title" : "Messages Number",
+                        "description" : "The number of messages to send in the time period set",
+                        "type" : "integer",
+                        "example" : 10
+                      },
+                      "timePeriod" : {
+                        "title" : "Time Period",
+                        "description" : "Sets the time period during which the maximum request count is valid for, in milliseconds",
+                        "type" : "string",
+                        "default" : "1000"
+                      }
+                    },
+                    "type" : "object"
+                  },
+                  "log" : {
+                    "title" : "Log",
+                    "description" : "Log payload.",
+                    "type" : "object",
+                    "properties" : {
+                      "multiLine" : {
+                        "title" : "Multi Line",
+                        "description" : "Multi Line",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showProperties" : {
+                        "title" : "Show Properties",
+                        "description" : "Show Properties",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showHeaders" : {
+                        "title" : "Show Headers",
+                        "description" : "Show Headers",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      }
+                    }
+                  },
+                  "jsonpath_extract" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_remove" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_rename" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "newKey" : {
+                        "title" : "NewKey",
+                        "description" : "NewKey",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_set" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "title" : "Value",
+                        "description" : "Value",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  }
+                },
+                "data_shape" : {
+                  "consumes" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "format" ],
+                    "properties" : {
+                      "format" : {
+                        "type" : "string",
+                        "default" : "application/json",
+                        "enum" : [ "application/json", "avro/binary" ]
+                      }
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "dead_letter_queue" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "topic" ],
+                    "properties" : {
+                      "topic" : {
+                        "type" : "string",
+                        "title" : "Dead Letter Topic Name",
+                        "description" : "The name of the Kafka topic used as dead letter queue"
+                      }
+                    }
+                  },
+                  "log" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  },
+                  "stop" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  }
+                }
+              }
+            }
+          }
+        }
+      aws_redshift_source_0.1.json: |-
+        {
+          "channels" : {
+            "stable" : {
+              "shard_metadata" : {
+                "connector_revision" : "8",
+                "connector_type" : "source",
+                "connector_image" : "quay.io/rhoas/cos-connector-aws-redshift:0.1.8",
+                "operators" : [ {
+                  "type" : "camel-connector-operator",
+                  "version" : "[1.0.0,2.0.0)"
+                } ],
+                "kamelets" : {
+                  "adapter" : {
+                    "name" : "aws-redshift-source",
+                    "prefix" : "sql"
+                  },
+                  "kafka" : {
+                    "name" : "cos-kafka-sink",
+                    "prefix" : "kafka"
+                  },
+                  "processors" : {
+                    "throttle" : "throttle-action",
+                    "jsonpath_set" : "cos-jsonpath-set-action",
+                    "log" : "cos-log-action",
+                    "jsonpath_rename" : "cos-jsonpath-rename-action",
+                    "jsonpath_extract" : "cos-jsonpath-extract-action",
+                    "jsonpath_remove" : "cos-jsonpath-remove-action"
+                  }
+                },
+                "consumes" : "application/json",
+                "produces" : "application/json"
+              }
+            }
+          },
+          "connector_type" : {
+            "id" : "aws_redshift_source_0.1",
+            "kind" : "ConnectorType",
+            "icon_href" : "TODO",
+            "name" : "AWS Redshift Source",
+            "description" : "AWS Redshift Source",
+            "version" : "0.1",
+            "labels" : [ "source" ],
+            "capabilities" : [ "data_shape", "error_handler", "processors" ],
+            "channels" : [ "stable" ],
+            "schema" : {
+              "type" : "object",
+              "required" : [ "sql_server_name", "sql_username", "sql_password", "sql_query", "sql_database_name", "kafka_topic" ],
+              "properties" : {
+                "sql_server_name" : {
+                  "title" : "Server Name",
+                  "description" : "Server Name for the data source",
+                  "type" : "string",
+                  "example" : "localhost"
+                },
+                "sql_server_port" : {
+                  "title" : "Server Port",
+                  "description" : "Server Port for the data source",
+                  "type" : "string",
+                  "default" : 5439
+                },
+                "sql_username" : {
+                  "title" : "Username",
+                  "description" : "The username to use for accessing a secured AWS Redshift Database",
+                  "type" : "string",
+                  "x-group" : "credentials"
+                },
+                "sql_password" : {
+                  "title" : "Password",
+                  "x-group" : "credentials",
+                  "oneOf" : [ {
+                    "title" : "Password",
+                    "description" : "The password to use for accessing a secured AWS Redshift Database",
+                    "type" : "string",
+                    "format" : "password"
+                  }, {
+                    "description" : "An opaque reference to the sql_password",
+                    "type" : "object",
+                    "properties" : { }
+                  } ]
+                },
+                "sql_query" : {
+                  "title" : "Query",
+                  "description" : "The Query to execute against the AWS Redshift Database",
+                  "type" : "string",
+                  "example" : "INSERT INTO accounts (username,city) VALUES (:#username,:#city)"
+                },
+                "sql_database_name" : {
+                  "title" : "Database Name",
+                  "description" : "The Database Name we are pointing",
+                  "type" : "string"
+                },
+                "sql_consumed_query" : {
+                  "title" : "Consumed Query",
+                  "description" : "A query to run on a tuple consumed",
+                  "type" : "string",
+                  "example" : "DELETE FROM accounts where user_id = :#user_id"
+                },
+                "kafka_topic" : {
+                  "title" : "Topic Names",
+                  "description" : "Comma separated list of Kafka topic names",
+                  "type" : "string"
+                },
+                "processors" : {
+                  "type" : "array",
+                  "items" : {
+                    "oneOf" : [ {
+                      "type" : "object",
+                      "required" : [ "throttle" ],
+                      "properties" : {
+                        "throttle" : {
+                          "$ref" : "#/$defs/processors/throttle"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "log" ],
+                      "properties" : {
+                        "log" : {
+                          "$ref" : "#/$defs/processors/log"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_extract" ],
+                      "properties" : {
+                        "jsonpath_extract" : {
+                          "$ref" : "#/$defs/processors/jsonpath_extract"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_remove" ],
+                      "properties" : {
+                        "jsonpath_remove" : {
+                          "$ref" : "#/$defs/processors/jsonpath_remove"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_rename" ],
+                      "properties" : {
+                        "jsonpath_rename" : {
+                          "$ref" : "#/$defs/processors/jsonpath_rename"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_set" ],
+                      "properties" : {
+                        "jsonpath_set" : {
+                          "$ref" : "#/$defs/processors/jsonpath_set"
+                        }
+                      }
+                    } ]
+                  }
+                },
+                "data_shape" : {
+                  "type" : "object",
+                  "additionalProperties" : false,
+                  "properties" : {
+                    "produces" : {
+                      "$ref" : "#/$defs/data_shape/produces"
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "type" : "object",
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "dead_letter_queue" ],
+                    "properties" : {
+                      "dead_letter_queue" : {
+                        "$ref" : "#/$defs/error_handler/dead_letter_queue"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "log" ],
+                    "properties" : {
+                      "log" : {
+                        "$ref" : "#/$defs/error_handler/log"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "stop" ],
+                    "properties" : {
+                      "stop" : {
+                        "$ref" : "#/$defs/error_handler/stop"
+                      }
+                    }
+                  } ]
+                }
+              },
+              "$defs" : {
+                "processors" : {
+                  "throttle" : {
+                    "title" : "Throttle Action",
+                    "description" : "The Throttle action allows to ensure that a specific sink does not get overloaded.",
+                    "required" : [ "messages" ],
+                    "properties" : {
+                      "messages" : {
+                        "title" : "Messages Number",
+                        "description" : "The number of messages to send in the time period set",
+                        "type" : "integer",
+                        "example" : 10
+                      },
+                      "timePeriod" : {
+                        "title" : "Time Period",
+                        "description" : "Sets the time period during which the maximum request count is valid for, in milliseconds",
+                        "type" : "string",
+                        "default" : "1000"
+                      }
+                    },
+                    "type" : "object"
+                  },
+                  "log" : {
+                    "title" : "Log",
+                    "description" : "Log payload.",
+                    "type" : "object",
+                    "properties" : {
+                      "multiLine" : {
+                        "title" : "Multi Line",
+                        "description" : "Multi Line",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showProperties" : {
+                        "title" : "Show Properties",
+                        "description" : "Show Properties",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showHeaders" : {
+                        "title" : "Show Headers",
+                        "description" : "Show Headers",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      }
+                    }
+                  },
+                  "jsonpath_extract" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_remove" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_rename" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "newKey" : {
+                        "title" : "NewKey",
+                        "description" : "NewKey",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_set" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "title" : "Value",
+                        "description" : "Value",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  }
+                },
+                "data_shape" : {
+                  "produces" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "format" ],
+                    "properties" : {
+                      "format" : {
+                        "type" : "string",
+                        "default" : "application/json",
+                        "enum" : [ "application/json", "avro/binary" ]
+                      }
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "dead_letter_queue" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "topic" ],
+                    "properties" : {
+                      "topic" : {
+                        "type" : "string",
+                        "title" : "Dead Letter Topic Name",
+                        "description" : "The name of the Kafka topic used as dead letter queue"
+                      }
+                    }
+                  },
+                  "log" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  },
+                  "stop" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  }
+                }
+              }
+            }
+          }
+        }
+      mariadb_sink_0.1.json: |-
+        {
+          "channels" : {
+            "stable" : {
+              "shard_metadata" : {
+                "connector_revision" : "8",
+                "connector_type" : "sink",
+                "connector_image" : "quay.io/rhoas/cos-connector-mariadb:0.1.8",
+                "operators" : [ {
+                  "type" : "camel-connector-operator",
+                  "version" : "[1.0.0,2.0.0)"
+                } ],
+                "kamelets" : {
+                  "adapter" : {
+                    "name" : "mariadb-sink",
+                    "prefix" : "db"
+                  },
+                  "kafka" : {
+                    "name" : "cos-kafka-source",
+                    "prefix" : "kafka"
+                  },
+                  "processors" : {
+                    "throttle" : "throttle-action",
+                    "jsonpath_set" : "cos-jsonpath-set-action",
+                    "log" : "cos-log-action",
+                    "jsonpath_rename" : "cos-jsonpath-rename-action",
+                    "jsonpath_extract" : "cos-jsonpath-extract-action",
+                    "jsonpath_remove" : "cos-jsonpath-remove-action"
+                  }
+                },
+                "consumes" : "application/json",
+                "produces" : "application/json"
+              }
+            }
+          },
+          "connector_type" : {
+            "id" : "mariadb_sink_0.1",
+            "kind" : "ConnectorType",
+            "icon_href" : "TODO",
+            "name" : "MariaDB Sink",
+            "description" : "MariaDB Sink",
+            "version" : "0.1",
+            "labels" : [ "sink" ],
+            "capabilities" : [ "data_shape", "error_handler", "processors" ],
+            "channels" : [ "stable" ],
+            "schema" : {
+              "type" : "object",
+              "required" : [ "db_server_name", "db_username", "db_password", "db_query", "db_database_name", "kafka_topic" ],
+              "properties" : {
+                "db_server_name" : {
+                  "title" : "Server Name",
+                  "description" : "Server Name for the data source",
+                  "type" : "string",
+                  "example" : "localhost"
+                },
+                "db_server_port" : {
+                  "title" : "Server Port",
+                  "description" : "Server Port for the data source",
+                  "type" : "string",
+                  "default" : 3306
+                },
+                "db_username" : {
+                  "title" : "Username",
+                  "description" : "The username to use for accessing a secured MariaDB Database",
+                  "type" : "string",
+                  "x-group" : "credentials"
+                },
+                "db_password" : {
+                  "title" : "Password",
+                  "x-group" : "credentials",
+                  "oneOf" : [ {
+                    "title" : "Password",
+                    "description" : "The password to use for accessing a secured MariaDB Database",
+                    "type" : "string",
+                    "format" : "password"
+                  }, {
+                    "description" : "An opaque reference to the db_password",
+                    "type" : "object",
+                    "properties" : { }
+                  } ]
+                },
+                "db_query" : {
+                  "title" : "Query",
+                  "description" : "The Query to execute against the MariaDB Database",
+                  "type" : "string",
+                  "example" : "INSERT INTO accounts (username,city) VALUES (:#username,:#city)"
+                },
+                "db_database_name" : {
+                  "title" : "Database Name",
+                  "description" : "The Database Name we are pointing",
+                  "type" : "string"
+                },
+                "kafka_topic" : {
+                  "title" : "Topic Names",
+                  "description" : "Comma separated list of Kafka topic names",
+                  "type" : "string"
+                },
+                "processors" : {
+                  "type" : "array",
+                  "items" : {
+                    "oneOf" : [ {
+                      "type" : "object",
+                      "required" : [ "throttle" ],
+                      "properties" : {
+                        "throttle" : {
+                          "$ref" : "#/$defs/processors/throttle"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "log" ],
+                      "properties" : {
+                        "log" : {
+                          "$ref" : "#/$defs/processors/log"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_extract" ],
+                      "properties" : {
+                        "jsonpath_extract" : {
+                          "$ref" : "#/$defs/processors/jsonpath_extract"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_remove" ],
+                      "properties" : {
+                        "jsonpath_remove" : {
+                          "$ref" : "#/$defs/processors/jsonpath_remove"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_rename" ],
+                      "properties" : {
+                        "jsonpath_rename" : {
+                          "$ref" : "#/$defs/processors/jsonpath_rename"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_set" ],
+                      "properties" : {
+                        "jsonpath_set" : {
+                          "$ref" : "#/$defs/processors/jsonpath_set"
+                        }
+                      }
+                    } ]
+                  }
+                },
+                "data_shape" : {
+                  "type" : "object",
+                  "additionalProperties" : false,
+                  "properties" : {
+                    "consumes" : {
+                      "$ref" : "#/$defs/data_shape/consumes"
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "type" : "object",
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "dead_letter_queue" ],
+                    "properties" : {
+                      "dead_letter_queue" : {
+                        "$ref" : "#/$defs/error_handler/dead_letter_queue"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "log" ],
+                    "properties" : {
+                      "log" : {
+                        "$ref" : "#/$defs/error_handler/log"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "stop" ],
+                    "properties" : {
+                      "stop" : {
+                        "$ref" : "#/$defs/error_handler/stop"
+                      }
+                    }
+                  } ]
+                }
+              },
+              "$defs" : {
+                "processors" : {
+                  "throttle" : {
+                    "title" : "Throttle Action",
+                    "description" : "The Throttle action allows to ensure that a specific sink does not get overloaded.",
+                    "required" : [ "messages" ],
+                    "properties" : {
+                      "messages" : {
+                        "title" : "Messages Number",
+                        "description" : "The number of messages to send in the time period set",
+                        "type" : "integer",
+                        "example" : 10
+                      },
+                      "timePeriod" : {
+                        "title" : "Time Period",
+                        "description" : "Sets the time period during which the maximum request count is valid for, in milliseconds",
+                        "type" : "string",
+                        "default" : "1000"
+                      }
+                    },
+                    "type" : "object"
+                  },
+                  "log" : {
+                    "title" : "Log",
+                    "description" : "Log payload.",
+                    "type" : "object",
+                    "properties" : {
+                      "multiLine" : {
+                        "title" : "Multi Line",
+                        "description" : "Multi Line",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showProperties" : {
+                        "title" : "Show Properties",
+                        "description" : "Show Properties",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showHeaders" : {
+                        "title" : "Show Headers",
+                        "description" : "Show Headers",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      }
+                    }
+                  },
+                  "jsonpath_extract" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_remove" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_rename" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "newKey" : {
+                        "title" : "NewKey",
+                        "description" : "NewKey",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_set" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "title" : "Value",
+                        "description" : "Value",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  }
+                },
+                "data_shape" : {
+                  "consumes" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "format" ],
+                    "properties" : {
+                      "format" : {
+                        "type" : "string",
+                        "default" : "application/json",
+                        "enum" : [ "application/json", "avro/binary" ]
+                      }
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "dead_letter_queue" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "topic" ],
+                    "properties" : {
+                      "topic" : {
+                        "type" : "string",
+                        "title" : "Dead Letter Topic Name",
+                        "description" : "The name of the Kafka topic used as dead letter queue"
+                      }
+                    }
+                  },
+                  "log" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  },
+                  "stop" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  }
+                }
+              }
+            }
+          }
+        }
+      mariadb_source_0.1.json: |-
+        {
+          "channels" : {
+            "stable" : {
+              "shard_metadata" : {
+                "connector_revision" : "8",
+                "connector_type" : "source",
+                "connector_image" : "quay.io/rhoas/cos-connector-mariadb:0.1.8",
+                "operators" : [ {
+                  "type" : "camel-connector-operator",
+                  "version" : "[1.0.0,2.0.0)"
+                } ],
+                "kamelets" : {
+                  "adapter" : {
+                    "name" : "mariadb-source",
+                    "prefix" : "db"
+                  },
+                  "kafka" : {
+                    "name" : "cos-kafka-sink",
+                    "prefix" : "kafka"
+                  },
+                  "processors" : {
+                    "throttle" : "throttle-action",
+                    "jsonpath_set" : "cos-jsonpath-set-action",
+                    "log" : "cos-log-action",
+                    "jsonpath_rename" : "cos-jsonpath-rename-action",
+                    "jsonpath_extract" : "cos-jsonpath-extract-action",
+                    "jsonpath_remove" : "cos-jsonpath-remove-action"
+                  }
+                }
+              }
+            }
+          },
+          "connector_type" : {
+            "id" : "mariadb_source_0.1",
+            "kind" : "ConnectorType",
+            "icon_href" : "TODO",
+            "name" : "MariaDB Source",
+            "description" : "MariaDB Source",
+            "version" : "0.1",
+            "labels" : [ "source" ],
+            "capabilities" : [ "error_handler", "processors" ],
+            "channels" : [ "stable" ],
+            "schema" : {
+              "type" : "object",
+              "required" : [ "db_server_name", "db_username", "db_password", "db_query", "db_database_name", "kafka_topic" ],
+              "properties" : {
+                "db_server_name" : {
+                  "title" : "Server Name",
+                  "description" : "Server Name for the data source",
+                  "type" : "string",
+                  "example" : "localhost"
+                },
+                "db_server_port" : {
+                  "title" : "Server Port",
+                  "description" : "Server Port for the data source",
+                  "type" : "string",
+                  "default" : 3306
+                },
+                "db_username" : {
+                  "title" : "Username",
+                  "description" : "The username to use for accessing a secured MariaDB Database",
+                  "type" : "string",
+                  "x-group" : "credentials"
+                },
+                "db_password" : {
+                  "title" : "Password",
+                  "x-group" : "credentials",
+                  "oneOf" : [ {
+                    "title" : "Password",
+                    "description" : "The password to use for accessing a secured MariaDB Database",
+                    "type" : "string",
+                    "format" : "password"
+                  }, {
+                    "description" : "An opaque reference to the db_password",
+                    "type" : "object",
+                    "properties" : { }
+                  } ]
+                },
+                "db_query" : {
+                  "title" : "Query",
+                  "description" : "The Query to execute against the MariaDB Database",
+                  "type" : "string",
+                  "example" : "INSERT INTO accounts (username,city) VALUES (:#username,:#city)"
+                },
+                "db_database_name" : {
+                  "title" : "Database Name",
+                  "description" : "The Database Name we are pointing",
+                  "type" : "string"
+                },
+                "db_consumed_query" : {
+                  "title" : "Consumed Query",
+                  "description" : "A query to run on a tuple consumed",
+                  "type" : "string",
+                  "example" : "DELETE FROM accounts where user_id = :#user_id"
+                },
+                "kafka_topic" : {
+                  "title" : "Topic Names",
+                  "description" : "Comma separated list of Kafka topic names",
+                  "type" : "string"
+                },
+                "processors" : {
+                  "type" : "array",
+                  "items" : {
+                    "oneOf" : [ {
+                      "type" : "object",
+                      "required" : [ "throttle" ],
+                      "properties" : {
+                        "throttle" : {
+                          "$ref" : "#/$defs/processors/throttle"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "log" ],
+                      "properties" : {
+                        "log" : {
+                          "$ref" : "#/$defs/processors/log"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_extract" ],
+                      "properties" : {
+                        "jsonpath_extract" : {
+                          "$ref" : "#/$defs/processors/jsonpath_extract"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_remove" ],
+                      "properties" : {
+                        "jsonpath_remove" : {
+                          "$ref" : "#/$defs/processors/jsonpath_remove"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_rename" ],
+                      "properties" : {
+                        "jsonpath_rename" : {
+                          "$ref" : "#/$defs/processors/jsonpath_rename"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_set" ],
+                      "properties" : {
+                        "jsonpath_set" : {
+                          "$ref" : "#/$defs/processors/jsonpath_set"
+                        }
+                      }
+                    } ]
+                  }
+                },
+                "error_handler" : {
+                  "type" : "object",
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "dead_letter_queue" ],
+                    "properties" : {
+                      "dead_letter_queue" : {
+                        "$ref" : "#/$defs/error_handler/dead_letter_queue"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "log" ],
+                    "properties" : {
+                      "log" : {
+                        "$ref" : "#/$defs/error_handler/log"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "stop" ],
+                    "properties" : {
+                      "stop" : {
+                        "$ref" : "#/$defs/error_handler/stop"
+                      }
+                    }
+                  } ]
+                }
+              },
+              "$defs" : {
+                "processors" : {
+                  "throttle" : {
+                    "title" : "Throttle Action",
+                    "description" : "The Throttle action allows to ensure that a specific sink does not get overloaded.",
+                    "required" : [ "messages" ],
+                    "properties" : {
+                      "messages" : {
+                        "title" : "Messages Number",
+                        "description" : "The number of messages to send in the time period set",
+                        "type" : "integer",
+                        "example" : 10
+                      },
+                      "timePeriod" : {
+                        "title" : "Time Period",
+                        "description" : "Sets the time period during which the maximum request count is valid for, in milliseconds",
+                        "type" : "string",
+                        "default" : "1000"
+                      }
+                    },
+                    "type" : "object"
+                  },
+                  "log" : {
+                    "title" : "Log",
+                    "description" : "Log payload.",
+                    "type" : "object",
+                    "properties" : {
+                      "multiLine" : {
+                        "title" : "Multi Line",
+                        "description" : "Multi Line",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showProperties" : {
+                        "title" : "Show Properties",
+                        "description" : "Show Properties",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showHeaders" : {
+                        "title" : "Show Headers",
+                        "description" : "Show Headers",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      }
+                    }
+                  },
+                  "jsonpath_extract" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_remove" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_rename" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "newKey" : {
+                        "title" : "NewKey",
+                        "description" : "NewKey",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_set" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "title" : "Value",
+                        "description" : "Value",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "dead_letter_queue" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "topic" ],
+                    "properties" : {
+                      "topic" : {
+                        "type" : "string",
+                        "title" : "Dead Letter Topic Name",
+                        "description" : "The name of the Kafka topic used as dead letter queue"
+                      }
+                    }
+                  },
+                  "log" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  },
+                  "stop" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  }
+                }
+              }
+            }
+          }
+        }
+      mysql_sink_0.1.json: |-
+        {
+          "channels" : {
+            "stable" : {
+              "shard_metadata" : {
+                "connector_revision" : "8",
+                "connector_type" : "sink",
+                "connector_image" : "quay.io/rhoas/cos-connector-mysql:0.1.8",
+                "operators" : [ {
+                  "type" : "camel-connector-operator",
+                  "version" : "[1.0.0,2.0.0)"
+                } ],
+                "kamelets" : {
+                  "adapter" : {
+                    "name" : "mysql-sink",
+                    "prefix" : "db"
+                  },
+                  "kafka" : {
+                    "name" : "cos-kafka-source",
+                    "prefix" : "kafka"
+                  },
+                  "processors" : {
+                    "throttle" : "throttle-action",
+                    "jsonpath_set" : "cos-jsonpath-set-action",
+                    "log" : "cos-log-action",
+                    "jsonpath_rename" : "cos-jsonpath-rename-action",
+                    "jsonpath_extract" : "cos-jsonpath-extract-action",
+                    "jsonpath_remove" : "cos-jsonpath-remove-action"
+                  }
+                },
+                "consumes" : "application/json",
+                "produces" : "application/json"
+              }
+            }
+          },
+          "connector_type" : {
+            "id" : "mysql_sink_0.1",
+            "kind" : "ConnectorType",
+            "icon_href" : "TODO",
+            "name" : "MySQL Sink",
+            "description" : "MySQL Sink",
+            "version" : "0.1",
+            "labels" : [ "sink" ],
+            "capabilities" : [ "data_shape", "error_handler", "processors" ],
+            "channels" : [ "stable" ],
+            "schema" : {
+              "type" : "object",
+              "required" : [ "db_server_name", "db_username", "db_password", "db_query", "db_database_name", "kafka_topic" ],
+              "properties" : {
+                "db_server_name" : {
+                  "title" : "Server Name",
+                  "description" : "Server Name for the data source",
+                  "type" : "string",
+                  "example" : "localhost"
+                },
+                "db_server_port" : {
+                  "title" : "Server Port",
+                  "description" : "Server Port for the data source",
+                  "type" : "string",
+                  "default" : 3306
+                },
+                "db_username" : {
+                  "title" : "Username",
+                  "description" : "The username to use for accessing a secured MySQL Database",
+                  "type" : "string",
+                  "x-group" : "credentials"
+                },
+                "db_password" : {
+                  "title" : "Password",
+                  "x-group" : "credentials",
+                  "oneOf" : [ {
+                    "title" : "Password",
+                    "description" : "The password to use for accessing a secured MySQL Database",
+                    "type" : "string",
+                    "format" : "password"
+                  }, {
+                    "description" : "An opaque reference to the db_password",
+                    "type" : "object",
+                    "properties" : { }
+                  } ]
+                },
+                "db_query" : {
+                  "title" : "Query",
+                  "description" : "The Query to execute against the MySQL Database",
+                  "type" : "string",
+                  "example" : "INSERT INTO accounts (username,city) VALUES (:#username,:#city)"
+                },
+                "db_database_name" : {
+                  "title" : "Database Name",
+                  "description" : "The Database Name we are pointing",
+                  "type" : "string"
+                },
+                "kafka_topic" : {
+                  "title" : "Topic Names",
+                  "description" : "Comma separated list of Kafka topic names",
+                  "type" : "string"
+                },
+                "processors" : {
+                  "type" : "array",
+                  "items" : {
+                    "oneOf" : [ {
+                      "type" : "object",
+                      "required" : [ "throttle" ],
+                      "properties" : {
+                        "throttle" : {
+                          "$ref" : "#/$defs/processors/throttle"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "log" ],
+                      "properties" : {
+                        "log" : {
+                          "$ref" : "#/$defs/processors/log"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_extract" ],
+                      "properties" : {
+                        "jsonpath_extract" : {
+                          "$ref" : "#/$defs/processors/jsonpath_extract"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_remove" ],
+                      "properties" : {
+                        "jsonpath_remove" : {
+                          "$ref" : "#/$defs/processors/jsonpath_remove"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_rename" ],
+                      "properties" : {
+                        "jsonpath_rename" : {
+                          "$ref" : "#/$defs/processors/jsonpath_rename"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_set" ],
+                      "properties" : {
+                        "jsonpath_set" : {
+                          "$ref" : "#/$defs/processors/jsonpath_set"
+                        }
+                      }
+                    } ]
+                  }
+                },
+                "data_shape" : {
+                  "type" : "object",
+                  "additionalProperties" : false,
+                  "properties" : {
+                    "consumes" : {
+                      "$ref" : "#/$defs/data_shape/consumes"
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "type" : "object",
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "dead_letter_queue" ],
+                    "properties" : {
+                      "dead_letter_queue" : {
+                        "$ref" : "#/$defs/error_handler/dead_letter_queue"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "log" ],
+                    "properties" : {
+                      "log" : {
+                        "$ref" : "#/$defs/error_handler/log"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "stop" ],
+                    "properties" : {
+                      "stop" : {
+                        "$ref" : "#/$defs/error_handler/stop"
+                      }
+                    }
+                  } ]
+                }
+              },
+              "$defs" : {
+                "processors" : {
+                  "throttle" : {
+                    "title" : "Throttle Action",
+                    "description" : "The Throttle action allows to ensure that a specific sink does not get overloaded.",
+                    "required" : [ "messages" ],
+                    "properties" : {
+                      "messages" : {
+                        "title" : "Messages Number",
+                        "description" : "The number of messages to send in the time period set",
+                        "type" : "integer",
+                        "example" : 10
+                      },
+                      "timePeriod" : {
+                        "title" : "Time Period",
+                        "description" : "Sets the time period during which the maximum request count is valid for, in milliseconds",
+                        "type" : "string",
+                        "default" : "1000"
+                      }
+                    },
+                    "type" : "object"
+                  },
+                  "log" : {
+                    "title" : "Log",
+                    "description" : "Log payload.",
+                    "type" : "object",
+                    "properties" : {
+                      "multiLine" : {
+                        "title" : "Multi Line",
+                        "description" : "Multi Line",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showProperties" : {
+                        "title" : "Show Properties",
+                        "description" : "Show Properties",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showHeaders" : {
+                        "title" : "Show Headers",
+                        "description" : "Show Headers",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      }
+                    }
+                  },
+                  "jsonpath_extract" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_remove" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_rename" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "newKey" : {
+                        "title" : "NewKey",
+                        "description" : "NewKey",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_set" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "title" : "Value",
+                        "description" : "Value",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  }
+                },
+                "data_shape" : {
+                  "consumes" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "format" ],
+                    "properties" : {
+                      "format" : {
+                        "type" : "string",
+                        "default" : "application/json",
+                        "enum" : [ "application/json", "avro/binary" ]
+                      }
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "dead_letter_queue" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "topic" ],
+                    "properties" : {
+                      "topic" : {
+                        "type" : "string",
+                        "title" : "Dead Letter Topic Name",
+                        "description" : "The name of the Kafka topic used as dead letter queue"
+                      }
+                    }
+                  },
+                  "log" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  },
+                  "stop" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  }
+                }
+              }
+            }
+          }
+        }
+      mysql_source_0.1.json: |-
+        {
+          "channels" : {
+            "stable" : {
+              "shard_metadata" : {
+                "connector_revision" : "8",
+                "connector_type" : "source",
+                "connector_image" : "quay.io/rhoas/cos-connector-mysql:0.1.8",
+                "operators" : [ {
+                  "type" : "camel-connector-operator",
+                  "version" : "[1.0.0,2.0.0)"
+                } ],
+                "kamelets" : {
+                  "adapter" : {
+                    "name" : "mysql-source",
+                    "prefix" : "db"
+                  },
+                  "kafka" : {
+                    "name" : "cos-kafka-sink",
+                    "prefix" : "kafka"
+                  },
+                  "processors" : {
+                    "throttle" : "throttle-action",
+                    "jsonpath_set" : "cos-jsonpath-set-action",
+                    "log" : "cos-log-action",
+                    "jsonpath_rename" : "cos-jsonpath-rename-action",
+                    "jsonpath_extract" : "cos-jsonpath-extract-action",
+                    "jsonpath_remove" : "cos-jsonpath-remove-action"
+                  }
+                },
+                "consumes" : "application/json",
+                "produces" : "application/json"
+              }
+            }
+          },
+          "connector_type" : {
+            "id" : "mysql_source_0.1",
+            "kind" : "ConnectorType",
+            "icon_href" : "TODO",
+            "name" : "MySQL Source",
+            "description" : "MySQL Source",
+            "version" : "0.1",
+            "labels" : [ "source" ],
+            "capabilities" : [ "data_shape", "error_handler", "processors" ],
+            "channels" : [ "stable" ],
+            "schema" : {
+              "type" : "object",
+              "required" : [ "db_server_name", "db_username", "db_password", "db_query", "db_database_name", "kafka_topic" ],
+              "properties" : {
+                "db_server_name" : {
+                  "title" : "Server Name",
+                  "description" : "Server Name for the data source",
+                  "type" : "string",
+                  "example" : "localhost"
+                },
+                "db_server_port" : {
+                  "title" : "Server Port",
+                  "description" : "Server Port for the data source",
+                  "type" : "string",
+                  "default" : 3306
+                },
+                "db_username" : {
+                  "title" : "Username",
+                  "description" : "The username to use for accessing a secured MySQL Database",
+                  "type" : "string",
+                  "x-group" : "credentials"
+                },
+                "db_password" : {
+                  "title" : "Password",
+                  "x-group" : "credentials",
+                  "oneOf" : [ {
+                    "title" : "Password",
+                    "description" : "The password to use for accessing a secured MySQL Database",
+                    "type" : "string",
+                    "format" : "password"
+                  }, {
+                    "description" : "An opaque reference to the db_password",
+                    "type" : "object",
+                    "properties" : { }
+                  } ]
+                },
+                "db_query" : {
+                  "title" : "Query",
+                  "description" : "The Query to execute against the MySQL Database",
+                  "type" : "string",
+                  "example" : "INSERT INTO accounts (username,city) VALUES (:#username,:#city)"
+                },
+                "db_database_name" : {
+                  "title" : "Database Name",
+                  "description" : "The Database Name we are pointing",
+                  "type" : "string"
+                },
+                "db_consumed_query" : {
+                  "title" : "Consumed Query",
+                  "description" : "A query to run on a tuple consumed",
+                  "type" : "string",
+                  "example" : "DELETE FROM accounts where user_id = :#user_id"
+                },
+                "kafka_topic" : {
+                  "title" : "Topic Names",
+                  "description" : "Comma separated list of Kafka topic names",
+                  "type" : "string"
+                },
+                "processors" : {
+                  "type" : "array",
+                  "items" : {
+                    "oneOf" : [ {
+                      "type" : "object",
+                      "required" : [ "throttle" ],
+                      "properties" : {
+                        "throttle" : {
+                          "$ref" : "#/$defs/processors/throttle"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "log" ],
+                      "properties" : {
+                        "log" : {
+                          "$ref" : "#/$defs/processors/log"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_extract" ],
+                      "properties" : {
+                        "jsonpath_extract" : {
+                          "$ref" : "#/$defs/processors/jsonpath_extract"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_remove" ],
+                      "properties" : {
+                        "jsonpath_remove" : {
+                          "$ref" : "#/$defs/processors/jsonpath_remove"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_rename" ],
+                      "properties" : {
+                        "jsonpath_rename" : {
+                          "$ref" : "#/$defs/processors/jsonpath_rename"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_set" ],
+                      "properties" : {
+                        "jsonpath_set" : {
+                          "$ref" : "#/$defs/processors/jsonpath_set"
+                        }
+                      }
+                    } ]
+                  }
+                },
+                "data_shape" : {
+                  "type" : "object",
+                  "additionalProperties" : false,
+                  "properties" : {
+                    "produces" : {
+                      "$ref" : "#/$defs/data_shape/produces"
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "type" : "object",
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "dead_letter_queue" ],
+                    "properties" : {
+                      "dead_letter_queue" : {
+                        "$ref" : "#/$defs/error_handler/dead_letter_queue"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "log" ],
+                    "properties" : {
+                      "log" : {
+                        "$ref" : "#/$defs/error_handler/log"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "stop" ],
+                    "properties" : {
+                      "stop" : {
+                        "$ref" : "#/$defs/error_handler/stop"
+                      }
+                    }
+                  } ]
+                }
+              },
+              "$defs" : {
+                "processors" : {
+                  "throttle" : {
+                    "title" : "Throttle Action",
+                    "description" : "The Throttle action allows to ensure that a specific sink does not get overloaded.",
+                    "required" : [ "messages" ],
+                    "properties" : {
+                      "messages" : {
+                        "title" : "Messages Number",
+                        "description" : "The number of messages to send in the time period set",
+                        "type" : "integer",
+                        "example" : 10
+                      },
+                      "timePeriod" : {
+                        "title" : "Time Period",
+                        "description" : "Sets the time period during which the maximum request count is valid for, in milliseconds",
+                        "type" : "string",
+                        "default" : "1000"
+                      }
+                    },
+                    "type" : "object"
+                  },
+                  "log" : {
+                    "title" : "Log",
+                    "description" : "Log payload.",
+                    "type" : "object",
+                    "properties" : {
+                      "multiLine" : {
+                        "title" : "Multi Line",
+                        "description" : "Multi Line",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showProperties" : {
+                        "title" : "Show Properties",
+                        "description" : "Show Properties",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showHeaders" : {
+                        "title" : "Show Headers",
+                        "description" : "Show Headers",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      }
+                    }
+                  },
+                  "jsonpath_extract" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_remove" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_rename" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "newKey" : {
+                        "title" : "NewKey",
+                        "description" : "NewKey",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_set" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "title" : "Value",
+                        "description" : "Value",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  }
+                },
+                "data_shape" : {
+                  "produces" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "format" ],
+                    "properties" : {
+                      "format" : {
+                        "type" : "string",
+                        "default" : "application/json",
+                        "enum" : [ "application/json", "avro/binary" ]
+                      }
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "dead_letter_queue" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "topic" ],
+                    "properties" : {
+                      "topic" : {
+                        "type" : "string",
+                        "title" : "Dead Letter Topic Name",
+                        "description" : "The name of the Kafka topic used as dead letter queue"
+                      }
+                    }
+                  },
+                  "log" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  },
+                  "stop" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  }
+                }
+              }
+            }
+          }
+        }
+      postgresql_sink_0.1.json: |-
+        {
+          "channels" : {
+            "stable" : {
+              "shard_metadata" : {
+                "connector_revision" : "8",
+                "connector_type" : "sink",
+                "connector_image" : "quay.io/rhoas/cos-connector-postgresql:0.1.8",
+                "operators" : [ {
+                  "type" : "camel-connector-operator",
+                  "version" : "[1.0.0,2.0.0)"
+                } ],
+                "kamelets" : {
+                  "adapter" : {
+                    "name" : "postgresql-sink",
+                    "prefix" : "db"
+                  },
+                  "kafka" : {
+                    "name" : "cos-kafka-source",
+                    "prefix" : "kafka"
+                  },
+                  "processors" : {
+                    "throttle" : "throttle-action",
+                    "jsonpath_set" : "cos-jsonpath-set-action",
+                    "log" : "cos-log-action",
+                    "jsonpath_rename" : "cos-jsonpath-rename-action",
+                    "jsonpath_extract" : "cos-jsonpath-extract-action",
+                    "jsonpath_remove" : "cos-jsonpath-remove-action"
+                  }
+                },
+                "annotations" : {
+                  "trait.camel.apache.org/container.request-memory" : "256m"
+                },
+                "consumes" : "application/json",
+                "produces" : "application/json"
+              }
+            }
+          },
+          "connector_type" : {
+            "id" : "postgresql_sink_0.1",
+            "kind" : "ConnectorType",
+            "icon_href" : "TODO",
+            "name" : "PostgreSQL Sink",
+            "description" : "PostgreSQL Sink",
+            "version" : "0.1",
+            "labels" : [ "sink" ],
+            "capabilities" : [ "data_shape", "error_handler", "processors" ],
+            "channels" : [ "stable" ],
+            "schema" : {
+              "type" : "object",
+              "required" : [ "db_server_name", "db_username", "db_password", "db_query", "db_database_name", "kafka_topic" ],
+              "properties" : {
+                "db_server_name" : {
+                  "title" : "Server Name",
+                  "description" : "Server Name for the data source",
+                  "type" : "string",
+                  "example" : "localhost"
+                },
+                "db_server_port" : {
+                  "title" : "Server Port",
+                  "description" : "Server Port for the data source",
+                  "type" : "string",
+                  "default" : 5432
+                },
+                "db_username" : {
+                  "title" : "Username",
+                  "description" : "The username to use for accessing a secured PostgreSQL Database",
+                  "type" : "string",
+                  "x-group" : "credentials"
+                },
+                "db_password" : {
+                  "title" : "Password",
+                  "x-group" : "credentials",
+                  "oneOf" : [ {
+                    "title" : "Password",
+                    "description" : "The password to use for accessing a secured PostgreSQL Database",
+                    "type" : "string",
+                    "format" : "password"
+                  }, {
+                    "description" : "An opaque reference to the db_password",
+                    "type" : "object",
+                    "properties" : { }
+                  } ]
+                },
+                "db_query" : {
+                  "title" : "Query",
+                  "description" : "The Query to execute against the PostgreSQL Database",
+                  "type" : "string",
+                  "example" : "INSERT INTO accounts (username,city) VALUES (:#username,:#city)"
+                },
+                "db_database_name" : {
+                  "title" : "Database Name",
+                  "description" : "The Database Name we are pointing",
+                  "type" : "string"
+                },
+                "kafka_topic" : {
+                  "title" : "Topic Names",
+                  "description" : "Comma separated list of Kafka topic names",
+                  "type" : "string"
+                },
+                "processors" : {
+                  "type" : "array",
+                  "items" : {
+                    "oneOf" : [ {
+                      "type" : "object",
+                      "required" : [ "throttle" ],
+                      "properties" : {
+                        "throttle" : {
+                          "$ref" : "#/$defs/processors/throttle"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "log" ],
+                      "properties" : {
+                        "log" : {
+                          "$ref" : "#/$defs/processors/log"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_extract" ],
+                      "properties" : {
+                        "jsonpath_extract" : {
+                          "$ref" : "#/$defs/processors/jsonpath_extract"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_remove" ],
+                      "properties" : {
+                        "jsonpath_remove" : {
+                          "$ref" : "#/$defs/processors/jsonpath_remove"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_rename" ],
+                      "properties" : {
+                        "jsonpath_rename" : {
+                          "$ref" : "#/$defs/processors/jsonpath_rename"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_set" ],
+                      "properties" : {
+                        "jsonpath_set" : {
+                          "$ref" : "#/$defs/processors/jsonpath_set"
+                        }
+                      }
+                    } ]
+                  }
+                },
+                "data_shape" : {
+                  "type" : "object",
+                  "additionalProperties" : false,
+                  "properties" : {
+                    "consumes" : {
+                      "$ref" : "#/$defs/data_shape/consumes"
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "type" : "object",
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "dead_letter_queue" ],
+                    "properties" : {
+                      "dead_letter_queue" : {
+                        "$ref" : "#/$defs/error_handler/dead_letter_queue"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "log" ],
+                    "properties" : {
+                      "log" : {
+                        "$ref" : "#/$defs/error_handler/log"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "stop" ],
+                    "properties" : {
+                      "stop" : {
+                        "$ref" : "#/$defs/error_handler/stop"
+                      }
+                    }
+                  } ]
+                }
+              },
+              "$defs" : {
+                "processors" : {
+                  "throttle" : {
+                    "title" : "Throttle Action",
+                    "description" : "The Throttle action allows to ensure that a specific sink does not get overloaded.",
+                    "required" : [ "messages" ],
+                    "properties" : {
+                      "messages" : {
+                        "title" : "Messages Number",
+                        "description" : "The number of messages to send in the time period set",
+                        "type" : "integer",
+                        "example" : 10
+                      },
+                      "timePeriod" : {
+                        "title" : "Time Period",
+                        "description" : "Sets the time period during which the maximum request count is valid for, in milliseconds",
+                        "type" : "string",
+                        "default" : "1000"
+                      }
+                    },
+                    "type" : "object"
+                  },
+                  "log" : {
+                    "title" : "Log",
+                    "description" : "Log payload.",
+                    "type" : "object",
+                    "properties" : {
+                      "multiLine" : {
+                        "title" : "Multi Line",
+                        "description" : "Multi Line",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showProperties" : {
+                        "title" : "Show Properties",
+                        "description" : "Show Properties",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showHeaders" : {
+                        "title" : "Show Headers",
+                        "description" : "Show Headers",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      }
+                    }
+                  },
+                  "jsonpath_extract" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_remove" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_rename" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "newKey" : {
+                        "title" : "NewKey",
+                        "description" : "NewKey",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_set" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "title" : "Value",
+                        "description" : "Value",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  }
+                },
+                "data_shape" : {
+                  "consumes" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "format" ],
+                    "properties" : {
+                      "format" : {
+                        "type" : "string",
+                        "default" : "application/json",
+                        "enum" : [ "application/json", "avro/binary" ]
+                      }
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "dead_letter_queue" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "topic" ],
+                    "properties" : {
+                      "topic" : {
+                        "type" : "string",
+                        "title" : "Dead Letter Topic Name",
+                        "description" : "The name of the Kafka topic used as dead letter queue"
+                      }
+                    }
+                  },
+                  "log" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  },
+                  "stop" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  }
+                }
+              }
+            }
+          }
+        }
+      postgresql_source_0.1.json: |-
+        {
+          "channels" : {
+            "stable" : {
+              "shard_metadata" : {
+                "connector_revision" : "8",
+                "connector_type" : "source",
+                "connector_image" : "quay.io/rhoas/cos-connector-postgresql:0.1.8",
+                "operators" : [ {
+                  "type" : "camel-connector-operator",
+                  "version" : "[1.0.0,2.0.0)"
+                } ],
+                "kamelets" : {
+                  "adapter" : {
+                    "name" : "postgresql-source",
+                    "prefix" : "db"
+                  },
+                  "kafka" : {
+                    "name" : "cos-kafka-sink",
+                    "prefix" : "kafka"
+                  },
+                  "processors" : {
+                    "throttle" : "throttle-action",
+                    "jsonpath_set" : "cos-jsonpath-set-action",
+                    "log" : "cos-log-action",
+                    "jsonpath_rename" : "cos-jsonpath-rename-action",
+                    "jsonpath_extract" : "cos-jsonpath-extract-action",
+                    "jsonpath_remove" : "cos-jsonpath-remove-action"
+                  }
+                },
+                "annotations" : {
+                  "trait.camel.apache.org/container.request-memory" : "256m"
+                },
+                "consumes" : "application/json",
+                "produces" : "application/json"
+              }
+            }
+          },
+          "connector_type" : {
+            "id" : "postgresql_source_0.1",
+            "kind" : "ConnectorType",
+            "icon_href" : "TODO",
+            "name" : "PostgreSQL Source",
+            "description" : "PostgreSQL Source",
+            "version" : "0.1",
+            "labels" : [ "source" ],
+            "capabilities" : [ "data_shape", "error_handler", "processors" ],
+            "channels" : [ "stable" ],
+            "schema" : {
+              "type" : "object",
+              "required" : [ "db_server_name", "db_username", "db_password", "db_query", "db_database_name", "kafka_topic" ],
+              "properties" : {
+                "db_server_name" : {
+                  "title" : "Server Name",
+                  "description" : "Server Name for the data source",
+                  "type" : "string",
+                  "example" : "localhost"
+                },
+                "db_server_port" : {
+                  "title" : "Server Port",
+                  "description" : "Server Port for the data source",
+                  "type" : "string",
+                  "default" : 5432
+                },
+                "db_username" : {
+                  "title" : "Username",
+                  "description" : "The username to use for accessing a secured PostgreSQL Database",
+                  "type" : "string",
+                  "x-group" : "credentials"
+                },
+                "db_password" : {
+                  "title" : "Password",
+                  "x-group" : "credentials",
+                  "oneOf" : [ {
+                    "title" : "Password",
+                    "description" : "The password to use for accessing a secured PostgreSQL Database",
+                    "type" : "string",
+                    "format" : "password"
+                  }, {
+                    "description" : "An opaque reference to the db_password",
+                    "type" : "object",
+                    "properties" : { }
+                  } ]
+                },
+                "db_query" : {
+                  "title" : "Query",
+                  "description" : "The Query to execute against the PostgreSQL Database",
+                  "type" : "string",
+                  "example" : "INSERT INTO accounts (username,city) VALUES (:#username,:#city)"
+                },
+                "db_database_name" : {
+                  "title" : "Database Name",
+                  "description" : "The Database Name we are pointing",
+                  "type" : "string"
+                },
+                "db_consumed_query" : {
+                  "title" : "Consumed Query",
+                  "description" : "A query to run on a tuple consumed",
+                  "type" : "string",
+                  "example" : "DELETE FROM accounts where user_id = :#user_id"
+                },
+                "kafka_topic" : {
+                  "title" : "Topic Names",
+                  "description" : "Comma separated list of Kafka topic names",
+                  "type" : "string"
+                },
+                "processors" : {
+                  "type" : "array",
+                  "items" : {
+                    "oneOf" : [ {
+                      "type" : "object",
+                      "required" : [ "throttle" ],
+                      "properties" : {
+                        "throttle" : {
+                          "$ref" : "#/$defs/processors/throttle"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "log" ],
+                      "properties" : {
+                        "log" : {
+                          "$ref" : "#/$defs/processors/log"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_extract" ],
+                      "properties" : {
+                        "jsonpath_extract" : {
+                          "$ref" : "#/$defs/processors/jsonpath_extract"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_remove" ],
+                      "properties" : {
+                        "jsonpath_remove" : {
+                          "$ref" : "#/$defs/processors/jsonpath_remove"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_rename" ],
+                      "properties" : {
+                        "jsonpath_rename" : {
+                          "$ref" : "#/$defs/processors/jsonpath_rename"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_set" ],
+                      "properties" : {
+                        "jsonpath_set" : {
+                          "$ref" : "#/$defs/processors/jsonpath_set"
+                        }
+                      }
+                    } ]
+                  }
+                },
+                "data_shape" : {
+                  "type" : "object",
+                  "additionalProperties" : false,
+                  "properties" : {
+                    "produces" : {
+                      "$ref" : "#/$defs/data_shape/produces"
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "type" : "object",
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "dead_letter_queue" ],
+                    "properties" : {
+                      "dead_letter_queue" : {
+                        "$ref" : "#/$defs/error_handler/dead_letter_queue"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "log" ],
+                    "properties" : {
+                      "log" : {
+                        "$ref" : "#/$defs/error_handler/log"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "stop" ],
+                    "properties" : {
+                      "stop" : {
+                        "$ref" : "#/$defs/error_handler/stop"
+                      }
+                    }
+                  } ]
+                }
+              },
+              "$defs" : {
+                "processors" : {
+                  "throttle" : {
+                    "title" : "Throttle Action",
+                    "description" : "The Throttle action allows to ensure that a specific sink does not get overloaded.",
+                    "required" : [ "messages" ],
+                    "properties" : {
+                      "messages" : {
+                        "title" : "Messages Number",
+                        "description" : "The number of messages to send in the time period set",
+                        "type" : "integer",
+                        "example" : 10
+                      },
+                      "timePeriod" : {
+                        "title" : "Time Period",
+                        "description" : "Sets the time period during which the maximum request count is valid for, in milliseconds",
+                        "type" : "string",
+                        "default" : "1000"
+                      }
+                    },
+                    "type" : "object"
+                  },
+                  "log" : {
+                    "title" : "Log",
+                    "description" : "Log payload.",
+                    "type" : "object",
+                    "properties" : {
+                      "multiLine" : {
+                        "title" : "Multi Line",
+                        "description" : "Multi Line",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showProperties" : {
+                        "title" : "Show Properties",
+                        "description" : "Show Properties",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showHeaders" : {
+                        "title" : "Show Headers",
+                        "description" : "Show Headers",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      }
+                    }
+                  },
+                  "jsonpath_extract" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_remove" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_rename" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "newKey" : {
+                        "title" : "NewKey",
+                        "description" : "NewKey",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_set" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "title" : "Value",
+                        "description" : "Value",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  }
+                },
+                "data_shape" : {
+                  "produces" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "format" ],
+                    "properties" : {
+                      "format" : {
+                        "type" : "string",
+                        "default" : "application/json",
+                        "enum" : [ "application/json", "avro/binary" ]
+                      }
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "dead_letter_queue" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "topic" ],
+                    "properties" : {
+                      "topic" : {
+                        "type" : "string",
+                        "title" : "Dead Letter Topic Name",
+                        "description" : "The name of the Kafka topic used as dead letter queue"
+                      }
+                    }
+                  },
+                  "log" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  },
+                  "stop" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  }
+                }
+              }
+            }
+          }
+        }
+      sqlserver_sink_0.1.json: |-
+        {
+          "channels" : {
+            "stable" : {
+              "shard_metadata" : {
+                "connector_revision" : "8",
+                "connector_type" : "sink",
+                "connector_image" : "quay.io/rhoas/cos-connector-sqlserver:0.1.8",
+                "operators" : [ {
+                  "type" : "camel-connector-operator",
+                  "version" : "[1.0.0,2.0.0)"
+                } ],
+                "kamelets" : {
+                  "adapter" : {
+                    "name" : "sqlserver-sink",
+                    "prefix" : "db"
+                  },
+                  "kafka" : {
+                    "name" : "cos-kafka-source",
+                    "prefix" : "kafka"
+                  },
+                  "processors" : {
+                    "throttle" : "throttle-action",
+                    "jsonpath_set" : "cos-jsonpath-set-action",
+                    "log" : "cos-log-action",
+                    "jsonpath_rename" : "cos-jsonpath-rename-action",
+                    "jsonpath_extract" : "cos-jsonpath-extract-action",
+                    "jsonpath_remove" : "cos-jsonpath-remove-action"
+                  }
+                },
+                "consumes" : "application/json",
+                "produces" : "application/json"
+              }
+            }
+          },
+          "connector_type" : {
+            "id" : "sqlserver_sink_0.1",
+            "kind" : "ConnectorType",
+            "icon_href" : "TODO",
+            "name" : "SQL Server Sink",
+            "description" : "SQL Server Sink",
+            "version" : "0.1",
+            "labels" : [ "sink" ],
+            "capabilities" : [ "data_shape", "error_handler", "processors" ],
+            "channels" : [ "stable" ],
+            "schema" : {
+              "type" : "object",
+              "required" : [ "db_server_name", "db_username", "db_password", "db_query", "db_database_name", "kafka_topic" ],
+              "properties" : {
+                "db_server_name" : {
+                  "title" : "Server Name",
+                  "description" : "Server Name for the data source",
+                  "type" : "string",
+                  "example" : "localhost"
+                },
+                "db_server_port" : {
+                  "title" : "Server Port",
+                  "description" : "Server Port for the data source",
+                  "type" : "string",
+                  "default" : 1433
+                },
+                "db_username" : {
+                  "title" : "Username",
+                  "description" : "The username to use for accessing a secured SQL Server Database",
+                  "type" : "string",
+                  "x-group" : "credentials"
+                },
+                "db_password" : {
+                  "title" : "Password",
+                  "x-group" : "credentials",
+                  "oneOf" : [ {
+                    "title" : "Password",
+                    "description" : "The password to use for accessing a secured SQL Server Database",
+                    "type" : "string",
+                    "format" : "password"
+                  }, {
+                    "description" : "An opaque reference to the db_password",
+                    "type" : "object",
+                    "properties" : { }
+                  } ]
+                },
+                "db_query" : {
+                  "title" : "Query",
+                  "description" : "The Query to execute against the SQL Server Database",
+                  "type" : "string",
+                  "example" : "INSERT INTO accounts (username,city) VALUES (:#username,:#city)"
+                },
+                "db_database_name" : {
+                  "title" : "Database Name",
+                  "description" : "The Database Name we are pointing",
+                  "type" : "string"
+                },
+                "kafka_topic" : {
+                  "title" : "Topic Names",
+                  "description" : "Comma separated list of Kafka topic names",
+                  "type" : "string"
+                },
+                "processors" : {
+                  "type" : "array",
+                  "items" : {
+                    "oneOf" : [ {
+                      "type" : "object",
+                      "required" : [ "throttle" ],
+                      "properties" : {
+                        "throttle" : {
+                          "$ref" : "#/$defs/processors/throttle"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "log" ],
+                      "properties" : {
+                        "log" : {
+                          "$ref" : "#/$defs/processors/log"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_extract" ],
+                      "properties" : {
+                        "jsonpath_extract" : {
+                          "$ref" : "#/$defs/processors/jsonpath_extract"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_remove" ],
+                      "properties" : {
+                        "jsonpath_remove" : {
+                          "$ref" : "#/$defs/processors/jsonpath_remove"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_rename" ],
+                      "properties" : {
+                        "jsonpath_rename" : {
+                          "$ref" : "#/$defs/processors/jsonpath_rename"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_set" ],
+                      "properties" : {
+                        "jsonpath_set" : {
+                          "$ref" : "#/$defs/processors/jsonpath_set"
+                        }
+                      }
+                    } ]
+                  }
+                },
+                "data_shape" : {
+                  "type" : "object",
+                  "additionalProperties" : false,
+                  "properties" : {
+                    "consumes" : {
+                      "$ref" : "#/$defs/data_shape/consumes"
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "type" : "object",
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "dead_letter_queue" ],
+                    "properties" : {
+                      "dead_letter_queue" : {
+                        "$ref" : "#/$defs/error_handler/dead_letter_queue"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "log" ],
+                    "properties" : {
+                      "log" : {
+                        "$ref" : "#/$defs/error_handler/log"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "stop" ],
+                    "properties" : {
+                      "stop" : {
+                        "$ref" : "#/$defs/error_handler/stop"
+                      }
+                    }
+                  } ]
+                }
+              },
+              "$defs" : {
+                "processors" : {
+                  "throttle" : {
+                    "title" : "Throttle Action",
+                    "description" : "The Throttle action allows to ensure that a specific sink does not get overloaded.",
+                    "required" : [ "messages" ],
+                    "properties" : {
+                      "messages" : {
+                        "title" : "Messages Number",
+                        "description" : "The number of messages to send in the time period set",
+                        "type" : "integer",
+                        "example" : 10
+                      },
+                      "timePeriod" : {
+                        "title" : "Time Period",
+                        "description" : "Sets the time period during which the maximum request count is valid for, in milliseconds",
+                        "type" : "string",
+                        "default" : "1000"
+                      }
+                    },
+                    "type" : "object"
+                  },
+                  "log" : {
+                    "title" : "Log",
+                    "description" : "Log payload.",
+                    "type" : "object",
+                    "properties" : {
+                      "multiLine" : {
+                        "title" : "Multi Line",
+                        "description" : "Multi Line",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showProperties" : {
+                        "title" : "Show Properties",
+                        "description" : "Show Properties",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showHeaders" : {
+                        "title" : "Show Headers",
+                        "description" : "Show Headers",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      }
+                    }
+                  },
+                  "jsonpath_extract" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_remove" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_rename" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "newKey" : {
+                        "title" : "NewKey",
+                        "description" : "NewKey",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_set" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "title" : "Value",
+                        "description" : "Value",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  }
+                },
+                "data_shape" : {
+                  "consumes" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "format" ],
+                    "properties" : {
+                      "format" : {
+                        "type" : "string",
+                        "default" : "application/json",
+                        "enum" : [ "application/json", "avro/binary" ]
+                      }
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "dead_letter_queue" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "topic" ],
+                    "properties" : {
+                      "topic" : {
+                        "type" : "string",
+                        "title" : "Dead Letter Topic Name",
+                        "description" : "The name of the Kafka topic used as dead letter queue"
+                      }
+                    }
+                  },
+                  "log" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  },
+                  "stop" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  }
+                }
+              }
+            }
+          }
+        }
+      sqlserver_source_0.1.json: |-
+        {
+          "channels" : {
+            "stable" : {
+              "shard_metadata" : {
+                "connector_revision" : "8",
+                "connector_type" : "source",
+                "connector_image" : "quay.io/rhoas/cos-connector-sqlserver:0.1.8",
+                "operators" : [ {
+                  "type" : "camel-connector-operator",
+                  "version" : "[1.0.0,2.0.0)"
+                } ],
+                "kamelets" : {
+                  "adapter" : {
+                    "name" : "sqlserver-source",
+                    "prefix" : "db"
+                  },
+                  "kafka" : {
+                    "name" : "cos-kafka-sink",
+                    "prefix" : "kafka"
+                  },
+                  "processors" : {
+                    "throttle" : "throttle-action",
+                    "jsonpath_set" : "cos-jsonpath-set-action",
+                    "log" : "cos-log-action",
+                    "jsonpath_rename" : "cos-jsonpath-rename-action",
+                    "jsonpath_extract" : "cos-jsonpath-extract-action",
+                    "jsonpath_remove" : "cos-jsonpath-remove-action"
+                  }
+                }
+              }
+            }
+          },
+          "connector_type" : {
+            "id" : "sqlserver_source_0.1",
+            "kind" : "ConnectorType",
+            "icon_href" : "TODO",
+            "name" : "SQL Server Source",
+            "description" : "SQL Server Source",
+            "version" : "0.1",
+            "labels" : [ "source" ],
+            "capabilities" : [ "error_handler", "processors" ],
+            "channels" : [ "stable" ],
+            "schema" : {
+              "type" : "object",
+              "required" : [ "db_server_name", "db_username", "db_password", "db_query", "db_database_name", "kafka_topic" ],
+              "properties" : {
+                "db_server_name" : {
+                  "title" : "Server Name",
+                  "description" : "Server Name for the data source",
+                  "type" : "string",
+                  "example" : "localhost"
+                },
+                "db_server_port" : {
+                  "title" : "Server Port",
+                  "description" : "Server Port for the data source",
+                  "type" : "string",
+                  "default" : 1433
+                },
+                "db_username" : {
+                  "title" : "Username",
+                  "description" : "The username to use for accessing a secured SQL Server Database",
+                  "type" : "string",
+                  "x-group" : "credentials"
+                },
+                "db_password" : {
+                  "title" : "Password",
+                  "x-group" : "credentials",
+                  "oneOf" : [ {
+                    "title" : "Password",
+                    "description" : "The password to use for accessing a secured SQL Server Database",
+                    "type" : "string",
+                    "format" : "password"
+                  }, {
+                    "description" : "An opaque reference to the db_password",
+                    "type" : "object",
+                    "properties" : { }
+                  } ]
+                },
+                "db_query" : {
+                  "title" : "Query",
+                  "description" : "The Query to execute against the SQL Server Database",
+                  "type" : "string",
+                  "example" : "INSERT INTO accounts (username,city) VALUES (:#username,:#city)"
+                },
+                "db_database_name" : {
+                  "title" : "Database Name",
+                  "description" : "The Database Name we are pointing",
+                  "type" : "string"
+                },
+                "db_consumed_query" : {
+                  "title" : "Consumed Query",
+                  "description" : "A query to run on a tuple consumed",
+                  "type" : "string",
+                  "example" : "DELETE FROM accounts where user_id = :#user_id"
+                },
+                "kafka_topic" : {
+                  "title" : "Topic Names",
+                  "description" : "Comma separated list of Kafka topic names",
+                  "type" : "string"
+                },
+                "processors" : {
+                  "type" : "array",
+                  "items" : {
+                    "oneOf" : [ {
+                      "type" : "object",
+                      "required" : [ "throttle" ],
+                      "properties" : {
+                        "throttle" : {
+                          "$ref" : "#/$defs/processors/throttle"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "log" ],
+                      "properties" : {
+                        "log" : {
+                          "$ref" : "#/$defs/processors/log"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_extract" ],
+                      "properties" : {
+                        "jsonpath_extract" : {
+                          "$ref" : "#/$defs/processors/jsonpath_extract"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_remove" ],
+                      "properties" : {
+                        "jsonpath_remove" : {
+                          "$ref" : "#/$defs/processors/jsonpath_remove"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_rename" ],
+                      "properties" : {
+                        "jsonpath_rename" : {
+                          "$ref" : "#/$defs/processors/jsonpath_rename"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_set" ],
+                      "properties" : {
+                        "jsonpath_set" : {
+                          "$ref" : "#/$defs/processors/jsonpath_set"
+                        }
+                      }
+                    } ]
+                  }
+                },
+                "error_handler" : {
+                  "type" : "object",
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "dead_letter_queue" ],
+                    "properties" : {
+                      "dead_letter_queue" : {
+                        "$ref" : "#/$defs/error_handler/dead_letter_queue"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "log" ],
+                    "properties" : {
+                      "log" : {
+                        "$ref" : "#/$defs/error_handler/log"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "stop" ],
+                    "properties" : {
+                      "stop" : {
+                        "$ref" : "#/$defs/error_handler/stop"
+                      }
+                    }
+                  } ]
+                }
+              },
+              "$defs" : {
+                "processors" : {
+                  "throttle" : {
+                    "title" : "Throttle Action",
+                    "description" : "The Throttle action allows to ensure that a specific sink does not get overloaded.",
+                    "required" : [ "messages" ],
+                    "properties" : {
+                      "messages" : {
+                        "title" : "Messages Number",
+                        "description" : "The number of messages to send in the time period set",
+                        "type" : "integer",
+                        "example" : 10
+                      },
+                      "timePeriod" : {
+                        "title" : "Time Period",
+                        "description" : "Sets the time period during which the maximum request count is valid for, in milliseconds",
+                        "type" : "string",
+                        "default" : "1000"
+                      }
+                    },
+                    "type" : "object"
+                  },
+                  "log" : {
+                    "title" : "Log",
+                    "description" : "Log payload.",
+                    "type" : "object",
+                    "properties" : {
+                      "multiLine" : {
+                        "title" : "Multi Line",
+                        "description" : "Multi Line",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showProperties" : {
+                        "title" : "Show Properties",
+                        "description" : "Show Properties",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showHeaders" : {
+                        "title" : "Show Headers",
+                        "description" : "Show Headers",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      }
+                    }
+                  },
+                  "jsonpath_extract" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_remove" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_rename" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "newKey" : {
+                        "title" : "NewKey",
+                        "description" : "NewKey",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_set" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "title" : "Value",
+                        "description" : "Value",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "dead_letter_queue" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "topic" ],
+                    "properties" : {
+                      "topic" : {
+                        "type" : "string",
+                        "title" : "Dead Letter Topic Name",
+                        "description" : "The name of the Kafka topic used as dead letter queue"
+                      }
+                    }
+                  },
+                  "log" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  },
+                  "stop" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  }
+                }
+              }
+            }
+          }
+        }
+    kind: ConfigMap
+    metadata:
+      creationTimestamp: null
+      name: connector-catalog-camel-sql
+  - apiVersion: v1
+    data:
+      ftps_sink_0.1.json: |-
+        {
+          "channels" : {
+            "stable" : {
+              "shard_metadata" : {
+                "connector_revision" : "8",
+                "connector_type" : "sink",
+                "connector_image" : "quay.io/rhoas/cos-connector-ftps:0.1.8",
+                "operators" : [ {
+                  "type" : "camel-connector-operator",
+                  "version" : "[1.0.0,2.0.0)"
+                } ],
+                "kamelets" : {
+                  "adapter" : {
+                    "name" : "ftps-sink",
+                    "prefix" : "ftps"
+                  },
+                  "kafka" : {
+                    "name" : "cos-kafka-source",
+                    "prefix" : "kafka"
+                  },
+                  "processors" : {
+                    "throttle" : "throttle-action",
+                    "jsonpath_set" : "cos-jsonpath-set-action",
+                    "log" : "cos-log-action",
+                    "jsonpath_rename" : "cos-jsonpath-rename-action",
+                    "jsonpath_extract" : "cos-jsonpath-extract-action",
+                    "jsonpath_remove" : "cos-jsonpath-remove-action"
+                  }
+                }
+              }
+            }
+          },
+          "connector_type" : {
+            "id" : "ftps_sink_0.1",
+            "kind" : "ConnectorType",
+            "icon_href" : "TODO",
+            "name" : "FTPS Sink",
+            "description" : "FTPS Sink",
+            "version" : "0.1",
+            "labels" : [ "sink" ],
+            "capabilities" : [ "error_handler", "processors" ],
+            "channels" : [ "stable" ],
+            "schema" : {
+              "type" : "object",
+              "required" : [ "ftps_connection_host", "ftps_connection_port", "ftps_username", "ftps_password", "ftps_directory_name", "kafka_topic" ],
+              "properties" : {
+                "ftps_connection_host" : {
+                  "title" : "Connection Host",
+                  "description" : "Hostname of the FTP server",
+                  "type" : "string"
+                },
+                "ftps_connection_port" : {
+                  "title" : "Connection Port",
+                  "description" : "Port of the FTP server",
+                  "type" : "string",
+                  "default" : 21
+                },
+                "ftps_username" : {
+                  "title" : "Username",
+                  "description" : "The username to access the FTP server",
+                  "type" : "string",
+                  "x-group" : "credentials"
+                },
+                "ftps_password" : {
+                  "title" : "Password",
+                  "x-group" : "credentials",
+                  "oneOf" : [ {
+                    "title" : "Password",
+                    "description" : "The password to access the FTP server",
+                    "type" : "string",
+                    "format" : "password"
+                  }, {
+                    "description" : "An opaque reference to the ftps_password",
+                    "type" : "object",
+                    "properties" : { }
+                  } ]
+                },
+                "ftps_directory_name" : {
+                  "title" : "Directory Name",
+                  "description" : "The starting directory",
+                  "type" : "string"
+                },
+                "ftps_passive_mode" : {
+                  "title" : "Passive Mode",
+                  "description" : "Sets passive mode connection",
+                  "type" : "boolean",
+                  "default" : false
+                },
+                "ftps_file_exist" : {
+                  "title" : "File Existence",
+                  "description" : "How to behave in case of file already existent. There are 4 enums and the value can be one of Override, Append, Fail or Ignore",
+                  "type" : "string",
+                  "default" : "Override"
+                },
+                "kafka_topic" : {
+                  "title" : "Topic Names",
+                  "description" : "Comma separated list of Kafka topic names",
+                  "type" : "string"
+                },
+                "processors" : {
+                  "type" : "array",
+                  "items" : {
+                    "oneOf" : [ {
+                      "type" : "object",
+                      "required" : [ "throttle" ],
+                      "properties" : {
+                        "throttle" : {
+                          "$ref" : "#/$defs/processors/throttle"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "log" ],
+                      "properties" : {
+                        "log" : {
+                          "$ref" : "#/$defs/processors/log"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_extract" ],
+                      "properties" : {
+                        "jsonpath_extract" : {
+                          "$ref" : "#/$defs/processors/jsonpath_extract"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_remove" ],
+                      "properties" : {
+                        "jsonpath_remove" : {
+                          "$ref" : "#/$defs/processors/jsonpath_remove"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_rename" ],
+                      "properties" : {
+                        "jsonpath_rename" : {
+                          "$ref" : "#/$defs/processors/jsonpath_rename"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_set" ],
+                      "properties" : {
+                        "jsonpath_set" : {
+                          "$ref" : "#/$defs/processors/jsonpath_set"
+                        }
+                      }
+                    } ]
+                  }
+                },
+                "error_handler" : {
+                  "type" : "object",
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "dead_letter_queue" ],
+                    "properties" : {
+                      "dead_letter_queue" : {
+                        "$ref" : "#/$defs/error_handler/dead_letter_queue"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "log" ],
+                    "properties" : {
+                      "log" : {
+                        "$ref" : "#/$defs/error_handler/log"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "stop" ],
+                    "properties" : {
+                      "stop" : {
+                        "$ref" : "#/$defs/error_handler/stop"
+                      }
+                    }
+                  } ]
+                }
+              },
+              "$defs" : {
+                "processors" : {
+                  "throttle" : {
+                    "title" : "Throttle Action",
+                    "description" : "The Throttle action allows to ensure that a specific sink does not get overloaded.",
+                    "required" : [ "messages" ],
+                    "properties" : {
+                      "messages" : {
+                        "title" : "Messages Number",
+                        "description" : "The number of messages to send in the time period set",
+                        "type" : "integer",
+                        "example" : 10
+                      },
+                      "timePeriod" : {
+                        "title" : "Time Period",
+                        "description" : "Sets the time period during which the maximum request count is valid for, in milliseconds",
+                        "type" : "string",
+                        "default" : "1000"
+                      }
+                    },
+                    "type" : "object"
+                  },
+                  "log" : {
+                    "title" : "Log",
+                    "description" : "Log payload.",
+                    "type" : "object",
+                    "properties" : {
+                      "multiLine" : {
+                        "title" : "Multi Line",
+                        "description" : "Multi Line",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showProperties" : {
+                        "title" : "Show Properties",
+                        "description" : "Show Properties",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showHeaders" : {
+                        "title" : "Show Headers",
+                        "description" : "Show Headers",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      }
+                    }
+                  },
+                  "jsonpath_extract" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_remove" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_rename" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "newKey" : {
+                        "title" : "NewKey",
+                        "description" : "NewKey",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_set" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "title" : "Value",
+                        "description" : "Value",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "dead_letter_queue" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "topic" ],
+                    "properties" : {
+                      "topic" : {
+                        "type" : "string",
+                        "title" : "Dead Letter Topic Name",
+                        "description" : "The name of the Kafka topic used as dead letter queue"
+                      }
+                    }
+                  },
+                  "log" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  },
+                  "stop" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  }
+                }
+              }
+            }
+          }
+        }
+      ftps_source_0.1.json: |-
+        {
+          "channels" : {
+            "stable" : {
+              "shard_metadata" : {
+                "connector_revision" : "8",
+                "connector_type" : "source",
+                "connector_image" : "quay.io/rhoas/cos-connector-ftps:0.1.8",
+                "operators" : [ {
+                  "type" : "camel-connector-operator",
+                  "version" : "[1.0.0,2.0.0)"
+                } ],
+                "kamelets" : {
+                  "adapter" : {
+                    "name" : "ftps-source",
+                    "prefix" : "ftps"
+                  },
+                  "kafka" : {
+                    "name" : "cos-kafka-sink",
+                    "prefix" : "kafka"
+                  },
+                  "processors" : {
+                    "throttle" : "throttle-action",
+                    "jsonpath_set" : "cos-jsonpath-set-action",
+                    "log" : "cos-log-action",
+                    "jsonpath_rename" : "cos-jsonpath-rename-action",
+                    "jsonpath_extract" : "cos-jsonpath-extract-action",
+                    "jsonpath_remove" : "cos-jsonpath-remove-action"
+                  }
+                }
+              }
+            }
+          },
+          "connector_type" : {
+            "id" : "ftps_source_0.1",
+            "kind" : "ConnectorType",
+            "icon_href" : "TODO",
+            "name" : "FTPS Source",
+            "description" : "FTPS Source",
+            "version" : "0.1",
+            "labels" : [ "source" ],
+            "capabilities" : [ "error_handler", "processors" ],
+            "channels" : [ "stable" ],
+            "schema" : {
+              "type" : "object",
+              "required" : [ "ftps_connection_host", "ftps_connection_port", "ftps_username", "ftps_password", "ftps_directory_name", "kafka_topic" ],
+              "properties" : {
+                "ftps_connection_host" : {
+                  "title" : "Connection Host",
+                  "description" : "Hostname of the FTPS server",
+                  "type" : "string"
+                },
+                "ftps_connection_port" : {
+                  "title" : "Connection Port",
+                  "description" : "Port of the FTPS server",
+                  "type" : "string",
+                  "default" : 21
+                },
+                "ftps_username" : {
+                  "title" : "Username",
+                  "description" : "The username to access the FTPS server",
+                  "type" : "string",
+                  "x-group" : "credentials"
+                },
+                "ftps_password" : {
+                  "title" : "Password",
+                  "x-group" : "credentials",
+                  "oneOf" : [ {
+                    "title" : "Password",
+                    "description" : "The password to access the FTPS server",
+                    "type" : "string",
+                    "format" : "password"
+                  }, {
+                    "description" : "An opaque reference to the ftps_password",
+                    "type" : "object",
+                    "properties" : { }
+                  } ]
+                },
+                "ftps_directory_name" : {
+                  "title" : "Directory Name",
+                  "description" : "The starting directory",
+                  "type" : "string"
+                },
+                "ftps_passive_mode" : {
+                  "title" : "Passive Mode",
+                  "description" : "Sets passive mode connection",
+                  "type" : "boolean",
+                  "default" : false
+                },
+                "ftps_recursive" : {
+                  "title" : "Recursive",
+                  "description" : "If a directory, will look for files in all the sub-directories as well.",
+                  "type" : "boolean",
+                  "default" : false
+                },
+                "ftps_idempotent" : {
+                  "title" : "Idempotency",
+                  "description" : "Skip already processed files.",
+                  "type" : "boolean",
+                  "default" : true
+                },
+                "kafka_topic" : {
+                  "title" : "Topic Names",
+                  "description" : "Comma separated list of Kafka topic names",
+                  "type" : "string"
+                },
+                "processors" : {
+                  "type" : "array",
+                  "items" : {
+                    "oneOf" : [ {
+                      "type" : "object",
+                      "required" : [ "throttle" ],
+                      "properties" : {
+                        "throttle" : {
+                          "$ref" : "#/$defs/processors/throttle"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "log" ],
+                      "properties" : {
+                        "log" : {
+                          "$ref" : "#/$defs/processors/log"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_extract" ],
+                      "properties" : {
+                        "jsonpath_extract" : {
+                          "$ref" : "#/$defs/processors/jsonpath_extract"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_remove" ],
+                      "properties" : {
+                        "jsonpath_remove" : {
+                          "$ref" : "#/$defs/processors/jsonpath_remove"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_rename" ],
+                      "properties" : {
+                        "jsonpath_rename" : {
+                          "$ref" : "#/$defs/processors/jsonpath_rename"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_set" ],
+                      "properties" : {
+                        "jsonpath_set" : {
+                          "$ref" : "#/$defs/processors/jsonpath_set"
+                        }
+                      }
+                    } ]
+                  }
+                },
+                "error_handler" : {
+                  "type" : "object",
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "dead_letter_queue" ],
+                    "properties" : {
+                      "dead_letter_queue" : {
+                        "$ref" : "#/$defs/error_handler/dead_letter_queue"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "log" ],
+                    "properties" : {
+                      "log" : {
+                        "$ref" : "#/$defs/error_handler/log"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "stop" ],
+                    "properties" : {
+                      "stop" : {
+                        "$ref" : "#/$defs/error_handler/stop"
+                      }
+                    }
+                  } ]
+                }
+              },
+              "$defs" : {
+                "processors" : {
+                  "throttle" : {
+                    "title" : "Throttle Action",
+                    "description" : "The Throttle action allows to ensure that a specific sink does not get overloaded.",
+                    "required" : [ "messages" ],
+                    "properties" : {
+                      "messages" : {
+                        "title" : "Messages Number",
+                        "description" : "The number of messages to send in the time period set",
+                        "type" : "integer",
+                        "example" : 10
+                      },
+                      "timePeriod" : {
+                        "title" : "Time Period",
+                        "description" : "Sets the time period during which the maximum request count is valid for, in milliseconds",
+                        "type" : "string",
+                        "default" : "1000"
+                      }
+                    },
+                    "type" : "object"
+                  },
+                  "log" : {
+                    "title" : "Log",
+                    "description" : "Log payload.",
+                    "type" : "object",
+                    "properties" : {
+                      "multiLine" : {
+                        "title" : "Multi Line",
+                        "description" : "Multi Line",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showProperties" : {
+                        "title" : "Show Properties",
+                        "description" : "Show Properties",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showHeaders" : {
+                        "title" : "Show Headers",
+                        "description" : "Show Headers",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      }
+                    }
+                  },
+                  "jsonpath_extract" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_remove" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_rename" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "newKey" : {
+                        "title" : "NewKey",
+                        "description" : "NewKey",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_set" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "title" : "Value",
+                        "description" : "Value",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "dead_letter_queue" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "topic" ],
+                    "properties" : {
+                      "topic" : {
+                        "type" : "string",
+                        "title" : "Dead Letter Topic Name",
+                        "description" : "The name of the Kafka topic used as dead letter queue"
+                      }
+                    }
+                  },
+                  "log" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  },
+                  "stop" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  }
+                }
+              }
+            }
+          }
+        }
+      minio_sink_0.1.json: |-
+        {
+          "channels" : {
+            "stable" : {
+              "shard_metadata" : {
+                "connector_revision" : "8",
+                "connector_type" : "sink",
+                "connector_image" : "quay.io/rhoas/cos-connector-minio:0.1.8",
+                "operators" : [ {
+                  "type" : "camel-connector-operator",
+                  "version" : "[1.0.0,2.0.0)"
+                } ],
+                "kamelets" : {
+                  "adapter" : {
+                    "name" : "minio-sink",
+                    "prefix" : "minio"
+                  },
+                  "kafka" : {
+                    "name" : "cos-kafka-source",
+                    "prefix" : "kafka"
+                  },
+                  "processors" : {
+                    "throttle" : "throttle-action",
+                    "jsonpath_set" : "cos-jsonpath-set-action",
+                    "log" : "cos-log-action",
+                    "jsonpath_rename" : "cos-jsonpath-rename-action",
+                    "jsonpath_extract" : "cos-jsonpath-extract-action",
+                    "jsonpath_remove" : "cos-jsonpath-remove-action"
+                  }
+                },
+                "annotations" : {
+                  "trait.camel.apache.org/container.request-memory" : "256m"
+                }
+              }
+            }
+          },
+          "connector_type" : {
+            "id" : "minio_sink_0.1",
+            "kind" : "ConnectorType",
+            "icon_href" : "TODO",
+            "name" : "Minio Sink",
+            "description" : "Minio Sink",
+            "version" : "0.1",
+            "labels" : [ "sink" ],
+            "capabilities" : [ "error_handler", "processors" ],
+            "channels" : [ "stable" ],
+            "schema" : {
+              "type" : "object",
+              "required" : [ "minio_bucket_name", "minio_access_key", "minio_secret_key", "minio_endpoint", "kafka_topic" ],
+              "properties" : {
+                "minio_bucket_name" : {
+                  "title" : "Bucket Name",
+                  "description" : "The Minio Bucket name",
+                  "type" : "string"
+                },
+                "minio_access_key" : {
+                  "title" : "Access Key",
+                  "x-group" : "credentials",
+                  "oneOf" : [ {
+                    "title" : "Access Key",
+                    "description" : "The access key obtained from Minio",
+                    "type" : "string",
+                    "format" : "password"
+                  }, {
+                    "description" : "An opaque reference to the minio_access_key",
+                    "type" : "object",
+                    "properties" : { }
+                  } ]
+                },
+                "minio_secret_key" : {
+                  "title" : "Secret Key",
+                  "x-group" : "credentials",
+                  "oneOf" : [ {
+                    "title" : "Secret Key",
+                    "description" : "The secret key obtained from Minio",
+                    "type" : "string",
+                    "format" : "password"
+                  }, {
+                    "description" : "An opaque reference to the minio_secret_key",
+                    "type" : "object",
+                    "properties" : { }
+                  } ]
+                },
+                "minio_endpoint" : {
+                  "title" : "Endpoint",
+                  "description" : "The Minio Endpoint, it can be an URL, domain name, IPv4 address or IPv6 address.",
+                  "type" : "string",
+                  "example" : "http://localhost:9000"
+                },
+                "minio_auto_create_bucket" : {
+                  "title" : "Autocreate Bucket",
+                  "description" : "Setting the autocreation of the Minio bucket bucketName.",
+                  "type" : "boolean",
+                  "default" : false
+                },
+                "kafka_topic" : {
+                  "title" : "Topic Names",
+                  "description" : "Comma separated list of Kafka topic names",
+                  "type" : "string"
+                },
+                "processors" : {
+                  "type" : "array",
+                  "items" : {
+                    "oneOf" : [ {
+                      "type" : "object",
+                      "required" : [ "throttle" ],
+                      "properties" : {
+                        "throttle" : {
+                          "$ref" : "#/$defs/processors/throttle"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "log" ],
+                      "properties" : {
+                        "log" : {
+                          "$ref" : "#/$defs/processors/log"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_extract" ],
+                      "properties" : {
+                        "jsonpath_extract" : {
+                          "$ref" : "#/$defs/processors/jsonpath_extract"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_remove" ],
+                      "properties" : {
+                        "jsonpath_remove" : {
+                          "$ref" : "#/$defs/processors/jsonpath_remove"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_rename" ],
+                      "properties" : {
+                        "jsonpath_rename" : {
+                          "$ref" : "#/$defs/processors/jsonpath_rename"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_set" ],
+                      "properties" : {
+                        "jsonpath_set" : {
+                          "$ref" : "#/$defs/processors/jsonpath_set"
+                        }
+                      }
+                    } ]
+                  }
+                },
+                "error_handler" : {
+                  "type" : "object",
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "dead_letter_queue" ],
+                    "properties" : {
+                      "dead_letter_queue" : {
+                        "$ref" : "#/$defs/error_handler/dead_letter_queue"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "log" ],
+                    "properties" : {
+                      "log" : {
+                        "$ref" : "#/$defs/error_handler/log"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "stop" ],
+                    "properties" : {
+                      "stop" : {
+                        "$ref" : "#/$defs/error_handler/stop"
+                      }
+                    }
+                  } ]
+                }
+              },
+              "$defs" : {
+                "processors" : {
+                  "throttle" : {
+                    "title" : "Throttle Action",
+                    "description" : "The Throttle action allows to ensure that a specific sink does not get overloaded.",
+                    "required" : [ "messages" ],
+                    "properties" : {
+                      "messages" : {
+                        "title" : "Messages Number",
+                        "description" : "The number of messages to send in the time period set",
+                        "type" : "integer",
+                        "example" : 10
+                      },
+                      "timePeriod" : {
+                        "title" : "Time Period",
+                        "description" : "Sets the time period during which the maximum request count is valid for, in milliseconds",
+                        "type" : "string",
+                        "default" : "1000"
+                      }
+                    },
+                    "type" : "object"
+                  },
+                  "log" : {
+                    "title" : "Log",
+                    "description" : "Log payload.",
+                    "type" : "object",
+                    "properties" : {
+                      "multiLine" : {
+                        "title" : "Multi Line",
+                        "description" : "Multi Line",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showProperties" : {
+                        "title" : "Show Properties",
+                        "description" : "Show Properties",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showHeaders" : {
+                        "title" : "Show Headers",
+                        "description" : "Show Headers",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      }
+                    }
+                  },
+                  "jsonpath_extract" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_remove" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_rename" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "newKey" : {
+                        "title" : "NewKey",
+                        "description" : "NewKey",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_set" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "title" : "Value",
+                        "description" : "Value",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "dead_letter_queue" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "topic" ],
+                    "properties" : {
+                      "topic" : {
+                        "type" : "string",
+                        "title" : "Dead Letter Topic Name",
+                        "description" : "The name of the Kafka topic used as dead letter queue"
+                      }
+                    }
+                  },
+                  "log" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  },
+                  "stop" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  }
+                }
+              }
+            }
+          }
+        }
+      minio_source_0.1.json: |-
+        {
+          "channels" : {
+            "stable" : {
+              "shard_metadata" : {
+                "connector_revision" : "8",
+                "connector_type" : "source",
+                "connector_image" : "quay.io/rhoas/cos-connector-minio:0.1.8",
+                "operators" : [ {
+                  "type" : "camel-connector-operator",
+                  "version" : "[1.0.0,2.0.0)"
+                } ],
+                "kamelets" : {
+                  "adapter" : {
+                    "name" : "minio-source",
+                    "prefix" : "minio"
+                  },
+                  "kafka" : {
+                    "name" : "cos-kafka-sink",
+                    "prefix" : "kafka"
+                  },
+                  "processors" : {
+                    "throttle" : "throttle-action",
+                    "jsonpath_set" : "cos-jsonpath-set-action",
+                    "log" : "cos-log-action",
+                    "jsonpath_rename" : "cos-jsonpath-rename-action",
+                    "jsonpath_extract" : "cos-jsonpath-extract-action",
+                    "jsonpath_remove" : "cos-jsonpath-remove-action"
+                  }
+                },
+                "annotations" : {
+                  "trait.camel.apache.org/container.request-memory" : "256m"
+                },
+                "consumes" : "application/json",
+                "produces" : "application/json"
+              }
+            }
+          },
+          "connector_type" : {
+            "id" : "minio_source_0.1",
+            "kind" : "ConnectorType",
+            "icon_href" : "TODO",
+            "name" : "Minio Source",
+            "description" : "Minio Source",
+            "version" : "0.1",
+            "labels" : [ "source" ],
+            "capabilities" : [ "data_shape", "error_handler", "processors" ],
+            "channels" : [ "stable" ],
+            "schema" : {
+              "type" : "object",
+              "required" : [ "minio_bucket_name", "minio_access_key", "minio_secret_key", "minio_endpoint", "kafka_topic" ],
+              "properties" : {
+                "minio_bucket_name" : {
+                  "title" : "Bucket Name",
+                  "description" : "The Minio Bucket name",
+                  "type" : "string"
+                },
+                "minio_delete_after_read" : {
+                  "title" : "Auto-delete Objects",
+                  "description" : "Delete objects after consuming them",
+                  "type" : "boolean",
+                  "default" : true
+                },
+                "minio_access_key" : {
+                  "title" : "Access Key",
+                  "x-group" : "credentials",
+                  "oneOf" : [ {
+                    "title" : "Access Key",
+                    "description" : "The access key obtained from Minio",
+                    "type" : "string",
+                    "format" : "password"
+                  }, {
+                    "description" : "An opaque reference to the minio_access_key",
+                    "type" : "object",
+                    "properties" : { }
+                  } ]
+                },
+                "minio_secret_key" : {
+                  "title" : "Secret Key",
+                  "x-group" : "credentials",
+                  "oneOf" : [ {
+                    "title" : "Secret Key",
+                    "description" : "The secret key obtained from Minio",
+                    "type" : "string",
+                    "format" : "password"
+                  }, {
+                    "description" : "An opaque reference to the minio_secret_key",
+                    "type" : "object",
+                    "properties" : { }
+                  } ]
+                },
+                "minio_endpoint" : {
+                  "title" : "Endpoint",
+                  "description" : "The Minio Endpoint, it can be an URL, domain name, IPv4 address or IPv6 address.",
+                  "type" : "string",
+                  "example" : "http://localhost:9000"
+                },
+                "minio_auto_create_bucket" : {
+                  "title" : "Autocreate Bucket",
+                  "description" : "Setting the autocreation of the Minio bucket bucketName.",
+                  "type" : "boolean",
+                  "default" : false
+                },
+                "kafka_topic" : {
+                  "title" : "Topic Names",
+                  "description" : "Comma separated list of Kafka topic names",
+                  "type" : "string"
+                },
+                "processors" : {
+                  "type" : "array",
+                  "items" : {
+                    "oneOf" : [ {
+                      "type" : "object",
+                      "required" : [ "throttle" ],
+                      "properties" : {
+                        "throttle" : {
+                          "$ref" : "#/$defs/processors/throttle"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "log" ],
+                      "properties" : {
+                        "log" : {
+                          "$ref" : "#/$defs/processors/log"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_extract" ],
+                      "properties" : {
+                        "jsonpath_extract" : {
+                          "$ref" : "#/$defs/processors/jsonpath_extract"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_remove" ],
+                      "properties" : {
+                        "jsonpath_remove" : {
+                          "$ref" : "#/$defs/processors/jsonpath_remove"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_rename" ],
+                      "properties" : {
+                        "jsonpath_rename" : {
+                          "$ref" : "#/$defs/processors/jsonpath_rename"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_set" ],
+                      "properties" : {
+                        "jsonpath_set" : {
+                          "$ref" : "#/$defs/processors/jsonpath_set"
+                        }
+                      }
+                    } ]
+                  }
+                },
+                "data_shape" : {
+                  "type" : "object",
+                  "additionalProperties" : false,
+                  "properties" : {
+                    "produces" : {
+                      "$ref" : "#/$defs/data_shape/produces"
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "type" : "object",
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "dead_letter_queue" ],
+                    "properties" : {
+                      "dead_letter_queue" : {
+                        "$ref" : "#/$defs/error_handler/dead_letter_queue"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "log" ],
+                    "properties" : {
+                      "log" : {
+                        "$ref" : "#/$defs/error_handler/log"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "stop" ],
+                    "properties" : {
+                      "stop" : {
+                        "$ref" : "#/$defs/error_handler/stop"
+                      }
+                    }
+                  } ]
+                }
+              },
+              "$defs" : {
+                "processors" : {
+                  "throttle" : {
+                    "title" : "Throttle Action",
+                    "description" : "The Throttle action allows to ensure that a specific sink does not get overloaded.",
+                    "required" : [ "messages" ],
+                    "properties" : {
+                      "messages" : {
+                        "title" : "Messages Number",
+                        "description" : "The number of messages to send in the time period set",
+                        "type" : "integer",
+                        "example" : 10
+                      },
+                      "timePeriod" : {
+                        "title" : "Time Period",
+                        "description" : "Sets the time period during which the maximum request count is valid for, in milliseconds",
+                        "type" : "string",
+                        "default" : "1000"
+                      }
+                    },
+                    "type" : "object"
+                  },
+                  "log" : {
+                    "title" : "Log",
+                    "description" : "Log payload.",
+                    "type" : "object",
+                    "properties" : {
+                      "multiLine" : {
+                        "title" : "Multi Line",
+                        "description" : "Multi Line",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showProperties" : {
+                        "title" : "Show Properties",
+                        "description" : "Show Properties",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showHeaders" : {
+                        "title" : "Show Headers",
+                        "description" : "Show Headers",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      }
+                    }
+                  },
+                  "jsonpath_extract" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_remove" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_rename" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "newKey" : {
+                        "title" : "NewKey",
+                        "description" : "NewKey",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_set" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "title" : "Value",
+                        "description" : "Value",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  }
+                },
+                "data_shape" : {
+                  "produces" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "format" ],
+                    "properties" : {
+                      "format" : {
+                        "type" : "string",
+                        "default" : "application/json",
+                        "enum" : [ "application/json", "avro/binary" ]
+                      }
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "dead_letter_queue" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "topic" ],
+                    "properties" : {
+                      "topic" : {
+                        "type" : "string",
+                        "title" : "Dead Letter Topic Name",
+                        "description" : "The name of the Kafka topic used as dead letter queue"
+                      }
+                    }
+                  },
+                  "log" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  },
+                  "stop" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  }
+                }
+              }
+            }
+          }
+        }
+      sftp_sink_0.1.json: |-
+        {
+          "channels" : {
+            "stable" : {
+              "shard_metadata" : {
+                "connector_revision" : "8",
+                "connector_type" : "sink",
+                "connector_image" : "quay.io/rhoas/cos-connector-sftp:0.1.8",
+                "operators" : [ {
+                  "type" : "camel-connector-operator",
+                  "version" : "[1.0.0,2.0.0)"
+                } ],
+                "kamelets" : {
+                  "adapter" : {
+                    "name" : "sftp-sink",
+                    "prefix" : "sftp"
+                  },
+                  "kafka" : {
+                    "name" : "cos-kafka-source",
+                    "prefix" : "kafka"
+                  },
+                  "processors" : {
+                    "throttle" : "throttle-action",
+                    "jsonpath_set" : "cos-jsonpath-set-action",
+                    "log" : "cos-log-action",
+                    "jsonpath_rename" : "cos-jsonpath-rename-action",
+                    "jsonpath_extract" : "cos-jsonpath-extract-action",
+                    "jsonpath_remove" : "cos-jsonpath-remove-action"
+                  }
+                }
+              }
+            }
+          },
+          "connector_type" : {
+            "id" : "sftp_sink_0.1",
+            "kind" : "ConnectorType",
+            "icon_href" : "TODO",
+            "name" : "SFTP Sink",
+            "description" : "SFTP Sink",
+            "version" : "0.1",
+            "labels" : [ "sink" ],
+            "capabilities" : [ "error_handler", "processors" ],
+            "channels" : [ "stable" ],
+            "schema" : {
+              "type" : "object",
+              "required" : [ "sftp_connection_host", "sftp_connection_port", "sftp_username", "sftp_password", "sftp_directory_name", "kafka_topic" ],
+              "properties" : {
+                "sftp_connection_host" : {
+                  "title" : "Connection Host",
+                  "description" : "Hostname of the FTP server",
+                  "type" : "string"
+                },
+                "sftp_connection_port" : {
+                  "title" : "Connection Port",
+                  "description" : "Port of the FTP server",
+                  "type" : "string",
+                  "default" : 22
+                },
+                "sftp_username" : {
+                  "title" : "Username",
+                  "description" : "The username to access the FTP server",
+                  "type" : "string",
+                  "x-group" : "credentials"
+                },
+                "sftp_password" : {
+                  "title" : "Password",
+                  "x-group" : "credentials",
+                  "oneOf" : [ {
+                    "title" : "Password",
+                    "description" : "The password to access the FTP server",
+                    "type" : "string",
+                    "format" : "password"
+                  }, {
+                    "description" : "An opaque reference to the sftp_password",
+                    "type" : "object",
+                    "properties" : { }
+                  } ]
+                },
+                "sftp_directory_name" : {
+                  "title" : "Directory Name",
+                  "description" : "The starting directory",
+                  "type" : "string"
+                },
+                "sftp_passive_mode" : {
+                  "title" : "Passive Mode",
+                  "description" : "Sets passive mode connection",
+                  "type" : "boolean",
+                  "default" : false
+                },
+                "sftp_file_exist" : {
+                  "title" : "File Existence",
+                  "description" : "How to behave in case of file already existent. There are 4 enums and the value can be one of Override, Append, Fail or Ignore",
+                  "type" : "string",
+                  "default" : "Override"
+                },
+                "kafka_topic" : {
+                  "title" : "Topic Names",
+                  "description" : "Comma separated list of Kafka topic names",
+                  "type" : "string"
+                },
+                "processors" : {
+                  "type" : "array",
+                  "items" : {
+                    "oneOf" : [ {
+                      "type" : "object",
+                      "required" : [ "throttle" ],
+                      "properties" : {
+                        "throttle" : {
+                          "$ref" : "#/$defs/processors/throttle"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "log" ],
+                      "properties" : {
+                        "log" : {
+                          "$ref" : "#/$defs/processors/log"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_extract" ],
+                      "properties" : {
+                        "jsonpath_extract" : {
+                          "$ref" : "#/$defs/processors/jsonpath_extract"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_remove" ],
+                      "properties" : {
+                        "jsonpath_remove" : {
+                          "$ref" : "#/$defs/processors/jsonpath_remove"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_rename" ],
+                      "properties" : {
+                        "jsonpath_rename" : {
+                          "$ref" : "#/$defs/processors/jsonpath_rename"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_set" ],
+                      "properties" : {
+                        "jsonpath_set" : {
+                          "$ref" : "#/$defs/processors/jsonpath_set"
+                        }
+                      }
+                    } ]
+                  }
+                },
+                "error_handler" : {
+                  "type" : "object",
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "dead_letter_queue" ],
+                    "properties" : {
+                      "dead_letter_queue" : {
+                        "$ref" : "#/$defs/error_handler/dead_letter_queue"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "log" ],
+                    "properties" : {
+                      "log" : {
+                        "$ref" : "#/$defs/error_handler/log"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "stop" ],
+                    "properties" : {
+                      "stop" : {
+                        "$ref" : "#/$defs/error_handler/stop"
+                      }
+                    }
+                  } ]
+                }
+              },
+              "$defs" : {
+                "processors" : {
+                  "throttle" : {
+                    "title" : "Throttle Action",
+                    "description" : "The Throttle action allows to ensure that a specific sink does not get overloaded.",
+                    "required" : [ "messages" ],
+                    "properties" : {
+                      "messages" : {
+                        "title" : "Messages Number",
+                        "description" : "The number of messages to send in the time period set",
+                        "type" : "integer",
+                        "example" : 10
+                      },
+                      "timePeriod" : {
+                        "title" : "Time Period",
+                        "description" : "Sets the time period during which the maximum request count is valid for, in milliseconds",
+                        "type" : "string",
+                        "default" : "1000"
+                      }
+                    },
+                    "type" : "object"
+                  },
+                  "log" : {
+                    "title" : "Log",
+                    "description" : "Log payload.",
+                    "type" : "object",
+                    "properties" : {
+                      "multiLine" : {
+                        "title" : "Multi Line",
+                        "description" : "Multi Line",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showProperties" : {
+                        "title" : "Show Properties",
+                        "description" : "Show Properties",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showHeaders" : {
+                        "title" : "Show Headers",
+                        "description" : "Show Headers",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      }
+                    }
+                  },
+                  "jsonpath_extract" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_remove" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_rename" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "newKey" : {
+                        "title" : "NewKey",
+                        "description" : "NewKey",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_set" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "title" : "Value",
+                        "description" : "Value",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "dead_letter_queue" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "topic" ],
+                    "properties" : {
+                      "topic" : {
+                        "type" : "string",
+                        "title" : "Dead Letter Topic Name",
+                        "description" : "The name of the Kafka topic used as dead letter queue"
+                      }
+                    }
+                  },
+                  "log" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  },
+                  "stop" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  }
+                }
+              }
+            }
+          }
+        }
+      sftp_source_0.1.json: |-
+        {
+          "channels" : {
+            "stable" : {
+              "shard_metadata" : {
+                "connector_revision" : "8",
+                "connector_type" : "source",
+                "connector_image" : "quay.io/rhoas/cos-connector-sftp:0.1.8",
+                "operators" : [ {
+                  "type" : "camel-connector-operator",
+                  "version" : "[1.0.0,2.0.0)"
+                } ],
+                "kamelets" : {
+                  "adapter" : {
+                    "name" : "sftp-source",
+                    "prefix" : "sftp"
+                  },
+                  "kafka" : {
+                    "name" : "cos-kafka-sink",
+                    "prefix" : "kafka"
+                  },
+                  "processors" : {
+                    "throttle" : "throttle-action",
+                    "jsonpath_set" : "cos-jsonpath-set-action",
+                    "log" : "cos-log-action",
+                    "jsonpath_rename" : "cos-jsonpath-rename-action",
+                    "jsonpath_extract" : "cos-jsonpath-extract-action",
+                    "jsonpath_remove" : "cos-jsonpath-remove-action"
+                  }
+                }
+              }
+            }
+          },
+          "connector_type" : {
+            "id" : "sftp_source_0.1",
+            "kind" : "ConnectorType",
+            "icon_href" : "TODO",
+            "name" : "SFTP Source",
+            "description" : "SFTP Source",
+            "version" : "0.1",
+            "labels" : [ "source" ],
+            "capabilities" : [ "error_handler", "processors" ],
+            "channels" : [ "stable" ],
+            "schema" : {
+              "type" : "object",
+              "required" : [ "sftp_connection_host", "sftp_connection_port", "sftp_username", "sftp_password", "sftp_directory_name", "kafka_topic" ],
+              "properties" : {
+                "sftp_connection_host" : {
+                  "title" : "Connection Host",
+                  "description" : "Hostname of the SFTP server",
+                  "type" : "string"
+                },
+                "sftp_connection_port" : {
+                  "title" : "Connection Port",
+                  "description" : "Port of the FTP server",
+                  "type" : "string",
+                  "default" : 22
+                },
+                "sftp_username" : {
+                  "title" : "Username",
+                  "description" : "The username to access the SFTP server",
+                  "type" : "string",
+                  "x-group" : "credentials"
+                },
+                "sftp_password" : {
+                  "title" : "Password",
+                  "x-group" : "credentials",
+                  "oneOf" : [ {
+                    "title" : "Password",
+                    "description" : "The password to access the SFTP server",
+                    "type" : "string",
+                    "format" : "password"
+                  }, {
+                    "description" : "An opaque reference to the sftp_password",
+                    "type" : "object",
+                    "properties" : { }
+                  } ]
+                },
+                "sftp_directory_name" : {
+                  "title" : "Directory Name",
+                  "description" : "The starting directory",
+                  "type" : "string"
+                },
+                "sftp_passive_mode" : {
+                  "title" : "Passive Mode",
+                  "description" : "Sets passive mode connection",
+                  "type" : "boolean",
+                  "default" : false
+                },
+                "sftp_recursive" : {
+                  "title" : "Recursive",
+                  "description" : "If a directory, will look for files in all the sub-directories as well.",
+                  "type" : "boolean",
+                  "default" : false
+                },
+                "sftp_idempotent" : {
+                  "title" : "Idempotency",
+                  "description" : "Skip already processed files.",
+                  "type" : "boolean",
+                  "default" : true
+                },
+                "kafka_topic" : {
+                  "title" : "Topic Names",
+                  "description" : "Comma separated list of Kafka topic names",
+                  "type" : "string"
+                },
+                "processors" : {
+                  "type" : "array",
+                  "items" : {
+                    "oneOf" : [ {
+                      "type" : "object",
+                      "required" : [ "throttle" ],
+                      "properties" : {
+                        "throttle" : {
+                          "$ref" : "#/$defs/processors/throttle"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "log" ],
+                      "properties" : {
+                        "log" : {
+                          "$ref" : "#/$defs/processors/log"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_extract" ],
+                      "properties" : {
+                        "jsonpath_extract" : {
+                          "$ref" : "#/$defs/processors/jsonpath_extract"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_remove" ],
+                      "properties" : {
+                        "jsonpath_remove" : {
+                          "$ref" : "#/$defs/processors/jsonpath_remove"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_rename" ],
+                      "properties" : {
+                        "jsonpath_rename" : {
+                          "$ref" : "#/$defs/processors/jsonpath_rename"
+                        }
+                      }
+                    }, {
+                      "type" : "object",
+                      "required" : [ "jsonpath_set" ],
+                      "properties" : {
+                        "jsonpath_set" : {
+                          "$ref" : "#/$defs/processors/jsonpath_set"
+                        }
+                      }
+                    } ]
+                  }
+                },
+                "error_handler" : {
+                  "type" : "object",
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "dead_letter_queue" ],
+                    "properties" : {
+                      "dead_letter_queue" : {
+                        "$ref" : "#/$defs/error_handler/dead_letter_queue"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "log" ],
+                    "properties" : {
+                      "log" : {
+                        "$ref" : "#/$defs/error_handler/log"
+                      }
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "stop" ],
+                    "properties" : {
+                      "stop" : {
+                        "$ref" : "#/$defs/error_handler/stop"
+                      }
+                    }
+                  } ]
+                }
+              },
+              "$defs" : {
+                "processors" : {
+                  "throttle" : {
+                    "title" : "Throttle Action",
+                    "description" : "The Throttle action allows to ensure that a specific sink does not get overloaded.",
+                    "required" : [ "messages" ],
+                    "properties" : {
+                      "messages" : {
+                        "title" : "Messages Number",
+                        "description" : "The number of messages to send in the time period set",
+                        "type" : "integer",
+                        "example" : 10
+                      },
+                      "timePeriod" : {
+                        "title" : "Time Period",
+                        "description" : "Sets the time period during which the maximum request count is valid for, in milliseconds",
+                        "type" : "string",
+                        "default" : "1000"
+                      }
+                    },
+                    "type" : "object"
+                  },
+                  "log" : {
+                    "title" : "Log",
+                    "description" : "Log payload.",
+                    "type" : "object",
+                    "properties" : {
+                      "multiLine" : {
+                        "title" : "Multi Line",
+                        "description" : "Multi Line",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showProperties" : {
+                        "title" : "Show Properties",
+                        "description" : "Show Properties",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      },
+                      "showHeaders" : {
+                        "title" : "Show Headers",
+                        "description" : "Show Headers",
+                        "type" : "boolean",
+                        "default" : false,
+                        "x-descriptors" : [ "urn:camel:group:common" ]
+                      }
+                    }
+                  },
+                  "jsonpath_extract" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_remove" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_rename" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "newKey" : {
+                        "title" : "NewKey",
+                        "description" : "NewKey",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  },
+                  "jsonpath_set" : {
+                    "title" : "Transform with JsonPath",
+                    "description" : "TBD",
+                    "type" : "object",
+                    "required" : [ "expression" ],
+                    "properties" : {
+                      "expression" : {
+                        "title" : "Expression",
+                        "description" : "Expression",
+                        "type" : "string"
+                      },
+                      "key" : {
+                        "title" : "Key",
+                        "description" : "Key",
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "title" : "Value",
+                        "description" : "Value",
+                        "type" : "string"
+                      }
+                    },
+                    "x-metadata" : {
+                      "supported.content-type" : "application/x-struct"
+                    }
+                  }
+                },
+                "error_handler" : {
+                  "dead_letter_queue" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "required" : [ "topic" ],
+                    "properties" : {
+                      "topic" : {
+                        "type" : "string",
+                        "title" : "Dead Letter Topic Name",
+                        "description" : "The name of the Kafka topic used as dead letter queue"
+                      }
+                    }
+                  },
+                  "log" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  },
+                  "stop" : {
+                    "type" : "object",
+                    "additionalProperties" : false
+                  }
+                }
+              }
+            }
+          }
+        }
+    kind: ConfigMap
+    metadata:
+      creationTimestamp: null
+      name: connector-catalog-camel-storage


### PR DESCRIPTION
Sometimes it is required to deliver the connector catalog as a template, in order to integrate with 3rd party systems. This commit adds that functionality in a very simplistic way

Signed-off-by: Luis Garcia Acosta <lgarciaa@redhat.com>