### PR TITLE
CAMEL-18617: workaround for hidden check when running with supervisor route controller

### DIFF
--- a/.github/workflows/build-pr.yaml
+++ b/.github/workflows/build-pr.yaml
@@ -25,13 +25,13 @@ jobs:
         with:
           java-version: '11'
           distribution: 'temurin'
-      - name: Cache m2 repo
-        uses: actions/cache@v1
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
+      #- name: Cache m2 repo
+      #  uses: actions/cache@v1
+      #  with:
+      #    path: ~/.m2/repository
+      #    key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+      #     restore-keys: |
+      #      ${{ runner.os }}-maven-
       - name: "Build"
         run: |
           ./mvnw ${MAVEN_ARGS} clean install

--- a/cos-connector-camel/deployment/pom.xml
+++ b/cos-connector-camel/deployment/pom.xml
@@ -30,6 +30,14 @@
             <artifactId>camel-quarkus-jackson-avro-deployment</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-microprofile-health-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-kafka-deployment</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.bf2</groupId>
             <artifactId>cos-connector-camel</artifactId>
         </dependency>

--- a/cos-connector-camel/deployment/src/main/java/org/bf2/cos/connector/camel/deployment/ConnectorProcessor.java
+++ b/cos-connector-camel/deployment/src/main/java/org/bf2/cos/connector/camel/deployment/ConnectorProcessor.java
@@ -1,5 +1,6 @@
 package org.bf2.cos.connector.camel.deployment;
 
+import org.apache.camel.quarkus.core.deployment.main.spi.CamelMainListenerBuildItem;
 import org.apache.camel.quarkus.core.deployment.spi.CamelContextCustomizerBuildItem;
 import org.bf2.cos.connector.camel.ConnectorConfig;
 import org.bf2.cos.connector.camel.ConnectorRecorder;
@@ -9,9 +10,16 @@ import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 
 public class ConnectorProcessor {
+
     @Record(ExecutionTime.STATIC_INIT)
     @BuildStep
     CamelContextCustomizerBuildItem customizeContext(ConnectorRecorder recorder, ConnectorConfig config) {
         return new CamelContextCustomizerBuildItem(recorder.createContextCustomizer(config));
+    }
+
+    @Record(ExecutionTime.STATIC_INIT)
+    @BuildStep
+    CamelMainListenerBuildItem customizeMain(ConnectorRecorder recorder, ConnectorConfig config) {
+        return new CamelMainListenerBuildItem(recorder.createMainCustomizer(config));
     }
 }

--- a/cos-connector-camel/runtime/pom.xml
+++ b/cos-connector-camel/runtime/pom.xml
@@ -29,6 +29,14 @@
             <groupId>org.apache.camel.quarkus</groupId>
             <artifactId>camel-quarkus-jackson-avro</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-microprofile-health</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-kafka</artifactId>
+        </dependency>
     </dependencies>
 
 

--- a/cos-connector-camel/runtime/src/main/java/org/apache/camel/microprofile/health/ConnectorHealthCheckRegistry.java
+++ b/cos-connector-camel/runtime/src/main/java/org/apache/camel/microprofile/health/ConnectorHealthCheckRegistry.java
@@ -1,0 +1,209 @@
+package org.apache.camel.microprofile.health;
+
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.StartupListener;
+import org.apache.camel.component.kafka.KafkaHealthCheckRepository;
+import org.apache.camel.health.HealthCheck;
+import org.apache.camel.health.HealthCheckRepository;
+import org.apache.camel.impl.health.ConsumersHealthCheckRepository;
+import org.apache.camel.impl.health.DefaultHealthCheckRegistry;
+import org.apache.camel.impl.health.HealthCheckRegistryRepository;
+import org.apache.camel.impl.health.RoutesHealthCheckRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.smallrye.health.api.HealthRegistry;
+import io.smallrye.health.api.HealthType;
+import io.smallrye.health.registry.HealthRegistries;
+
+/**
+ * Workaround for <a href="https://issues.apache.org/jira/browse/CAMEL-18617">CAMEL-18617</a>
+ *
+ * This must be in the org.apache.camel.microprofile.health as some classes such as the
+ * CamelMicroProfileRepositoryHealthCheck have package private scope in camel-mp-health
+ */
+public class ConnectorHealthCheckRegistry extends DefaultHealthCheckRegistry implements StartupListener {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ConnectorHealthCheckRegistry.class);
+
+    private final Set<HealthCheckRepository> repositories;
+
+    public ConnectorHealthCheckRegistry(CamelContext camelContext) {
+        super(camelContext);
+        super.setId("camel-microprofile-health");
+
+        this.repositories = new CopyOnWriteArraySet<>();
+    }
+
+    @Override
+    protected void doInit() throws Exception {
+        super.doInit();
+        super.getCamelContext().addStartupListener(this);
+    }
+
+    @Override
+    public boolean register(Object obj) {
+        boolean registered = super.register(obj);
+        if (obj instanceof HealthCheck) {
+            HealthCheck check = (HealthCheck) obj;
+            if (check.isEnabled()) {
+                registerMicroProfileHealthCheck(check);
+            }
+        } else {
+            HealthCheckRepository repository = (HealthCheckRepository) obj;
+            if (canRegister(repository)) {
+                registerRepositoryChecks(repository);
+            } else {
+                // Try health check registration again on CamelContext started
+                repositories.add(repository);
+            }
+        }
+        return registered;
+    }
+
+    @Override
+    public boolean unregister(Object obj) {
+        boolean unregistered = super.unregister(obj);
+        if (obj instanceof HealthCheck) {
+            HealthCheck check = (HealthCheck) obj;
+            removeMicroProfileHealthCheck(check);
+        } else {
+            HealthCheckRepository repository = (HealthCheckRepository) obj;
+            boolean isAllChecksLiveness = repository.stream().allMatch(HealthCheck::isLiveness);
+            boolean isAllChecksReadiness = repository.stream().allMatch(HealthCheck::isReadiness);
+
+            if (!(repository instanceof HealthCheckRegistryRepository) && (isAllChecksLiveness || isAllChecksReadiness)) {
+                try {
+                    if (isAllChecksLiveness) {
+                        getLivenessRegistry().remove(repository.getId());
+                    }
+
+                    if (isAllChecksReadiness) {
+                        getReadinessRegistry().remove(repository.getId());
+                    }
+                } catch (IllegalStateException e) {
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("Failed to remove repository readiness health {} check due to: {}", repository.getId(),
+                                e.getMessage());
+                    }
+                }
+            } else {
+                repository.stream().forEach(this::removeMicroProfileHealthCheck);
+            }
+        }
+        return unregistered;
+    }
+
+    @Override
+    public void onCamelContextStarted(CamelContext context, boolean alreadyStarted) throws Exception {
+        //Noop
+    }
+
+    @Override
+    public void onCamelContextFullyStarted(CamelContext context, boolean alreadyStarted) throws Exception {
+        // Some repository checks may not be resolvable earlier in the lifecycle, so try one last time on CamelContext started
+        if (alreadyStarted) {
+            repositories.stream()
+                    .filter(repository -> repository.stream().findAny().isPresent())
+                    .forEach(this::registerRepositoryChecks);
+            repositories.clear();
+        }
+    }
+
+    protected void registerRepositoryChecks(HealthCheckRepository repository) {
+        if (repository.isEnabled()) {
+            boolean isAllChecksLiveness = repository.stream().allMatch(HealthCheck::isLiveness);
+            boolean isAllChecksReadiness = repository.stream().allMatch(HealthCheck::isReadiness);
+
+            if (repository instanceof HealthCheckRegistryRepository || !isAllChecksLiveness && !isAllChecksReadiness) {
+                // Register each check individually for HealthCheckRegistryRepository or where the repository contains
+                // a mix or readiness and liveness checks
+                repository.stream()
+                        .filter(HealthCheck::isEnabled)
+                        .forEach(this::registerMicroProfileHealthCheck);
+            } else {
+                // Since the number of potential checks for consumers / routes etc is non-deterministic
+                // avoid registering each one with SmallRye health and instead aggregate the results so
+                // that we avoid highly verbose health output
+                String healthCheckName = repository.getId();
+                if (repository.getClass().getName().startsWith("org.apache.camel") && !healthCheckName.startsWith("camel-")) {
+                    healthCheckName = "camel-" + healthCheckName;
+                }
+
+                CamelMicroProfileRepositoryHealthCheck repositoryHealthCheck = new CamelMicroProfileRepositoryHealthCheck(
+                        getCamelContext(), repository, healthCheckName);
+
+                if (repository instanceof RoutesHealthCheckRepository
+                        || repository instanceof ConsumersHealthCheckRepository
+                        || repository instanceof KafkaHealthCheckRepository) {
+
+                    // Eagerly register routes & consumers HealthCheckRepository since routes may be supervised
+                    // and added with an initial delay. E.g repository.stream() may be empty initially but will eventually
+                    // return some results
+                    getReadinessRegistry().register(repository.getId(), repositoryHealthCheck);
+                } else {
+                    if (isAllChecksLiveness) {
+                        getLivenessRegistry().register(repository.getId(), repositoryHealthCheck);
+                    }
+
+                    if (isAllChecksReadiness) {
+                        getReadinessRegistry().register(repository.getId(), repositoryHealthCheck);
+                    }
+                }
+            }
+        }
+    }
+
+    protected void registerMicroProfileHealthCheck(HealthCheck camelHealthCheck) {
+        org.eclipse.microprofile.health.HealthCheck microProfileHealthCheck = new CamelMicroProfileHealthCheck(
+                getCamelContext(), camelHealthCheck);
+
+        if (camelHealthCheck.isReadiness()) {
+            getReadinessRegistry().register(camelHealthCheck.getId(), microProfileHealthCheck);
+        }
+
+        if (camelHealthCheck.isLiveness()) {
+            getLivenessRegistry().register(camelHealthCheck.getId(), microProfileHealthCheck);
+        }
+    }
+
+    protected void removeMicroProfileHealthCheck(HealthCheck camelHealthCheck) {
+        if (camelHealthCheck.isReadiness()) {
+            try {
+                getReadinessRegistry().remove(camelHealthCheck.getId());
+            } catch (IllegalStateException e) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Failed to remove readiness health check due to: {}", e.getMessage());
+                }
+            }
+        }
+
+        if (camelHealthCheck.isLiveness()) {
+            try {
+                getLivenessRegistry().remove(camelHealthCheck.getId());
+            } catch (IllegalStateException e) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Failed to remove liveness health check due to: {}", e.getMessage());
+                }
+            }
+        }
+    }
+
+    protected boolean canRegister(HealthCheckRepository repository) {
+        return repository.stream().findAny().isPresent()
+                || repository instanceof RoutesHealthCheckRepository
+                || repository instanceof ConsumersHealthCheckRepository
+                || repository instanceof KafkaHealthCheckRepository;
+    }
+
+    protected HealthRegistry getLivenessRegistry() {
+        return HealthRegistries.getRegistry(HealthType.LIVENESS);
+    }
+
+    protected HealthRegistry getReadinessRegistry() {
+        return HealthRegistries.getRegistry(HealthType.READINESS);
+    }
+}

--- a/cos-connector-camel/runtime/src/main/java/org/bf2/cos/connector/camel/ConnectorRecorder.java
+++ b/cos-connector-camel/runtime/src/main/java/org/bf2/cos/connector/camel/ConnectorRecorder.java
@@ -1,6 +1,11 @@
 package org.bf2.cos.connector.camel;
 
 import org.apache.camel.CamelContext;
+import org.apache.camel.health.HealthCheckRegistry;
+import org.apache.camel.main.BaseMainSupport;
+import org.apache.camel.main.MainListener;
+import org.apache.camel.main.MainListenerSupport;
+import org.apache.camel.microprofile.health.ConnectorHealthCheckRegistry;
 import org.apache.camel.spi.CamelContextCustomizer;
 
 import io.quarkus.runtime.RuntimeValue;
@@ -9,18 +14,34 @@ import io.quarkus.runtime.annotations.Recorder;
 @Recorder
 public class ConnectorRecorder {
     public RuntimeValue<CamelContextCustomizer> createContextCustomizer(ConnectorConfig config) {
-        return new RuntimeValue<>(new ConnectorContextCustomizer(config));
+        return new RuntimeValue<>(new CamelContextCustomizer() {
+
+            @Override
+            public void configure(CamelContext camelContext) {
+                configureHealthCheckRegistry(camelContext);
+            }
+
+            /*
+             * explicitly configure the health check registry as a workaround
+             * for https://issues.apache.org/jira/browse/CAMEL-18617
+             */
+            private void configureHealthCheckRegistry(CamelContext camelContext) {
+                HealthCheckRegistry registry = new ConnectorHealthCheckRegistry(camelContext);
+                registry.setId("camel-microprofile-health");
+                registry.setEnabled(true);
+
+                camelContext.setExtension(HealthCheckRegistry.class, registry);
+            }
+        });
     }
 
-    public static class ConnectorContextCustomizer implements CamelContextCustomizer {
-        private final ConnectorConfig config;
-
-        public ConnectorContextCustomizer(ConnectorConfig config) {
-            this.config = config;
-        }
-
-        @Override
-        public void configure(CamelContext camelContext) {
-        }
+    public RuntimeValue<MainListener> createMainCustomizer(ConnectorConfig config) {
+        return new RuntimeValue<>(new MainListenerSupport() {
+            @Override
+            public void beforeInitialize(BaseMainSupport main) {
+                main.addOverrideProperty("camel.health.registryEnabled", "false");
+                main.configure().health().setRegistryEnabled(false);
+            }
+        });
     }
 }

--- a/cos-fleet-catalog-connectors-it-support/src/main/java/org/bf2/cos/connector/camel/it/support/ConnectorContainer.java
+++ b/cos-fleet-catalog-connectors-it-support/src/main/java/org/bf2/cos/connector/camel/it/support/ConnectorContainer.java
@@ -183,6 +183,7 @@ public class ConnectorContainer extends GenericContainer<ConnectorContainer> {
     public static class Builder {
         private final String definition;
         private final Map<String, String> properties;
+        private final Map<String, String> userProperties;
 
         private Network network;
         private String dlqKafkaTopic;
@@ -197,13 +198,14 @@ public class ConnectorContainer extends GenericContainer<ConnectorContainer> {
 
             this.definition = definition;
             this.properties = new HashMap<>();
+            this.userProperties = new HashMap<>();
         }
 
         public Builder withProperty(String key, String val) {
             Objects.requireNonNull(key);
             Objects.requireNonNull(val);
 
-            this.properties.put(key, val);
+            this.properties.put(key.trim(), val);
             return this;
         }
 
@@ -211,6 +213,21 @@ public class ConnectorContainer extends GenericContainer<ConnectorContainer> {
             Objects.requireNonNull(properties);
 
             this.properties.putAll(properties);
+            return this;
+        }
+
+        public Builder withUserProperty(String key, String val) {
+            Objects.requireNonNull(key);
+            Objects.requireNonNull(val);
+
+            this.userProperties.put(key.trim(), val);
+            return this;
+        }
+
+        public Builder withUserProperties(Map<String, String> properties) {
+            Objects.requireNonNull(properties);
+
+            this.userProperties.putAll(properties);
             return this;
         }
 
@@ -396,6 +413,7 @@ public class ConnectorContainer extends GenericContainer<ConnectorContainer> {
                     LOGGER.info("route: \n{}", routeYaml);
 
                     answer.withFile(DEFAULT_ROUTE_LOCATION, routeYaml);
+                    answer.withUserProperties(userProperties);
 
                     try (InputStream ip = ConnectorContainer.class.getResourceAsStream("/integration-application.properties")) {
                         answer.withFile(DEFAULT_APPLICATION_PROPERTIES_LOCATION, ip);

--- a/cos-fleet-catalog-connectors-it/messaging/http-it/src/test/groovy/org/bf2/cos/connector/camel/it/ConnectorHealthIT.groovy
+++ b/cos-fleet-catalog-connectors-it/messaging/http-it/src/test/groovy/org/bf2/cos/connector/camel/it/ConnectorHealthIT.groovy
@@ -1,0 +1,149 @@
+package org.bf2.cos.connector.camel.it
+
+import groovy.util.logging.Slf4j
+import io.restassured.RestAssured
+import io.restassured.builder.RequestSpecBuilder
+import io.restassured.http.ContentType
+import org.bf2.cos.connector.camel.it.support.ConnectorContainer
+import org.bf2.cos.connector.camel.it.support.KafkaConnectorSpec
+import org.bf2.cos.connector.camel.it.support.KafkaContainer
+import org.bf2.cos.connector.camel.it.support.SimpleConnectorSpec
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.containers.Network
+import org.testcontainers.containers.wait.strategy.Wait
+import org.testcontainers.utility.DockerImageName
+
+import java.util.concurrent.TimeUnit
+
+@Slf4j
+class ConnectorHealthIT extends SimpleConnectorSpec {
+    static final int PORT = 8080
+    static final String SCHEME = 'http'
+    static final String HOST = 'tc-mock'
+
+    static Network network
+    static GenericContainer mock
+
+    def setupSpec() {
+        RestAssured.requestSpecification = new RequestSpecBuilder()
+                .setContentType(ContentType.JSON)
+                .setAccept(ContentType.JSON)
+                .build()
+
+        network = Network.newNetwork()
+
+        mock = new GenericContainer<>(DockerImageName.parse('wiremock/wiremock:2.34.0'))
+        mock.withLogConsumer(logger(HOST))
+        mock.withNetwork(KafkaConnectorSpec.network)
+        mock.withNetworkAliases(HOST)
+        mock.withExposedPorts(PORT)
+        mock.waitingFor(Wait.forListeningPort())
+        mock.start()
+    }
+
+
+    def cleanupSpec() {
+        log.info("cleaning up network container")
+        closeQuietly(network)
+
+        log.info("cleaning up http mock")
+        closeQuietly(mock)
+    }
+
+    def "container image exposes readiness "() {
+        setup:
+            def topic = UUID.randomUUID().toString()
+
+            def kafka = new KafkaContainer()
+            kafka.withNetwork(network)
+            kafka.start()
+            kafka.createTopic(topic)
+
+            def cnt = connector('http_sink_0.1.json', kafka, topic)
+            cnt.start()
+        when:
+            cnt.start()
+        then:
+            untilAsserted(10, TimeUnit.SECONDS) {
+                def health = cnt.request.get('/q/health/ready')
+                def unstructured = health.as(Map.class)
+
+                with(unstructured) {
+                    status == 'UP'
+                    checks.find {
+                        it.name == 'context' && it.status == 'UP'
+                    }
+                    checks.find {
+                        it.name == 'camel-routes' && it.status == 'UP'
+                    }
+                    checks.find {
+                        it.name == 'camel-consumers' && it.status == 'UP'
+                    }
+                    checks.find {
+                        it.name == 'camel-kafka' && it.status == 'UP'
+                    }
+                }
+            }
+        cleanup:
+            closeQuietly(cnt)
+            closeQuietly(kafka)
+    }
+
+    def "container image reports readiness down when kafka stops"() {
+        setup:
+            def topic = UUID.randomUUID().toString()
+
+            def kafka = new KafkaContainer()
+            kafka.withNetwork(network)
+            kafka.start()
+            kafka.createTopic(topic)
+
+            def cnt = connector('http_sink_0.1.json', kafka, topic)
+            cnt.start()
+        when:
+            closeQuietly(kafka)
+        then:
+            untilAsserted(10, TimeUnit.SECONDS) {
+                def health = cnt.request.get('/q/health/ready')
+                def unstructured = health.as(Map.class)
+
+                with(unstructured) {
+                    status == 'DOWN'
+                    checks.find {
+                        it.name == 'context' && it.status == 'UP'
+                    }
+                    checks.find {
+                        it.name == 'camel-routes' && it.status == 'UP'
+                    }
+                    checks.find {
+                        it.name == 'camel-consumers' && it.status == 'UP'
+                    }
+                    checks.find {
+                        it.name == 'camel-kafka' && it.status == 'DOWN'
+                    }
+                }
+            }
+        cleanup:
+            closeQuietly(cnt)
+            closeQuietly(kafka)
+    }
+
+    def connector(String definition, KafkaContainer kafka, String topic) {
+        return ConnectorContainer.forDefinition(definition)
+            .witNetwork(network)
+            .withUserProperty('quarkus.log.category."org.apache.camel.main".level', 'INFO')
+            .withUserProperty('quarkus.log.category."org.apache.camel.microprofile.health".level', 'INFO')
+            .withUserProperty('camel.main.route-controller-supervise-enabled', 'true')
+            .withUserProperty('camel.main.route-controller-back-off-max-attempts', '10')
+            .withUserProperty('camel.main.route-controller-unhealthy-on-exhausted', 'true')
+            .withUserProperty('camel.health.enabled ', 'true')
+            .withUserProperty('camel.health.routes-enabled ', 'true')
+            .withUserProperty('camel.health.registry-enabled ', 'true')
+            .withProperty('kafka_topic', topic)
+            .withProperty('kafka_bootstrap_servers', kafka.outsideBootstrapServers)
+            .withProperty('kafka_consumer_group', topic)
+            .withProperty('http_method', 'POST')
+            .withProperty('http_url', "${SCHEME}://${HOST}:${PORT}/run".toString())
+            .build()
+    }
+}

--- a/cos-fleet-catalog-connectors/aws/aws-cloudwatch-0.1/src/generated/resources/META-INF/connectors/aws_cloudwatch_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/aws/aws-cloudwatch-0.1/src/generated/resources/META-INF/connectors/aws_cloudwatch_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-cloudwatch:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-cloudwatch:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/aws/aws-dynamodb-0.1/src/generated/resources/META-INF/connectors/aws_ddb_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/aws/aws-dynamodb-0.1/src/generated/resources/META-INF/connectors/aws_ddb_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-ddb:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-ddb:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/aws/aws-dynamodb-streams-0.1/src/generated/resources/META-INF/connectors/aws_ddb_streams_source_0.1.json
+++ b/cos-fleet-catalog-connectors/aws/aws-dynamodb-streams-0.1/src/generated/resources/META-INF/connectors/aws_ddb_streams_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-ddb-streams:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-ddb-streams:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "source",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/aws/aws-kinesis-0.1/src/generated/resources/META-INF/connectors/aws_kinesis_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/aws/aws-kinesis-0.1/src/generated/resources/META-INF/connectors/aws_kinesis_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-kinesis:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-kinesis:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/aws/aws-kinesis-0.1/src/generated/resources/META-INF/connectors/aws_kinesis_source_0.1.json
+++ b/cos-fleet-catalog-connectors/aws/aws-kinesis-0.1/src/generated/resources/META-INF/connectors/aws_kinesis_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-kinesis:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-kinesis:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/aws/aws-lambda-0.1/src/generated/resources/META-INF/connectors/aws_lambda_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/aws/aws-lambda-0.1/src/generated/resources/META-INF/connectors/aws_lambda_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-lambda:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-lambda:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/aws/aws-s3-0.1/src/generated/resources/META-INF/connectors/aws_s3_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/aws/aws-s3-0.1/src/generated/resources/META-INF/connectors/aws_s3_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-s3:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-s3:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/aws/aws-s3-0.1/src/generated/resources/META-INF/connectors/aws_s3_source_0.1.json
+++ b/cos-fleet-catalog-connectors/aws/aws-s3-0.1/src/generated/resources/META-INF/connectors/aws_s3_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-s3:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-s3:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/aws/aws-ses-0.1/src/generated/resources/META-INF/connectors/aws_ses_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/aws/aws-ses-0.1/src/generated/resources/META-INF/connectors/aws_ses_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-ses:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-ses:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/aws/aws-sns-0.1/src/generated/resources/META-INF/connectors/aws_sns_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/aws/aws-sns-0.1/src/generated/resources/META-INF/connectors/aws_sns_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-sns:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-sns:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/aws/aws-sqs-0.1/src/generated/resources/META-INF/connectors/aws_sqs_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/aws/aws-sqs-0.1/src/generated/resources/META-INF/connectors/aws_sqs_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-sqs:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-sqs:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/aws/aws-sqs-0.1/src/generated/resources/META-INF/connectors/aws_sqs_source_0.1.json
+++ b/cos-fleet-catalog-connectors/aws/aws-sqs-0.1/src/generated/resources/META-INF/connectors/aws_sqs_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-sqs:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-sqs:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/azure/azure-eventhubs-0.1/src/generated/resources/META-INF/connectors/azure_eventhubs_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/azure/azure-eventhubs-0.1/src/generated/resources/META-INF/connectors/azure_eventhubs_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-azure-eventhubs:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-azure-eventhubs:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/azure/azure-eventhubs-0.1/src/generated/resources/META-INF/connectors/azure_eventhubs_source_0.1.json
+++ b/cos-fleet-catalog-connectors/azure/azure-eventhubs-0.1/src/generated/resources/META-INF/connectors/azure_eventhubs_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-azure-eventhubs:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-azure-eventhubs:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "source",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/azure/azure-functions-0.1/src/generated/resources/META-INF/connectors/azure_functions_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/azure/azure-functions-0.1/src/generated/resources/META-INF/connectors/azure_functions_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-azure-functions:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-azure-functions:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/azure/azure-storage-blob-0.1/src/generated/resources/META-INF/connectors/azure_storage_blob_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/azure/azure-storage-blob-0.1/src/generated/resources/META-INF/connectors/azure_storage_blob_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-azure-storage-blob:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-azure-storage-blob:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/azure/azure-storage-blob-0.1/src/generated/resources/META-INF/connectors/azure_storage_blob_source_0.1.json
+++ b/cos-fleet-catalog-connectors/azure/azure-storage-blob-0.1/src/generated/resources/META-INF/connectors/azure_storage_blob_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-azure-storage-blob:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-azure-storage-blob:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/azure/azure-storage-blob-changefeed-0.1/src/generated/resources/META-INF/connectors/azure_storage_blob_changefeed_source_0.1.json
+++ b/cos-fleet-catalog-connectors/azure/azure-storage-blob-changefeed-0.1/src/generated/resources/META-INF/connectors/azure_storage_blob_changefeed_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-azure-storage-blob-changefeed:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-azure-storage-blob-changefeed:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/azure/azure-storage-queue-0.1/src/generated/resources/META-INF/connectors/azure_storage_queue_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/azure/azure-storage-queue-0.1/src/generated/resources/META-INF/connectors/azure_storage_queue_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-azure-storage-queue:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-azure-storage-queue:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/azure/azure-storage-queue-0.1/src/generated/resources/META-INF/connectors/azure_storage_queue_source_0.1.json
+++ b/cos-fleet-catalog-connectors/azure/azure-storage-queue-0.1/src/generated/resources/META-INF/connectors/azure_storage_queue_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-azure-storage-queue:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-azure-storage-queue:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/gcp/google-bigquery-0.1/src/generated/resources/META-INF/connectors/google_bigquery_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/gcp/google-bigquery-0.1/src/generated/resources/META-INF/connectors/google_bigquery_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-google-bigquery:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-google-bigquery:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/gcp/google-functions-0.1/src/generated/resources/META-INF/connectors/google_functions_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/gcp/google-functions-0.1/src/generated/resources/META-INF/connectors/google_functions_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-google-functions:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-google-functions:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/gcp/google-pubsub-0.1/src/generated/resources/META-INF/connectors/google_pubsub_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/gcp/google-pubsub-0.1/src/generated/resources/META-INF/connectors/google_pubsub_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-google-pubsub:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-google-pubsub:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/gcp/google-pubsub-0.1/src/generated/resources/META-INF/connectors/google_pubsub_source_0.1.json
+++ b/cos-fleet-catalog-connectors/gcp/google-pubsub-0.1/src/generated/resources/META-INF/connectors/google_pubsub_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-google-pubsub:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-google-pubsub:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/gcp/google-storage-0.1/src/generated/resources/META-INF/connectors/google_storage_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/gcp/google-storage-0.1/src/generated/resources/META-INF/connectors/google_storage_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-google-storage:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-google-storage:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/gcp/google-storage-0.1/src/generated/resources/META-INF/connectors/google_storage_source_0.1.json
+++ b/cos-fleet-catalog-connectors/gcp/google-storage-0.1/src/generated/resources/META-INF/connectors/google_storage_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-google-storage:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-google-storage:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/itops/ansible-tower-0.1/src/generated/resources/META-INF/connectors/ansible_tower_job_template_launch_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/itops/ansible-tower-0.1/src/generated/resources/META-INF/connectors/ansible_tower_job_template_launch_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-ansible-tower:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-ansible-tower:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/itops/splunk-0.1/src/generated/resources/META-INF/connectors/splunk_0.1.json
+++ b/cos-fleet-catalog-connectors/itops/splunk-0.1/src/generated/resources/META-INF/connectors/splunk_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-splunk:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-splunk:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/messaging/http-0.1/src/generated/resources/META-INF/connectors/http_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/messaging/http-0.1/src/generated/resources/META-INF/connectors/http_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-http:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-http:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/messaging/jms-amqp-0.1/src/generated/resources/META-INF/connectors/jms_amqp_10_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/messaging/jms-amqp-0.1/src/generated/resources/META-INF/connectors/jms_amqp_10_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-jms-amqp-10:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-jms-amqp-10:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/messaging/jms-amqp-0.1/src/generated/resources/META-INF/connectors/jms_amqp_10_source_0.1.json
+++ b/cos-fleet-catalog-connectors/messaging/jms-amqp-0.1/src/generated/resources/META-INF/connectors/jms_amqp_10_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-jms-amqp-10:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-jms-amqp-10:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/messaging/jms-artemis-0.1/src/generated/resources/META-INF/connectors/jms_apache_artemis_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/messaging/jms-artemis-0.1/src/generated/resources/META-INF/connectors/jms_apache_artemis_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-jms-apache-artemis:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-jms-apache-artemis:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/messaging/jms-artemis-0.1/src/generated/resources/META-INF/connectors/jms_apache_artemis_source_0.1.json
+++ b/cos-fleet-catalog-connectors/messaging/jms-artemis-0.1/src/generated/resources/META-INF/connectors/jms_apache_artemis_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-jms-apache-artemis:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-jms-apache-artemis:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/messaging/openapi-0.1/src/generated/resources/META-INF/connectors/rest_openapi_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/messaging/openapi-0.1/src/generated/resources/META-INF/connectors/rest_openapi_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-rest-openapi:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-rest-openapi:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/misc/data-generator-0.1/src/generated/resources/META-INF/connectors/data_generator_0.1.json
+++ b/cos-fleet-catalog-connectors/misc/data-generator-0.1/src/generated/resources/META-INF/connectors/data_generator_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-data-generator:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-data-generator:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/nosql/cassandra-0.1/src/generated/resources/META-INF/connectors/cassandra_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/nosql/cassandra-0.1/src/generated/resources/META-INF/connectors/cassandra_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-cassandra:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-cassandra:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/nosql/cassandra-0.1/src/generated/resources/META-INF/connectors/cassandra_source_0.1.json
+++ b/cos-fleet-catalog-connectors/nosql/cassandra-0.1/src/generated/resources/META-INF/connectors/cassandra_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-cassandra:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-cassandra:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "source",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/nosql/elasticsearch-0.1/src/generated/resources/META-INF/connectors/elasticsearch_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/nosql/elasticsearch-0.1/src/generated/resources/META-INF/connectors/elasticsearch_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-elasticsearch:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-elasticsearch:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/nosql/mongodb-0.1/src/generated/resources/META-INF/connectors/mongodb_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/nosql/mongodb-0.1/src/generated/resources/META-INF/connectors/mongodb_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-mongodb:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-mongodb:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/nosql/mongodb-0.1/src/generated/resources/META-INF/connectors/mongodb_source_0.1.json
+++ b/cos-fleet-catalog-connectors/nosql/mongodb-0.1/src/generated/resources/META-INF/connectors/mongodb_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-mongodb:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-mongodb:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "source",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/saas/jira-0.1/src/generated/resources/META-INF/connectors/jira_add_comment_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/saas/jira-0.1/src/generated/resources/META-INF/connectors/jira_add_comment_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-jira:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-jira:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/saas/jira-0.1/src/generated/resources/META-INF/connectors/jira_add_issue_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/saas/jira-0.1/src/generated/resources/META-INF/connectors/jira_add_issue_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-jira:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-jira:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/saas/jira-0.1/src/generated/resources/META-INF/connectors/jira_source_0.1.json
+++ b/cos-fleet-catalog-connectors/saas/jira-0.1/src/generated/resources/META-INF/connectors/jira_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-jira:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-jira:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "source",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/saas/salesforce-0.1/src/generated/resources/META-INF/connectors/salesforce_create_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/saas/salesforce-0.1/src/generated/resources/META-INF/connectors/salesforce_create_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-salesforce:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-salesforce:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/saas/salesforce-0.1/src/generated/resources/META-INF/connectors/salesforce_delete_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/saas/salesforce-0.1/src/generated/resources/META-INF/connectors/salesforce_delete_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-salesforce:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-salesforce:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/saas/salesforce-0.1/src/generated/resources/META-INF/connectors/salesforce_streaming_source_0.1.json
+++ b/cos-fleet-catalog-connectors/saas/salesforce-0.1/src/generated/resources/META-INF/connectors/salesforce_streaming_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-salesforce:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-salesforce:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "source",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/saas/salesforce-0.1/src/generated/resources/META-INF/connectors/salesforce_update_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/saas/salesforce-0.1/src/generated/resources/META-INF/connectors/salesforce_update_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-salesforce:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-salesforce:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/social/slack-0.1/src/generated/resources/META-INF/connectors/slack_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/social/slack-0.1/src/generated/resources/META-INF/connectors/slack_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-slack:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-slack:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/social/slack-0.1/src/generated/resources/META-INF/connectors/slack_source_0.1.json
+++ b/cos-fleet-catalog-connectors/social/slack-0.1/src/generated/resources/META-INF/connectors/slack_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-slack:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-slack:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "source",
         "consumes" : "application/json",
         "consumes_class" : "com.slack.api.model.Message",

--- a/cos-fleet-catalog-connectors/social/telegram-0.1/src/generated/resources/META-INF/connectors/telegram_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/social/telegram-0.1/src/generated/resources/META-INF/connectors/telegram_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-telegram:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-telegram:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/social/telegram-0.1/src/generated/resources/META-INF/connectors/telegram_source_0.1.json
+++ b/cos-fleet-catalog-connectors/social/telegram-0.1/src/generated/resources/META-INF/connectors/telegram_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-telegram:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-telegram:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "source",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/sql/aws-redshift-0.1/src/generated/resources/META-INF/connectors/aws_redshift_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/sql/aws-redshift-0.1/src/generated/resources/META-INF/connectors/aws_redshift_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-redshift:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-redshift:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/sql/aws-redshift-0.1/src/generated/resources/META-INF/connectors/aws_redshift_source_0.1.json
+++ b/cos-fleet-catalog-connectors/sql/aws-redshift-0.1/src/generated/resources/META-INF/connectors/aws_redshift_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-redshift:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-redshift:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "source",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/sql/mariadb-0.1/src/generated/resources/META-INF/connectors/mariadb_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/sql/mariadb-0.1/src/generated/resources/META-INF/connectors/mariadb_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-mariadb:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-mariadb:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/sql/mariadb-0.1/src/generated/resources/META-INF/connectors/mariadb_source_0.1.json
+++ b/cos-fleet-catalog-connectors/sql/mariadb-0.1/src/generated/resources/META-INF/connectors/mariadb_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-mariadb:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-mariadb:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "source",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/sql/mysql-0.1/src/generated/resources/META-INF/connectors/mysql_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/sql/mysql-0.1/src/generated/resources/META-INF/connectors/mysql_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-mysql:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-mysql:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/sql/mysql-0.1/src/generated/resources/META-INF/connectors/mysql_source_0.1.json
+++ b/cos-fleet-catalog-connectors/sql/mysql-0.1/src/generated/resources/META-INF/connectors/mysql_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-mysql:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-mysql:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "source",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/sql/postgresql-0.1/src/generated/resources/META-INF/connectors/postgresql_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/sql/postgresql-0.1/src/generated/resources/META-INF/connectors/postgresql_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-postgresql:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-postgresql:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/sql/postgresql-0.1/src/generated/resources/META-INF/connectors/postgresql_source_0.1.json
+++ b/cos-fleet-catalog-connectors/sql/postgresql-0.1/src/generated/resources/META-INF/connectors/postgresql_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-postgresql:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-postgresql:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "source",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/sql/sqlserver-0.1/src/generated/resources/META-INF/connectors/sqlserver_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/sql/sqlserver-0.1/src/generated/resources/META-INF/connectors/sqlserver_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-sqlserver:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-sqlserver:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/sql/sqlserver-0.1/src/generated/resources/META-INF/connectors/sqlserver_source_0.1.json
+++ b/cos-fleet-catalog-connectors/sql/sqlserver-0.1/src/generated/resources/META-INF/connectors/sqlserver_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-sqlserver:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-sqlserver:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "source",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/storage/ftps-0.1/src/generated/resources/META-INF/connectors/ftps_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/storage/ftps-0.1/src/generated/resources/META-INF/connectors/ftps_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-ftps:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-ftps:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/storage/ftps-0.1/src/generated/resources/META-INF/connectors/ftps_source_0.1.json
+++ b/cos-fleet-catalog-connectors/storage/ftps-0.1/src/generated/resources/META-INF/connectors/ftps_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-ftps:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-ftps:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/storage/minio-0.1/src/generated/resources/META-INF/connectors/minio_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/storage/minio-0.1/src/generated/resources/META-INF/connectors/minio_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-minio:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-minio:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/storage/minio-0.1/src/generated/resources/META-INF/connectors/minio_source_0.1.json
+++ b/cos-fleet-catalog-connectors/storage/minio-0.1/src/generated/resources/META-INF/connectors/minio_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-minio:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-minio:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/storage/sftp-0.1/src/generated/resources/META-INF/connectors/sftp_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/storage/sftp-0.1/src/generated/resources/META-INF/connectors/sftp_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-sftp:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-sftp:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/storage/sftp-0.1/src/generated/resources/META-INF/connectors/sftp_source_0.1.json
+++ b/cos-fleet-catalog-connectors/storage/sftp-0.1/src/generated/resources/META-INF/connectors/sftp_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-sftp:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-sftp:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-aws/aws_cloudwatch_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-aws/aws_cloudwatch_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-cloudwatch:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-cloudwatch:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-aws/aws_ddb_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-aws/aws_ddb_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-ddb:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-ddb:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-aws/aws_ddb_streams_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-aws/aws_ddb_streams_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-ddb-streams:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-ddb-streams:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "source",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-aws/aws_kinesis_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-aws/aws_kinesis_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-kinesis:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-kinesis:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-aws/aws_kinesis_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-aws/aws_kinesis_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-kinesis:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-kinesis:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-aws/aws_lambda_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-aws/aws_lambda_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-lambda:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-lambda:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-aws/aws_s3_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-aws/aws_s3_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-s3:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-s3:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-aws/aws_s3_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-aws/aws_s3_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-s3:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-s3:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-aws/aws_ses_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-aws/aws_ses_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-ses:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-ses:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-aws/aws_sns_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-aws/aws_sns_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-sns:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-sns:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-aws/aws_sqs_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-aws/aws_sqs_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-sqs:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-sqs:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-aws/aws_sqs_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-aws/aws_sqs_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-sqs:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-sqs:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-azure/azure_eventhubs_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-azure/azure_eventhubs_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-azure-eventhubs:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-azure-eventhubs:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-azure/azure_eventhubs_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-azure/azure_eventhubs_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-azure-eventhubs:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-azure-eventhubs:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "source",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-azure/azure_functions_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-azure/azure_functions_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-azure-functions:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-azure-functions:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-azure/azure_storage_blob_changefeed_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-azure/azure_storage_blob_changefeed_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-azure-storage-blob-changefeed:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-azure-storage-blob-changefeed:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-azure/azure_storage_blob_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-azure/azure_storage_blob_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-azure-storage-blob:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-azure-storage-blob:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-azure/azure_storage_blob_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-azure/azure_storage_blob_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-azure-storage-blob:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-azure-storage-blob:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-azure/azure_storage_queue_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-azure/azure_storage_queue_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-azure-storage-queue:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-azure-storage-queue:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-azure/azure_storage_queue_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-azure/azure_storage_queue_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-azure-storage-queue:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-azure-storage-queue:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-gcp/google_bigquery_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-gcp/google_bigquery_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-google-bigquery:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-google-bigquery:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-gcp/google_functions_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-gcp/google_functions_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-google-functions:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-google-functions:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-gcp/google_pubsub_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-gcp/google_pubsub_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-google-pubsub:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-google-pubsub:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-gcp/google_pubsub_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-gcp/google_pubsub_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-google-pubsub:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-google-pubsub:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-gcp/google_storage_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-gcp/google_storage_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-google-storage:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-google-storage:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-gcp/google_storage_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-gcp/google_storage_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-google-storage:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-google-storage:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-itops/ansible_tower_job_template_launch_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-itops/ansible_tower_job_template_launch_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-ansible-tower:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-ansible-tower:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-itops/splunk_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-itops/splunk_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-splunk:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-splunk:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-messaging/http_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-messaging/http_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-http:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-http:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-messaging/jms_amqp_10_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-messaging/jms_amqp_10_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-jms-amqp-10:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-jms-amqp-10:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-messaging/jms_amqp_10_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-messaging/jms_amqp_10_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-jms-amqp-10:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-jms-amqp-10:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-messaging/jms_apache_artemis_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-messaging/jms_apache_artemis_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-jms-apache-artemis:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-jms-apache-artemis:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-messaging/jms_apache_artemis_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-messaging/jms_apache_artemis_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-jms-apache-artemis:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-jms-apache-artemis:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-messaging/rest_openapi_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-messaging/rest_openapi_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-rest-openapi:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-rest-openapi:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-misc/data_generator_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-misc/data_generator_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-data-generator:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-data-generator:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-nosql/cassandra_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-nosql/cassandra_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-cassandra:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-cassandra:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-nosql/cassandra_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-nosql/cassandra_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-cassandra:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-cassandra:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "source",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-nosql/elasticsearch_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-nosql/elasticsearch_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-elasticsearch:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-elasticsearch:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-nosql/mongodb_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-nosql/mongodb_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-mongodb:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-mongodb:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-nosql/mongodb_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-nosql/mongodb_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-mongodb:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-mongodb:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "source",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-saas/jira_add_comment_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-saas/jira_add_comment_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-jira:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-jira:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-saas/jira_add_issue_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-saas/jira_add_issue_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-jira:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-jira:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-saas/jira_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-saas/jira_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-jira:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-jira:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "source",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-saas/salesforce_create_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-saas/salesforce_create_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-salesforce:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-salesforce:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-saas/salesforce_delete_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-saas/salesforce_delete_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-salesforce:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-salesforce:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-saas/salesforce_streaming_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-saas/salesforce_streaming_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-salesforce:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-salesforce:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "source",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-saas/salesforce_update_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-saas/salesforce_update_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-salesforce:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-salesforce:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-social/slack_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-social/slack_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-slack:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-slack:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-social/slack_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-social/slack_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-slack:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-slack:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "source",
         "consumes" : "application/json",
         "consumes_class" : "com.slack.api.model.Message",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-social/telegram_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-social/telegram_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-telegram:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-telegram:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-social/telegram_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-social/telegram_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-telegram:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-telegram:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "source",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-sql/aws_redshift_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-sql/aws_redshift_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-redshift:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-redshift:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-sql/aws_redshift_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-sql/aws_redshift_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-redshift:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-redshift:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "source",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-sql/mariadb_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-sql/mariadb_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-mariadb:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-mariadb:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-sql/mariadb_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-sql/mariadb_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-mariadb:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-mariadb:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "source",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-sql/mysql_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-sql/mysql_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-mysql:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-mysql:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-sql/mysql_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-sql/mysql_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-mysql:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-mysql:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "source",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-sql/postgresql_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-sql/postgresql_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-postgresql:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-postgresql:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-sql/postgresql_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-sql/postgresql_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-postgresql:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-postgresql:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "source",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-sql/sqlserver_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-sql/sqlserver_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-sqlserver:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-sqlserver:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-sql/sqlserver_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-sql/sqlserver_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-sqlserver:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-sqlserver:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "source",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-storage/ftps_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-storage/ftps_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-ftps:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-ftps:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-storage/ftps_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-storage/ftps_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-ftps:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-ftps:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-storage/minio_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-storage/minio_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-minio:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-minio:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-storage/minio_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-storage/minio_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-minio:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-minio:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-storage/sftp_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-storage/sftp_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-sftp:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-sftp:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-storage/sftp_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-storage/sftp_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-sftp:0.1.50",
-        "connector_revision" : 50,
+        "connector_image" : "quay.io/rhoas/cos-connector-sftp:0.1.51",
+        "connector_revision" : 51,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/pom.xml
+++ b/pom.xml
@@ -214,6 +214,7 @@
                 <artifactId>jsonschema-generator</artifactId>
                 <version>${jsonschema-generator.version}</version>
             </dependency>
+
             <dependency>
                 <groupId>com.github.victools</groupId>
                 <artifactId>jsonschema-module-jackson</artifactId>
@@ -358,10 +359,6 @@
 
     <repositories>
         <repository>
-            <id>jitpack.io</id>
-            <url>https://jitpack.io</url>
-        </repository>
-        <repository>
             <id>apache.snapshots</id>
             <url>https://repository.apache.org/snapshots/</url>
             <snapshots>
@@ -371,23 +368,9 @@
                 <enabled>false</enabled>
             </releases>
         </repository>
-        <!--
-        <repository>
-            <id>oss-sonatype</id>
-            <name>oss-sonatype</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-        -->
     </repositories>
     <pluginRepositories>
         <pluginRepository>
-            <id>jitpack.io</id>
-            <url>https://jitpack.io</url>
-        </pluginRepository>
-        <pluginRepository>
             <id>apache.snapshots</id>
             <url>https://repository.apache.org/snapshots/</url>
             <snapshots>
@@ -397,16 +380,6 @@
                 <enabled>false</enabled>
             </releases>
         </pluginRepository>
-        <!--
-        <pluginRepository>
-            <id>oss-sonatype</id>
-            <name>oss-sonatype</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </pluginRepository>
-        -->
     </pluginRepositories>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <cos.connector.catalog.group>all</cos.connector.catalog.group>
 
         <cos.connector.version>0.1</cos.connector.version>
-        <cos.connector.revision>50</cos.connector.revision>
+        <cos.connector.revision>51</cos.connector.revision>
         <cos.connector.operator.version>[1.0.0,2.0.0)</cos.connector.operator.version>
         <cos.kamelets.version>0.0.1</cos.kamelets.version>
 


### PR DESCRIPTION
This is a workaround for:
- https://issues.apache.org/jira/browse/CAMEL-18483
- https://issues.apache.org/jira/browse/CAMEL-18617

Note that [CAMEL-18483](https://issues.apache.org/jira/browse/CAMEL-18483) is resolved and should be part of the upcoming Apache Camel 3.18.3 release however that won't solve [CAMEL-18617](https://issues.apache.org/jira/browse/CAMEL-18617) which would require some additional work and will be fixed in a future Apache Camel version, likely 3.20.x hence we would need this workaround to be applied in order to surface all the health checks until we get a proper solution.

Note that with this PR, the `camel.health.registryEnabled` property is forcefully set to `false` in order to avoid Camel Quarkus to inject a custom [health check registry](https://github.com/apache/camel-quarkus/blob/d977326a0d1490916a9e945b58e660b0cd593f21/extensions/microprofile-health/deployment/src/main/java/org/apache/camel/quarkus/component/microprofile/health/deployment/MicroProfileHealthProcessor.java#L98-L102) 

