### PR TITLE
feat: create a testcontainer wait strategy for jms

### DIFF
--- a/cos-fleet-catalog-connectors-it-support/src/main/java/org/bf2/cos/connector/camel/it/support/AwaitStrategy.java
+++ b/cos-fleet-catalog-connectors-it-support/src/main/java/org/bf2/cos/connector/camel/it/support/AwaitStrategy.java
@@ -1,0 +1,50 @@
+package org.bf2.cos.connector.camel.it.support;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
+
+import org.awaitility.Awaitility;
+import org.testcontainers.containers.ContainerLaunchException;
+import org.testcontainers.containers.wait.strategy.WaitStrategy;
+import org.testcontainers.containers.wait.strategy.WaitStrategyTarget;
+
+public abstract class AwaitStrategy implements WaitStrategy {
+    protected Duration startupTimeout = Duration.ofSeconds(60);
+    protected WaitStrategyTarget target;
+
+    @Override
+    public WaitStrategy withStartupTimeout(Duration startupTimeout) {
+        this.startupTimeout = startupTimeout;
+        return this;
+    }
+
+    @Override
+    public void waitUntilReady(WaitStrategyTarget target) {
+        this.target = target;
+
+        try {
+            Awaitility
+                    .await()
+                    .pollInSameThread()
+                    .pollInterval(100, TimeUnit.MILLISECONDS)
+                    .pollDelay(500, TimeUnit.MILLISECONDS)
+                    .timeout(startupTimeout.getSeconds(), TimeUnit.SECONDS)
+                    .until(this::ready);
+        } catch (Exception e) {
+            throw new ContainerLaunchException(
+                    "Error waiting for container to be ready", e);
+        }
+    }
+
+    protected abstract boolean ready();
+
+    public static WaitStrategy waitFor(Predicate<WaitStrategyTarget> condition) {
+        return new AwaitStrategy() {
+            @Override
+            protected boolean ready() {
+                return condition.test(target);
+            }
+        };
+    }
+}

--- a/cos-fleet-catalog-connectors-it/messaging/jms-amqp-it/src/test/groovy/org/bf2/cos/connector/camel/it/ConnectorIT.groovy
+++ b/cos-fleet-catalog-connectors-it/messaging/jms-amqp-it/src/test/groovy/org/bf2/cos/connector/camel/it/ConnectorIT.groovy
@@ -3,13 +3,16 @@ package org.bf2.cos.connector.camel.it
 import com.fasterxml.jackson.databind.ObjectMapper
 import groovy.util.logging.Slf4j
 import org.apache.qpid.jms.JmsConnectionFactory
+import org.bf2.cos.connector.camel.it.support.AwaitStrategy
 import org.bf2.cos.connector.camel.it.support.KafkaConnectorSpec
+import org.testcontainers.containers.ContainerState
 import org.testcontainers.containers.GenericContainer
+import org.testcontainers.containers.wait.strategy.WaitStrategy
 import org.testcontainers.utility.DockerImageName
 
 import javax.jms.BytesMessage
 import javax.jms.Connection
-import javax.jms.ConnectionFactory
+import javax.jms.JMSException
 import javax.jms.MessageConsumer
 import javax.jms.Queue
 import javax.jms.Session
@@ -21,14 +24,17 @@ class ConnectorIT extends KafkaConnectorSpec {
 
     @Override
     def setupSpec() {
-        DockerImageName imageName = DockerImageName.parse('quay.io/artemiscloud/activemq-artemis-broker:0.1.4');
+        DockerImageName imageName = DockerImageName.parse('quay.io/artemiscloud/activemq-artemis-broker:1.0.9')
+
         mq = new GenericContainer(imageName)
         mq.withLogConsumer(logger('tc-activemq'))
         mq.withNetwork(network)
         mq.withNetworkAliases('tc-activemq')
         mq.withExposedPorts(61616)
-        mq.withEnv("AMQ_USER", 'artemis')
-        mq.withEnv("AMQ_PASSWORD", 'simetraehcapa')
+        mq.withEnv('AMQ_USER', 'artemis')
+        mq.withEnv('AMQ_PASSWORD', 'simetraehcapa')
+        mq.withEnv('AMQ_EXTRA_ARGS', '--no-autotune --mapped --no-fsync')
+        mq.waitingFor(waitForConnection())
         mq.start()
     }
 
@@ -39,11 +45,10 @@ class ConnectorIT extends KafkaConnectorSpec {
 
     def "jms-amqp sink"() {
         setup:
-            ConnectionFactory factory = new JmsConnectionFactory("amqp://${mq.host}:${mq.getMappedPort(61616)}")
-            Connection connection = factory.createConnection()
-            Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE)
+            Connection connection = createConnection(mq)
             connection.start()
 
+            Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE)
             Queue queue = session.createQueue("cards")
             MessageConsumer consumer = session.createConsumer(queue)
 
@@ -84,5 +89,28 @@ class ConnectorIT extends KafkaConnectorSpec {
             closeQuietly(session)
             closeQuietly(connection)
             closeQuietly(cnt)
+    }
+
+
+    static Connection createConnection(ContainerState state) {
+        def remoteURI = "amqp://${state.host}:${state.getMappedPort(61616)}"
+        def factory = new JmsConnectionFactory(remoteURI)
+
+        return factory.createConnection()
+    }
+
+    static WaitStrategy waitForConnection() {
+        return new AwaitStrategy() {
+            @Override
+            boolean ready() {
+                try (Connection connection = createConnection(target)) {
+                    connection.start()
+                } catch (JMSException e) {
+                    return false
+                }
+
+                return true
+            }
+        }
     }
 }


### PR DESCRIPTION
In some cases, the jmc test fails because the tcp port is open but the broker is not ready to accept messages, this PR is aimed to add a custom wait strategy to ensure the broker is ready before starting the tests