### PR TITLE
MGDCTRS-886: fix prefix generation

### DIFF
--- a/cos-fleet-catalog-connectors/messaging/jms-amqp-0.1/src/generated/resources/connectors/jms_amqp_10_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/messaging/jms-amqp-0.1/src/generated/resources/connectors/jms_amqp_10_sink_0.1.json
@@ -15,7 +15,7 @@
         "kamelets" : {
           "adapter" : {
             "name" : "jms-amqp-10-sink",
-            "prefix" : "jms-amqp"
+            "prefix" : "jms_amqp"
           },
           "kafka" : {
             "name" : "cos-kafka-source",

--- a/cos-fleet-catalog-connectors/messaging/jms-amqp-0.1/src/generated/resources/connectors/jms_amqp_10_source_0.1.json
+++ b/cos-fleet-catalog-connectors/messaging/jms-amqp-0.1/src/generated/resources/connectors/jms_amqp_10_source_0.1.json
@@ -15,7 +15,7 @@
         "kamelets" : {
           "adapter" : {
             "name" : "jms-amqp-10-source",
-            "prefix" : "jms-amqp"
+            "prefix" : "jms_amqp"
           },
           "kafka" : {
             "name" : "cos-kafka-sink",

--- a/cos-fleet-catalog-connectors/messaging/jms-artemis-0.1/src/generated/resources/connectors/jms_apache_artemis_source_0.1.json
+++ b/cos-fleet-catalog-connectors/messaging/jms-artemis-0.1/src/generated/resources/connectors/jms_apache_artemis_source_0.1.json
@@ -15,7 +15,7 @@
         "kamelets" : {
           "adapter" : {
             "name" : "jms-apache-artemis-source",
-            "prefix" : "jms-artemis"
+            "prefix" : "jms_artemis"
           },
           "kafka" : {
             "name" : "cos-kafka-sink",

--- a/cos-fleet-catalog-connectors/messaging/openapi-0.1/src/generated/resources/connectors/rest_openapi_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/messaging/openapi-0.1/src/generated/resources/connectors/rest_openapi_sink_0.1.json
@@ -15,7 +15,7 @@
         "kamelets" : {
           "adapter" : {
             "name" : "rest-openapi-sink",
-            "prefix" : "rest-openapi"
+            "prefix" : "rest_openapi"
           },
           "kafka" : {
             "name" : "cos-kafka-source",

--- a/cos-fleet-catalog-tools/camel-connector-maven-plugin/src/main/java/org/bf2/cos/catalog/camel/maven/connector/GenerateCatalogMojo.java
+++ b/cos-fleet-catalog-tools/camel-connector-maven-plugin/src/main/java/org/bf2/cos/catalog/camel/maven/connector/GenerateCatalogMojo.java
@@ -220,7 +220,7 @@ public class GenerateCatalogMojo extends AbstractMojo {
                             ch.getValue().getOperatorVersion()));
 
                     metadata.getKamelets().getAdapter().setName(adapter.getName());
-                    metadata.getKamelets().getAdapter().setPrefix(adapter.getPrefix());
+                    metadata.getKamelets().getAdapter().setPrefix(asKey(adapter.getPrefix()));
 
                     metadata.getKamelets().getKafka().setName(kafka.getName());
                     metadata.getKamelets().getKafka().setPrefix(kafka.getPrefix());

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-messaging/jms_amqp_10_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-messaging/jms_amqp_10_sink_0.1.json
@@ -15,7 +15,7 @@
         "kamelets" : {
           "adapter" : {
             "name" : "jms-amqp-10-sink",
-            "prefix" : "jms-amqp"
+            "prefix" : "jms_amqp"
           },
           "kafka" : {
             "name" : "cos-kafka-source",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-messaging/jms_amqp_10_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-messaging/jms_amqp_10_source_0.1.json
@@ -15,7 +15,7 @@
         "kamelets" : {
           "adapter" : {
             "name" : "jms-amqp-10-source",
-            "prefix" : "jms-amqp"
+            "prefix" : "jms_amqp"
           },
           "kafka" : {
             "name" : "cos-kafka-sink",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-messaging/jms_apache_artemis_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-messaging/jms_apache_artemis_source_0.1.json
@@ -15,7 +15,7 @@
         "kamelets" : {
           "adapter" : {
             "name" : "jms-apache-artemis-source",
-            "prefix" : "jms-artemis"
+            "prefix" : "jms_artemis"
           },
           "kafka" : {
             "name" : "cos-kafka-sink",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-messaging/rest_openapi_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-messaging/rest_openapi_sink_0.1.json
@@ -15,7 +15,7 @@
         "kamelets" : {
           "adapter" : {
             "name" : "rest-openapi-sink",
-            "prefix" : "rest-openapi"
+            "prefix" : "rest_openapi"
           },
           "kafka" : {
             "name" : "cos-kafka-source",


### PR DESCRIPTION
Fixes prefix generation which was ending up different between spec and properties, which made properties not being applied by the camel operator when prefix had an hyphen: https://issues.redhat.com/browse/MGDCTRS-886