### PR TITLE
MGDCTRS-1414: make possible to test dlq error handler

### DIFF
--- a/cos-connector-camel/runtime/src/main/java/org/bf2/cos/connector/camel/processor/SimulateErrorProcessor.java
+++ b/cos-connector-camel/runtime/src/main/java/org/bf2/cos/connector/camel/processor/SimulateErrorProcessor.java
@@ -1,0 +1,10 @@
+package org.bf2.cos.connector.camel.processor;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.TypeConverter;
+
+public class SimulateErrorProcessor {
+    public void process(Exchange exchange, TypeConverter converter) throws Exception {
+        throw new RuntimeException("too bad");
+    }
+}

--- a/cos-fleet-catalog-connectors-it-support/pom.xml
+++ b/cos-fleet-catalog-connectors-it-support/pom.xml
@@ -104,6 +104,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-api</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.spockframework</groupId>
             <artifactId>spock-core</artifactId>
             <exclusions>

--- a/cos-fleet-catalog-connectors-it-support/src/main/groovy/org/bf2/cos/connector/camel/it/support/KafkaConnectorSpec.groovy
+++ b/cos-fleet-catalog-connectors-it-support/src/main/groovy/org/bf2/cos/connector/camel/it/support/KafkaConnectorSpec.groovy
@@ -50,6 +50,17 @@ abstract class KafkaConnectorSpec extends ConnectorSpecSupport {
         return ConnectorContainer.forDefinition(definition).withProperties(properties).witNetwork(network).build()
     }
 
+    ConnectorContainer connectorContainer(String definition,
+                                          Map<String, String> properties,
+                                          String dlqKafkaTopic,
+                                          boolean simulateError) {
+        return ConnectorContainer.forDefinition(definition)
+                .withDlqErrorHandler(dlqKafkaTopic, simulateError)
+                .withProperties(properties)
+                .witNetwork(network)
+                .build()
+    }
+
     ConnectorContainer.Builder connectorContainer(String definition) {
         return ConnectorContainer.forDefinition(definition).witNetwork(network)
     }

--- a/cos-fleet-catalog-connectors-it-support/src/main/java/org/bf2/cos/connector/camel/it/support/ConnectorContainer.java
+++ b/cos-fleet-catalog-connectors-it-support/src/main/java/org/bf2/cos/connector/camel/it/support/ConnectorContainer.java
@@ -256,15 +256,18 @@ public class ConnectorContainer extends GenericContainer<ConnectorContainer> {
 
                     if (dlqKafkaTopic != null) {
                         integration.addObject().with("errorHandler").put("ref", "defaultErrorHandler");
-                        answer.withUserProperties(Map.of(
-                                "camel.beans.defaultErrorHandler",
-                                "#class:org.apache.camel.builder.DeadLetterChannelBuilder",
-                                "camel.beans.defaultErrorHandler.deadLetterUri",
-                                "kamelet:cos-kafka-not-secured-sink/errorHandler",
-                                "camel.kamelet.cos-kafka-not-secured-sink.errorHandler.bootstrapServers",
-                                properties.get("kafka_bootstrap_servers"),
-                                "camel.kamelet.cos-kafka-not-secured-sink.errorHandler.topic",
-                                dlqKafkaTopic));
+                        answer.withUserProperties(
+                                Map.of(
+                                        "camel.beans.defaultErrorHandler",
+                                        "#class:org.apache.camel.builder.DeadLetterChannelBuilder",
+                                        "camel.beans.defaultErrorHandler.deadLetterUri",
+                                        "kamelet:cos-kafka-not-secured-sink/errorHandler",
+                                        "camel.kamelet.cos-kafka-not-secured-sink.errorHandler.bootstrapServers",
+                                        properties.get("kafka_bootstrap_servers"),
+                                        "camel.kamelet.cos-kafka-not-secured-sink.errorHandler.topic",
+                                        dlqKafkaTopic,
+                                        "camel.beans.defaultErrorHandler.useOriginalMessage",
+                                        "true"));
                     }
 
                     if (consumes != null) {

--- a/cos-fleet-catalog-connectors-it/nosql/mongodb-it/src/test/groovy/org/bf2/cos/connector/camel/it/ConnectorIT.groovy
+++ b/cos-fleet-catalog-connectors-it/nosql/mongodb-it/src/test/groovy/org/bf2/cos/connector/camel/it/ConnectorIT.groovy
@@ -2,7 +2,9 @@ package org.bf2.cos.connector.camel.it
 
 import com.mongodb.client.MongoClients
 import groovy.util.logging.Slf4j
+import org.apache.commons.lang3.StringUtils
 import org.bf2.cos.connector.camel.it.support.KafkaConnectorSpec
+import org.bf2.cos.connector.camel.it.support.TestUtils
 import org.testcontainers.containers.MongoDBContainer
 
 import java.util.concurrent.TimeUnit
@@ -65,4 +67,49 @@ class ConnectorIT extends KafkaConnectorSpec {
             closeQuietly(mongoClient)
             closeQuietly(cnt)
     }
+
+    def "mongodb sink with DLQ"() {
+        setup:
+            def mongoClient = MongoClients.create(db.replicaSetUrl)
+            def database = mongoClient.getDatabase("toys2")
+            def collection = database.getCollection("cards2")
+
+            def topic = topic()
+            def errorHandlerTopic = super.topic();
+            def group = UUID.randomUUID().toString()
+            def payload = '''{ "value": "4", "suit": "hearts" }'''
+
+            def cnt = connectorContainer('mongodb_sink_0.1.json', [
+                    'kafka_topic' : topic,
+                    'kafka_bootstrap_servers': kafka.outsideBootstrapServers,
+                    'kafka_consumer_group': UUID.randomUUID().toString(),
+                    'mongodb_hosts': 'tc-mongodb:27017',
+                    'mongodb_collection': collection.getNamespace().getCollectionName(),
+                    'mongodb_database': database.getName(),
+                    'mongodb_create_collection': 'true',
+            ], errorHandlerTopic, true)
+
+            cnt.start()
+        when:
+            kafka.send(topic, payload)
+        then:
+            def records = kafka.poll(group, topic)
+            records.size() == 1
+            records.first().value() == payload
+
+            await(10, TimeUnit.SECONDS) {
+                return collection.countDocuments(and(eq('value', '4'), eq('suit', 'hearts'))) == 0
+            }
+
+            def errorRecords = kafka.poll(group, errorHandlerTopic)
+            errorRecords.size() == 1
+            def actual = TestUtils.SLURPER.parseText(errorRecords.first().value())
+            def expected = TestUtils.SLURPER.parseText(payload)
+            actual == expected
+
+        cleanup:
+            closeQuietly(mongoClient)
+            closeQuietly(cnt)
+    }
+
 }

--- a/cos-fleet-catalog-connectors-it/sql/postgresql-it/src/test/groovy/org/bf2/cos/connector/camel/it/ConnectorIT.groovy
+++ b/cos-fleet-catalog-connectors-it/sql/postgresql-it/src/test/groovy/org/bf2/cos/connector/camel/it/ConnectorIT.groovy
@@ -3,6 +3,7 @@ package org.bf2.cos.connector.camel.it
 import groovy.sql.Sql
 import groovy.util.logging.Slf4j
 import org.bf2.cos.connector.camel.it.support.KafkaConnectorSpec
+import org.bf2.cos.connector.camel.it.support.TestUtils
 import org.testcontainers.containers.PostgreSQLContainer
 
 import java.util.concurrent.TimeUnit
@@ -68,4 +69,46 @@ class ConnectorIT extends KafkaConnectorSpec {
             closeQuietly(sql)
             closeQuietly(cnt)
     }
+
+    def "postgresql sink with DLQ"() {
+        setup:
+            def sql = Sql.newInstance(db.jdbcUrl, db.username, db.password, db.driverClassName)
+            def payload = '''{ "username":"oscerd", "city":"Rome" }'''
+
+            def topic = topic()
+            def errorHandlerTopic = super.topic();
+            def group = UUID.randomUUID().toString()
+
+            def cnt = connectorContainer('postgresql_sink_0.1.json', [
+                    'kafka_topic'            : topic,
+                    'kafka_bootstrap_servers': kafka.outsideBootstrapServers,
+                    'kafka_consumer_group'   : UUID.randomUUID().toString(),
+                    'db_server_name'         : 'tc-postgres',
+                    'db_server_port'         : Integer.toString(PostgreSQLContainer.POSTGRESQL_PORT),
+                    'db_username'            : db.username,
+                    'db_password'            : db.password,
+                    'db_query'               : 'INSERT INTO accounts2 (username,city) VALUES (:#username,:#city)',
+                    'db_database_name'       : db.databaseName
+            ],
+                    errorHandlerTopic,
+                    false)
+
+            cnt.start()
+        when:
+            kafka.send(topic, payload)
+        then:
+            def records = kafka.poll(group, topic)
+            records.size() == 1
+            records.first().value() == payload
+
+            def errorRecords = kafka.poll(group, errorHandlerTopic)
+            errorRecords.size() == 1
+            def actual = TestUtils.SLURPER.parseText(errorRecords.first().value())
+            def expected = TestUtils.SLURPER.parseText(payload)
+            actual == expected
+        cleanup:
+            closeQuietly(sql)
+            closeQuietly(cnt)
+    }
+
 }

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <groovy.version>4.0.4</groovy.version>
         <spock.version>2.2-M3-groovy-4.0</spock.version>
         <auto-service.version>1.0.1</auto-service.version>
-        <logback.version>1.4.0</logback.version>
+        <logback.version>1.2.11</logback.version>
         <slf4j.version>1.7.36</slf4j.version>
         <awaitility.version>4.2.0</awaitility.version>
         <rest-assured.version>5.1.1</rest-assured.version>


### PR DESCRIPTION
[MGDCTRS-1414: make possible to test dlq error handler](https://github.com/bf2fc6cc711aee1a0c2a/cos-fleet-catalog-camel/pull/373/commits/f689e199d6d0b5c46440b1b9440b5327aab5743b)
[chore(deps-dev): revert logback to 1.2.11](https://github.com/bf2fc6cc711aee1a0c2a/cos-fleet-catalog-camel/pull/373/commits/b0ec54aecf9f6a0e507cf331ab8cca401f581e92)
[MGDCTRS-1414: test postgres with useOriginalMessage DLQ](https://github.com/bf2fc6cc711aee1a0c2a/cos-fleet-catalog-camel/pull/373/commits/758a0e5f92b6cc079fc9f63d8ca7b316497ebd65)

Tests to https://github.com/bf2fc6cc711aee1a0c2a/cos-fleetshard/pull/454