### PR TITLE
chore: properly set the build context when generating the catalog

### DIFF
--- a/.github/workflows/build-tag.yaml
+++ b/.github/workflows/build-tag.yaml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Build Catalog Image
         run: |
-          docker build -t "quay.io/rhoas/cos-fleet-catalog-camel:${CONNECTORS_RELEASE}" -f etc/Dockerfile.catalog .
+          docker build -t "quay.io/rhoas/cos-fleet-catalog-camel:${CONNECTORS_RELEASE}" -f etc/Dockerfile.catalog ./etc
 
       - name: List Images
         run: |

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Build Catalog Image
         run: |
-          docker build -t "quay.io/rhoas/cos-fleet-catalog-camel:${CONNECTORS_RELEASE}" -f etc/Dockerfile.catalog .
+          docker build -t "quay.io/rhoas/cos-fleet-catalog-camel:${CONNECTORS_RELEASE}" -f etc/Dockerfile.catalog ./etc
           docker tag "quay.io/rhoas/cos-fleet-catalog-camel:${CONNECTORS_RELEASE}" "quay.io/rhoas/cos-fleet-catalog-camel:latest"
 
       - name: Push Container Images

--- a/etc/Dockerfile.catalog
+++ b/etc/Dockerfile.catalog
@@ -1,6 +1,6 @@
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5
 
-COPY etc/kubernetes/manifests/base/connectors /etc/connectors
+COPY kubernetes/manifests/base/connectors /etc/connectors
 
 LABEL name="cos-fleet-catalog-camel" \
       vendor="Red Hat" \


### PR DESCRIPTION
Docker send the entire content of the build context to the daemon, this
commit changes the path of the context to be etc so we can reduce the
amount of data that is sent to docker
