### PR TITLE
Define container images in a single location and update java base image

### DIFF
--- a/cos-fleet-catalog-connectors-it-support/src/main/java/org/bf2/cos/connector/camel/it/support/ContainerImages.java
+++ b/cos-fleet-catalog-connectors-it-support/src/main/java/org/bf2/cos/connector/camel/it/support/ContainerImages.java
@@ -1,0 +1,47 @@
+package org.bf2.cos.connector.camel.it.support;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
+
+public enum ContainerImages {
+    REDPANDA("docker.io/vectorized/redpanda:v22.2.6"),
+    WIREMOCK("docker.io/wiremock/wiremock:2.34.0"),
+    ACTIVEMQ_ARTEMIS("quay.io/artemiscloud/activemq-artemis-broker:1.0.9"),
+    CASSANDRA("cassandra:3.11"),
+    MONGODB("mongo:5"),
+    MARIADB("mariadb:10.3.6"),
+    MYSQL("mysql:5"),
+    POSTGRES("postgres:14.2"),
+    SQLSERVER("mcr.microsoft.com/mssql/server:2017-CU12"),
+    MINIO("quay.io/minio/minio:latest"),
+    LOCALSTACK("docker.io/localstack/localstack:0.14.2"),
+    GCR_PUBSUB("gcr.io/google.com/cloudsdktool/cloud-sdk:emulators");
+
+    private final DockerImageName imageName;
+
+    ContainerImages(String fullImageName) {
+        this.imageName = DockerImageName.parse(fullImageName);
+    }
+
+    public DockerImageName imageName() {
+        return this.imageName;
+    }
+
+    public GenericContainer<?> container() {
+        return new GenericContainer<>(this.imageName);
+    }
+
+    public <T extends GenericContainer<T>> T container(Class<T> type) {
+        try {
+            Constructor<T> constructor = type.getConstructor(DockerImageName.class);
+            T instance = constructor.newInstance(this.imageName());
+
+            return instance;
+        } catch (NoSuchMethodException | InstantiationException | InvocationTargetException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/cos-fleet-catalog-connectors-it-support/src/main/java/org/bf2/cos/connector/camel/it/support/RedPandaKafkaContainer.java
+++ b/cos-fleet-catalog-connectors-it-support/src/main/java/org/bf2/cos/connector/camel/it/support/RedPandaKafkaContainer.java
@@ -18,7 +18,7 @@ public class RedPandaKafkaContainer extends GenericContainer<RedPandaKafkaContai
     private static final String STARTER_SCRIPT = "/var/lib/redpanda/redpanda.sh";
 
     public RedPandaKafkaContainer() {
-        super("docker.io/vectorized/redpanda:v22.2.2");
+        super(ContainerImages.REDPANDA.imageName());
 
         withCreateContainerCmdModifier(cmd -> cmd.withEntrypoint("sh"));
         withCommand("-c", "while [ ! -f " + STARTER_SCRIPT + " ]; do sleep 0.1; done; " + STARTER_SCRIPT);

--- a/cos-fleet-catalog-connectors-it/aws/aws-it/src/test/java/org/bf2/cos/connector/camel/it/aws/AWSContainer.java
+++ b/cos-fleet-catalog-connectors-it/aws/aws-it/src/test/java/org/bf2/cos/connector/camel/it/aws/AWSContainer.java
@@ -2,12 +2,12 @@ package org.bf2.cos.connector.camel.it.aws;
 
 import java.net.URI;
 
+import org.bf2.cos.connector.camel.it.support.ContainerImages;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.Wait;
-import org.testcontainers.utility.DockerImageName;
 
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
@@ -20,12 +20,11 @@ import software.amazon.awssdk.services.sns.SnsClient;
 import software.amazon.awssdk.services.sqs.SqsClient;
 
 public class AWSContainer extends GenericContainer<AWSContainer> {
-    public static final String IMAGE = "localstack/localstack:0.14.2";
     public static final String CONTAINER_ALIAS = "tc-aws";
     public static final int PORT = 4566;
 
     public AWSContainer(Network network, String... services) {
-        super(DockerImageName.parse(IMAGE));
+        super(ContainerImages.LOCALSTACK.imageName());
 
         withEnv("SERVICE", String.join(",", services));
         withLogConsumer(new Slf4jLogConsumer(LoggerFactory.getLogger(CONTAINER_ALIAS)));

--- a/cos-fleet-catalog-connectors-it/aws/aws-it/src/test/resources/logback-test.xml
+++ b/cos-fleet-catalog-connectors-it/aws/aws-it/src/test/resources/logback-test.xml
@@ -8,8 +8,10 @@
 
     <logger name="org.apache.kafka.clients.consumer.ConsumerConfig" level="WARN"/>
     <logger name="org.apache.kafka.clients.producer.ProducerConfig" level="WARN"/>
-    <logger name="org.apache.kafka.clients.consumer.internals.ConsumerCoordinator" level="WARN"/>
     <logger name="org.apache.kafka.clients.admin.AdminClientConfig" level="ERROR"/>
+
+    <logger name="org.apache.kafka.clients.NetworkClient" level="WARN"/>
+    <logger name="org.apache.kafka.clients.consumer.internals.ConsumerCoordinator" level="WARN"/>
 
     <logger name="tc-container" level="INFO"/>
     <logger name="tc-kafka" level="WARN"/>

--- a/cos-fleet-catalog-connectors-it/azure/eventhubs-it/src/test/resources/logback-test.xml
+++ b/cos-fleet-catalog-connectors-it/azure/eventhubs-it/src/test/resources/logback-test.xml
@@ -10,6 +10,9 @@
     <logger name="org.apache.kafka.clients.producer.ProducerConfig" level="WARN"/>
     <logger name="org.apache.kafka.clients.admin.AdminClientConfig" level="ERROR"/>
 
+    <logger name="org.apache.kafka.clients.NetworkClient" level="WARN"/>
+    <logger name="org.apache.kafka.clients.consumer.internals.ConsumerCoordinator" level="WARN"/>
+
     <logger name="tc-container" level="INFO"/>
     <logger name="tc-kafka" level="WARN"/>
 

--- a/cos-fleet-catalog-connectors-it/gcp/google-pubsub-it/src/test/groovy/org/bf2/cos/connector/camel/it/ConnectorIT.groovy
+++ b/cos-fleet-catalog-connectors-it/gcp/google-pubsub-it/src/test/groovy/org/bf2/cos/connector/camel/it/ConnectorIT.groovy
@@ -12,15 +12,19 @@ import com.google.cloud.pubsub.v1.TopicAdminSettings
 import com.google.cloud.pubsub.v1.stub.GrpcSubscriberStub
 import com.google.cloud.pubsub.v1.stub.SubscriberStub
 import com.google.cloud.pubsub.v1.stub.SubscriberStubSettings
-import com.google.pubsub.v1.*
+import com.google.pubsub.v1.ProjectSubscriptionName
+import com.google.pubsub.v1.PullRequest
+import com.google.pubsub.v1.PullResponse
+import com.google.pubsub.v1.Subscription
+import com.google.pubsub.v1.Topic
+import com.google.pubsub.v1.TopicName
 import groovy.util.logging.Slf4j
 import io.grpc.ManagedChannel
 import io.grpc.ManagedChannelBuilder
+import org.bf2.cos.connector.camel.it.support.ContainerImages
 import org.bf2.cos.connector.camel.it.support.KafkaConnectorSpec
 import org.testcontainers.containers.PubSubEmulatorContainer
-import org.testcontainers.utility.DockerImageName
 
-import java.sql.Time
 import java.util.concurrent.TimeUnit
 
 @Slf4j
@@ -30,8 +34,7 @@ class ConnectorIT extends KafkaConnectorSpec {
 
     @Override
     def setupSpec() {
-        DockerImageName imageName = DockerImageName.parse('gcr.io/google.com/cloudsdktool/cloud-sdk:emulators');
-        container = new PubSubEmulatorContainer(imageName)
+        container = ContainerImages.GCR_PUBSUB.container(PubSubEmulatorContainer.class)
         container.withLogConsumer(logger('tc-google-pubsub'))
         container.withNetwork(network)
         container.withNetworkAliases('tc-google-pubsub')

--- a/cos-fleet-catalog-connectors-it/gcp/google-pubsub-it/src/test/resources/logback-test.xml
+++ b/cos-fleet-catalog-connectors-it/gcp/google-pubsub-it/src/test/resources/logback-test.xml
@@ -10,6 +10,9 @@
     <logger name="org.apache.kafka.clients.producer.ProducerConfig" level="WARN"/>
     <logger name="org.apache.kafka.clients.admin.AdminClientConfig" level="ERROR"/>
 
+    <logger name="org.apache.kafka.clients.NetworkClient" level="WARN"/>
+    <logger name="org.apache.kafka.clients.consumer.internals.ConsumerCoordinator" level="WARN"/>
+
     <logger name="tc-container" level="INFO"/>
     <logger name="tc-kafka" level="WARN"/>
     <logger name="tc-google-pubsub" level="WARN"/>

--- a/cos-fleet-catalog-connectors-it/itops/ansible-tower-it/src/test/groovy/org/bf2/cos/connector/camel/it/ConnectorIT.groovy
+++ b/cos-fleet-catalog-connectors-it/itops/ansible-tower-it/src/test/groovy/org/bf2/cos/connector/camel/it/ConnectorIT.groovy
@@ -2,12 +2,12 @@ package org.bf2.cos.connector.camel.it
 
 import com.github.tomakehurst.wiremock.client.WireMock
 import groovy.util.logging.Slf4j
+import org.bf2.cos.connector.camel.it.support.ContainerImages
 import org.bf2.cos.connector.camel.it.support.KafkaConnectorSpec
 import org.testcontainers.containers.BindMode
 import org.testcontainers.containers.GenericContainer
 import org.testcontainers.containers.SelinuxContext
 import org.testcontainers.containers.wait.strategy.Wait
-import org.testcontainers.utility.DockerImageName
 import spock.lang.Unroll
 
 import java.util.concurrent.TimeUnit
@@ -32,7 +32,7 @@ class ConnectorIT extends KafkaConnectorSpec {
 
     @Override
     def setupSpec() {
-        mock = new GenericContainer<>(DockerImageName.parse('wiremock/wiremock:2.33.2'))
+        mock = ContainerImages.WIREMOCK.container()
         mock.withLogConsumer(logger(HOST))
         mock.withNetwork(KafkaConnectorSpec.network)
         mock.withNetworkAliases(HOST)

--- a/cos-fleet-catalog-connectors-it/itops/ansible-tower-it/src/test/resources/logback-test.xml
+++ b/cos-fleet-catalog-connectors-it/itops/ansible-tower-it/src/test/resources/logback-test.xml
@@ -10,6 +10,9 @@
     <logger name="org.apache.kafka.clients.producer.ProducerConfig" level="WARN"/>
     <logger name="org.apache.kafka.clients.admin.AdminClientConfig" level="ERROR"/>
 
+    <logger name="org.apache.kafka.clients.NetworkClient" level="WARN"/>
+    <logger name="org.apache.kafka.clients.consumer.internals.ConsumerCoordinator" level="WARN"/>
+
     <logger name="tc-container" level="INFO"/>
     <logger name="tc-kafka" level="WARN"/>
     <logger name="tc-mock" level="INFO"/>

--- a/cos-fleet-catalog-connectors-it/messaging/http-it/src/test/groovy/org/bf2/cos/connector/camel/it/ConnectorHealthIT.groovy
+++ b/cos-fleet-catalog-connectors-it/messaging/http-it/src/test/groovy/org/bf2/cos/connector/camel/it/ConnectorHealthIT.groovy
@@ -5,13 +5,13 @@ import io.restassured.RestAssured
 import io.restassured.builder.RequestSpecBuilder
 import io.restassured.http.ContentType
 import org.bf2.cos.connector.camel.it.support.ConnectorContainer
+import org.bf2.cos.connector.camel.it.support.ContainerImages
 import org.bf2.cos.connector.camel.it.support.KafkaConnectorSpec
 import org.bf2.cos.connector.camel.it.support.KafkaContainer
 import org.bf2.cos.connector.camel.it.support.SimpleConnectorSpec
 import org.testcontainers.containers.GenericContainer
 import org.testcontainers.containers.Network
 import org.testcontainers.containers.wait.strategy.Wait
-import org.testcontainers.utility.DockerImageName
 
 import java.util.concurrent.TimeUnit
 
@@ -32,7 +32,7 @@ class ConnectorHealthIT extends SimpleConnectorSpec {
 
         network = Network.newNetwork()
 
-        mock = new GenericContainer<>(DockerImageName.parse('wiremock/wiremock:2.34.0'))
+        mock = new GenericContainer<>(ContainerImages.WIREMOCK.imageName())
         mock.withLogConsumer(logger(HOST))
         mock.withNetwork(KafkaConnectorSpec.network)
         mock.withNetworkAliases(HOST)

--- a/cos-fleet-catalog-connectors-it/messaging/http-it/src/test/groovy/org/bf2/cos/connector/camel/it/ConnectorIT.groovy
+++ b/cos-fleet-catalog-connectors-it/messaging/http-it/src/test/groovy/org/bf2/cos/connector/camel/it/ConnectorIT.groovy
@@ -2,21 +2,21 @@ package org.bf2.cos.connector.camel.it
 
 import com.github.tomakehurst.wiremock.client.WireMock
 import groovy.util.logging.Slf4j
+import org.bf2.cos.connector.camel.it.support.ContainerImages
 import org.bf2.cos.connector.camel.it.support.KafkaConnectorSpec
 import org.testcontainers.containers.GenericContainer
 import org.testcontainers.containers.wait.strategy.Wait
-import org.testcontainers.utility.DockerImageName
 import spock.lang.Unroll
 
 import java.util.concurrent.TimeUnit
 
+import static com.github.tomakehurst.wiremock.client.WireMock.absent
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo
 import static com.github.tomakehurst.wiremock.client.WireMock.ok
 import static com.github.tomakehurst.wiremock.client.WireMock.post
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo
 import static com.github.tomakehurst.wiremock.client.WireMock.verify
-import static com.github.tomakehurst.wiremock.client.WireMock.equalTo
-import static com.github.tomakehurst.wiremock.client.WireMock.absent
 
 @Slf4j
 class ConnectorIT extends KafkaConnectorSpec {
@@ -28,7 +28,7 @@ class ConnectorIT extends KafkaConnectorSpec {
 
     @Override
     def setupSpec() {
-        mock = new GenericContainer<>(DockerImageName.parse('wiremock/wiremock:2.33.2'))
+        mock = ContainerImages.WIREMOCK.container()
         mock.withLogConsumer(logger(HOST))
         mock.withNetwork(KafkaConnectorSpec.network)
         mock.withNetworkAliases(HOST)

--- a/cos-fleet-catalog-connectors-it/messaging/http-it/src/test/resources/logback-test.xml
+++ b/cos-fleet-catalog-connectors-it/messaging/http-it/src/test/resources/logback-test.xml
@@ -10,6 +10,9 @@
     <logger name="org.apache.kafka.clients.producer.ProducerConfig" level="WARN"/>
     <logger name="org.apache.kafka.clients.admin.AdminClientConfig" level="ERROR"/>
 
+    <logger name="org.apache.kafka.clients.NetworkClient" level="WARN"/>
+    <logger name="org.apache.kafka.clients.consumer.internals.ConsumerCoordinator" level="WARN"/>
+
     <logger name="tc-container" level="INFO"/>
     <logger name="tc-kafka" level="WARN"/>
     <logger name="tc-mock" level="INFO"/>

--- a/cos-fleet-catalog-connectors-it/messaging/jms-amqp-it/src/test/groovy/org/bf2/cos/connector/camel/it/ConnectorIT.groovy
+++ b/cos-fleet-catalog-connectors-it/messaging/jms-amqp-it/src/test/groovy/org/bf2/cos/connector/camel/it/ConnectorIT.groovy
@@ -3,12 +3,12 @@ package org.bf2.cos.connector.camel.it
 import com.fasterxml.jackson.databind.ObjectMapper
 import groovy.util.logging.Slf4j
 import org.apache.qpid.jms.JmsConnectionFactory
+import org.bf2.cos.connector.camel.it.support.ContainerImages
 import org.bf2.cos.connector.camel.it.support.AwaitStrategy
 import org.bf2.cos.connector.camel.it.support.KafkaConnectorSpec
 import org.testcontainers.containers.ContainerState
 import org.testcontainers.containers.GenericContainer
 import org.testcontainers.containers.wait.strategy.WaitStrategy
-import org.testcontainers.utility.DockerImageName
 
 import javax.jms.BytesMessage
 import javax.jms.Connection
@@ -24,9 +24,7 @@ class ConnectorIT extends KafkaConnectorSpec {
 
     @Override
     def setupSpec() {
-        DockerImageName imageName = DockerImageName.parse('quay.io/artemiscloud/activemq-artemis-broker:1.0.9')
-
-        mq = new GenericContainer(imageName)
+        mq = ContainerImages.ACTIVEMQ_ARTEMIS.container()
         mq.withLogConsumer(logger('tc-activemq'))
         mq.withNetwork(network)
         mq.withNetworkAliases('tc-activemq')

--- a/cos-fleet-catalog-connectors-it/messaging/jms-amqp-it/src/test/resources/logback-test.xml
+++ b/cos-fleet-catalog-connectors-it/messaging/jms-amqp-it/src/test/resources/logback-test.xml
@@ -10,6 +10,9 @@
     <logger name="org.apache.kafka.clients.producer.ProducerConfig" level="WARN"/>
     <logger name="org.apache.kafka.clients.admin.AdminClientConfig" level="ERROR"/>
 
+    <logger name="org.apache.kafka.clients.NetworkClient" level="WARN"/>
+    <logger name="org.apache.kafka.clients.consumer.internals.ConsumerCoordinator" level="WARN"/>
+
     <logger name="tc-container" level="INFO"/>
     <logger name="tc-kafka" level="WARN"/>
     <logger name="tc-activemq" level="DEBUG"/>

--- a/cos-fleet-catalog-connectors-it/nosql/cassandra-it/src/test/groovy/org/bf2/cos/connector/camel/it/ConnectorIT.groovy
+++ b/cos-fleet-catalog-connectors-it/nosql/cassandra-it/src/test/groovy/org/bf2/cos/connector/camel/it/ConnectorIT.groovy
@@ -7,6 +7,7 @@ import com.datastax.driver.core.Session
 import com.datastax.driver.core.Statement
 import com.datastax.driver.core.schemabuilder.SchemaBuilder
 import groovy.util.logging.Slf4j
+import org.bf2.cos.connector.camel.it.support.ContainerImages
 import org.bf2.cos.connector.camel.it.support.KafkaConnectorSpec
 import org.testcontainers.containers.CassandraContainer
 
@@ -21,7 +22,7 @@ class ConnectorIT extends KafkaConnectorSpec {
 
     @Override
     def setupSpec() {
-        cassandra = new CassandraContainer()
+        cassandra = ContainerImages.CASSANDRA.container(CassandraContainer.class)
         cassandra.withLogConsumer(logger('tc-cassandra'))
         cassandra.withNetwork(network)
         cassandra.withNetworkAliases('tc-cassandra')

--- a/cos-fleet-catalog-connectors-it/nosql/cassandra-it/src/test/resources/logback-test.xml
+++ b/cos-fleet-catalog-connectors-it/nosql/cassandra-it/src/test/resources/logback-test.xml
@@ -8,6 +8,10 @@
 
     <logger name="org.apache.kafka.clients.consumer.ConsumerConfig" level="WARN"/>
     <logger name="org.apache.kafka.clients.producer.ProducerConfig" level="WARN"/>
+    <logger name="org.apache.kafka.clients.admin.AdminClientConfig" level="ERROR"/>
+
+    <logger name="org.apache.kafka.clients.NetworkClient" level="WARN"/>
+    <logger name="org.apache.kafka.clients.consumer.internals.ConsumerCoordinator" level="WARN"/>
 
     <logger name="tc-container" level="INFO"/>
     <logger name="tc-kafka" level="WARN"/>

--- a/cos-fleet-catalog-connectors-it/nosql/mongodb-it/src/test/groovy/org/bf2/cos/connector/camel/it/ConnectorIT.groovy
+++ b/cos-fleet-catalog-connectors-it/nosql/mongodb-it/src/test/groovy/org/bf2/cos/connector/camel/it/ConnectorIT.groovy
@@ -2,8 +2,7 @@ package org.bf2.cos.connector.camel.it
 
 import com.mongodb.client.MongoClients
 import groovy.util.logging.Slf4j
-import org.apache.commons.lang3.StringUtils
-import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.bf2.cos.connector.camel.it.support.ContainerImages
 import org.bf2.cos.connector.camel.it.support.KafkaConnectorSpec
 import org.bf2.cos.connector.camel.it.support.TestUtils
 import org.testcontainers.containers.MongoDBContainer
@@ -19,7 +18,7 @@ class ConnectorIT extends KafkaConnectorSpec {
 
     @Override
     def setupSpec() {
-        db = new MongoDBContainer('mongo:5.0.8')
+        db = ContainerImages.MONGODB.container(MongoDBContainer.class)
         db.withLogConsumer(logger('tc-mongodb'))
         db.withNetwork(network)
         db.withNetworkAliases('tc-mongodb')

--- a/cos-fleet-catalog-connectors-it/nosql/mongodb-it/src/test/resources/logback-test.xml
+++ b/cos-fleet-catalog-connectors-it/nosql/mongodb-it/src/test/resources/logback-test.xml
@@ -10,6 +10,9 @@
     <logger name="org.apache.kafka.clients.producer.ProducerConfig" level="WARN"/>
     <logger name="org.apache.kafka.clients.admin.AdminClientConfig" level="ERROR"/>
 
+    <logger name="org.apache.kafka.clients.NetworkClient" level="WARN"/>
+    <logger name="org.apache.kafka.clients.consumer.internals.ConsumerCoordinator" level="WARN"/>
+
     <logger name="tc-container" level="INFO"/>
     <logger name="tc-kafka" level="WARN"/>
     <logger name="tc-mongodb" level="WARN"/>

--- a/cos-fleet-catalog-connectors-it/saas/salesforce-it/src/test/resources/logback-test.xml
+++ b/cos-fleet-catalog-connectors-it/saas/salesforce-it/src/test/resources/logback-test.xml
@@ -8,6 +8,10 @@
 
     <logger name="org.apache.kafka.clients.consumer.ConsumerConfig" level="WARN"/>
     <logger name="org.apache.kafka.clients.producer.ProducerConfig" level="WARN"/>
+    <logger name="org.apache.kafka.clients.admin.AdminClientConfig" level="ERROR"/>
+
+    <logger name="org.apache.kafka.clients.NetworkClient" level="WARN"/>
+    <logger name="org.apache.kafka.clients.consumer.internals.ConsumerCoordinator" level="WARN"/>
 
     <logger name="tc-container" level="INFO"/>
     <logger name="tc-kafka" level="WARN"/>

--- a/cos-fleet-catalog-connectors-it/social/slack-it/src/test/resources/logback-test.xml
+++ b/cos-fleet-catalog-connectors-it/social/slack-it/src/test/resources/logback-test.xml
@@ -9,6 +9,7 @@
     <logger name="org.apache.kafka.clients.consumer.ConsumerConfig" level="WARN"/>
     <logger name="org.apache.kafka.clients.producer.ProducerConfig" level="WARN"/>
     <logger name="org.apache.kafka.clients.admin.AdminClientConfig" level="ERROR"/>
+
     <logger name="org.apache.kafka.clients.NetworkClient" level="WARN"/>
     <logger name="org.apache.kafka.clients.consumer.internals.ConsumerCoordinator" level="WARN"/>
 

--- a/cos-fleet-catalog-connectors-it/sql/mariadb-it/src/test/groovy/org/bf2/cos/connector/camel/it/ConnectorIT.groovy
+++ b/cos-fleet-catalog-connectors-it/sql/mariadb-it/src/test/groovy/org/bf2/cos/connector/camel/it/ConnectorIT.groovy
@@ -2,6 +2,7 @@ package org.bf2.cos.connector.camel.it
 
 import groovy.sql.Sql
 import groovy.util.logging.Slf4j
+import org.bf2.cos.connector.camel.it.support.ContainerImages
 import org.bf2.cos.connector.camel.it.support.KafkaConnectorSpec
 import org.testcontainers.containers.MariaDBContainer
 
@@ -13,7 +14,7 @@ class ConnectorIT extends KafkaConnectorSpec {
 
     @Override
     def setupSpec() {
-        db = new MariaDBContainer('mariadb:10.3.6')
+        db = ContainerImages.MARIADB.container(MariaDBContainer.class)
         db.withLogConsumer(logger('tc-mariadb'))
         db.withNetwork(network)
         db.withNetworkAliases('tc-mariadb')

--- a/cos-fleet-catalog-connectors-it/sql/mariadb-it/src/test/resources/logback-test.xml
+++ b/cos-fleet-catalog-connectors-it/sql/mariadb-it/src/test/resources/logback-test.xml
@@ -10,6 +10,9 @@
     <logger name="org.apache.kafka.clients.producer.ProducerConfig" level="WARN"/>
     <logger name="org.apache.kafka.clients.admin.AdminClientConfig" level="ERROR"/>
 
+    <logger name="org.apache.kafka.clients.NetworkClient" level="WARN"/>
+    <logger name="org.apache.kafka.clients.consumer.internals.ConsumerCoordinator" level="WARN"/>
+
     <logger name="tc-container" level="INFO"/>
     <logger name="tc-kafka" level="WARN"/>
     <logger name="tc-mariadb" level="WARN"/>

--- a/cos-fleet-catalog-connectors-it/sql/mysql-it/src/test/groovy/org/bf2/cos/connector/camel/it/ConnectorIT.groovy
+++ b/cos-fleet-catalog-connectors-it/sql/mysql-it/src/test/groovy/org/bf2/cos/connector/camel/it/ConnectorIT.groovy
@@ -2,6 +2,7 @@ package org.bf2.cos.connector.camel.it
 
 import groovy.sql.Sql
 import groovy.util.logging.Slf4j
+import org.bf2.cos.connector.camel.it.support.ContainerImages
 import org.bf2.cos.connector.camel.it.support.KafkaConnectorSpec
 import org.testcontainers.containers.MySQLContainer
 
@@ -13,7 +14,7 @@ class ConnectorIT extends KafkaConnectorSpec {
 
     @Override
     def setupSpec() {
-        db = new MySQLContainer('mysql:5.7.34')
+        db = ContainerImages.MYSQL.container(MySQLContainer.class)
         db.withLogConsumer(logger('tc-mysql'))
         db.withNetwork(network)
         db.withNetworkAliases('tc-mysql')

--- a/cos-fleet-catalog-connectors-it/sql/mysql-it/src/test/resources/logback-test.xml
+++ b/cos-fleet-catalog-connectors-it/sql/mysql-it/src/test/resources/logback-test.xml
@@ -10,6 +10,9 @@
     <logger name="org.apache.kafka.clients.producer.ProducerConfig" level="WARN"/>
     <logger name="org.apache.kafka.clients.admin.AdminClientConfig" level="ERROR"/>
 
+    <logger name="org.apache.kafka.clients.NetworkClient" level="WARN"/>
+    <logger name="org.apache.kafka.clients.consumer.internals.ConsumerCoordinator" level="WARN"/>
+
     <logger name="tc-container" level="INFO"/>
     <logger name="tc-kafka" level="WARN"/>
     <logger name="tc-mysql" level="WARN"/>

--- a/cos-fleet-catalog-connectors-it/sql/postgresql-it/src/test/groovy/org/bf2/cos/connector/camel/it/ConnectorIT.groovy
+++ b/cos-fleet-catalog-connectors-it/sql/postgresql-it/src/test/groovy/org/bf2/cos/connector/camel/it/ConnectorIT.groovy
@@ -2,6 +2,7 @@ package org.bf2.cos.connector.camel.it
 
 import groovy.sql.Sql
 import groovy.util.logging.Slf4j
+import org.bf2.cos.connector.camel.it.support.ContainerImages
 import org.bf2.cos.connector.camel.it.support.KafkaConnectorSpec
 import org.bf2.cos.connector.camel.it.support.TestUtils
 import org.testcontainers.containers.PostgreSQLContainer
@@ -14,7 +15,7 @@ class ConnectorIT extends KafkaConnectorSpec {
 
     @Override
     def setupSpec() {
-        db = new PostgreSQLContainer<>('postgres:14.2')
+        db = ContainerImages.POSTGRES.container(PostgreSQLContainer.class)
         db.withLogConsumer(logger('tc-postgres'))
         db.withNetwork(network)
         db.withNetworkAliases('tc-postgres')

--- a/cos-fleet-catalog-connectors-it/sql/postgresql-it/src/test/resources/logback-test.xml
+++ b/cos-fleet-catalog-connectors-it/sql/postgresql-it/src/test/resources/logback-test.xml
@@ -10,6 +10,9 @@
     <logger name="org.apache.kafka.clients.producer.ProducerConfig" level="WARN"/>
     <logger name="org.apache.kafka.clients.admin.AdminClientConfig" level="ERROR"/>
 
+    <logger name="org.apache.kafka.clients.NetworkClient" level="WARN"/>
+    <logger name="org.apache.kafka.clients.consumer.internals.ConsumerCoordinator" level="WARN"/>
+
     <logger name="tc-container" level="INFO"/>
     <logger name="tc-kafka" level="WARN"/>
     <logger name="tc-postgres" level="WARN"/>

--- a/cos-fleet-catalog-connectors-it/sql/sqlserver-it/src/test/groovy/org/bf2/cos/connector/camel/it/ConnectorIT.groovy
+++ b/cos-fleet-catalog-connectors-it/sql/sqlserver-it/src/test/groovy/org/bf2/cos/connector/camel/it/ConnectorIT.groovy
@@ -2,6 +2,7 @@ package org.bf2.cos.connector.camel.it
 
 import groovy.sql.Sql
 import groovy.util.logging.Slf4j
+import org.bf2.cos.connector.camel.it.support.ContainerImages
 import org.bf2.cos.connector.camel.it.support.KafkaConnectorSpec
 import org.testcontainers.containers.MSSQLServerContainer
 
@@ -13,7 +14,7 @@ class ConnectorIT extends KafkaConnectorSpec {
 
     @Override
     def setupSpec() {
-        db = new MSSQLServerContainer('mcr.microsoft.com/mssql/server:2017-CU12')
+        db = ContainerImages.SQLSERVER.container(MSSQLServerContainer.class)
         db.acceptLicense()
         db.withLogConsumer(logger('tc-sqlserver'))
         db.withNetwork(network)

--- a/cos-fleet-catalog-connectors-it/sql/sqlserver-it/src/test/resources/logback-test.xml
+++ b/cos-fleet-catalog-connectors-it/sql/sqlserver-it/src/test/resources/logback-test.xml
@@ -10,6 +10,9 @@
     <logger name="org.apache.kafka.clients.producer.ProducerConfig" level="WARN"/>
     <logger name="org.apache.kafka.clients.admin.AdminClientConfig" level="ERROR"/>
 
+    <logger name="org.apache.kafka.clients.NetworkClient" level="WARN"/>
+    <logger name="org.apache.kafka.clients.consumer.internals.ConsumerCoordinator" level="WARN"/>
+
     <logger name="tc-container" level="INFO"/>
     <logger name="tc-kafka" level="WARN"/>
     <logger name="tc-sqlserver" level="INFO"/>

--- a/cos-fleet-catalog-connectors-it/storage/minio-it/src/test/java/org/bf2/cos/connector/camel/it/storage/minio/MinioContainer.java
+++ b/cos-fleet-catalog-connectors-it/storage/minio-it/src/test/java/org/bf2/cos/connector/camel/it/storage/minio/MinioContainer.java
@@ -3,6 +3,7 @@ package org.bf2.cos.connector.camel.it.storage.minio;
 import java.time.Duration;
 import java.util.UUID;
 
+import org.bf2.cos.connector.camel.it.support.ContainerImages;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
@@ -10,7 +11,6 @@ import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
 import io.minio.MinioClient;
 
 public class MinioContainer extends GenericContainer<MinioContainer> {
-    public static final String IMAGE = "quay.io/minio/minio:latest";
     public static final String CONTAINER_ALIAS = "tc-minio";
 
     public static final int PORT = 9000;
@@ -28,7 +28,7 @@ public class MinioContainer extends GenericContainer<MinioContainer> {
     }
 
     public MinioContainer(Network network, String accessKey, String secretKey) {
-        super(IMAGE);
+        super(ContainerImages.MINIO.imageName());
 
         this.accessKey = accessKey;
         this.secretKey = secretKey;

--- a/cos-fleet-catalog-connectors-it/storage/minio-it/src/test/resources/logback-test.xml
+++ b/cos-fleet-catalog-connectors-it/storage/minio-it/src/test/resources/logback-test.xml
@@ -8,6 +8,10 @@
 
     <logger name="org.apache.kafka.clients.consumer.ConsumerConfig" level="WARN"/>
     <logger name="org.apache.kafka.clients.producer.ProducerConfig" level="WARN"/>
+    <logger name="org.apache.kafka.clients.admin.AdminClientConfig" level="ERROR"/>
+
+    <logger name="org.apache.kafka.clients.NetworkClient" level="WARN"/>
+    <logger name="org.apache.kafka.clients.consumer.internals.ConsumerCoordinator" level="WARN"/>
 
     <logger name="tc-container" level="INFO"/>
     <logger name="tc-kafka" level="WARN"/>

--- a/cos-fleet-catalog-connectors/aws/aws-cloudwatch-0.1/src/generated/resources/META-INF/connectors/aws_cloudwatch_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/aws/aws-cloudwatch-0.1/src/generated/resources/META-INF/connectors/aws_cloudwatch_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-cloudwatch:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-cloudwatch:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/aws/aws-dynamodb-0.1/src/generated/resources/META-INF/connectors/aws_ddb_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/aws/aws-dynamodb-0.1/src/generated/resources/META-INF/connectors/aws_ddb_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-ddb:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-ddb:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/aws/aws-dynamodb-streams-0.1/src/generated/resources/META-INF/connectors/aws_ddb_streams_source_0.1.json
+++ b/cos-fleet-catalog-connectors/aws/aws-dynamodb-streams-0.1/src/generated/resources/META-INF/connectors/aws_ddb_streams_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-ddb-streams:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-ddb-streams:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "source",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/aws/aws-kinesis-0.1/src/generated/resources/META-INF/connectors/aws_kinesis_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/aws/aws-kinesis-0.1/src/generated/resources/META-INF/connectors/aws_kinesis_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-kinesis:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-kinesis:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/aws/aws-kinesis-0.1/src/generated/resources/META-INF/connectors/aws_kinesis_source_0.1.json
+++ b/cos-fleet-catalog-connectors/aws/aws-kinesis-0.1/src/generated/resources/META-INF/connectors/aws_kinesis_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-kinesis:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-kinesis:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/aws/aws-lambda-0.1/src/generated/resources/META-INF/connectors/aws_lambda_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/aws/aws-lambda-0.1/src/generated/resources/META-INF/connectors/aws_lambda_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-lambda:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-lambda:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/aws/aws-s3-0.1/src/generated/resources/META-INF/connectors/aws_s3_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/aws/aws-s3-0.1/src/generated/resources/META-INF/connectors/aws_s3_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-s3:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-s3:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/aws/aws-s3-0.1/src/generated/resources/META-INF/connectors/aws_s3_source_0.1.json
+++ b/cos-fleet-catalog-connectors/aws/aws-s3-0.1/src/generated/resources/META-INF/connectors/aws_s3_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-s3:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-s3:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/aws/aws-ses-0.1/src/generated/resources/META-INF/connectors/aws_ses_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/aws/aws-ses-0.1/src/generated/resources/META-INF/connectors/aws_ses_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-ses:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-ses:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/aws/aws-sns-0.1/src/generated/resources/META-INF/connectors/aws_sns_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/aws/aws-sns-0.1/src/generated/resources/META-INF/connectors/aws_sns_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-sns:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-sns:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/aws/aws-sqs-0.1/src/generated/resources/META-INF/connectors/aws_sqs_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/aws/aws-sqs-0.1/src/generated/resources/META-INF/connectors/aws_sqs_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-sqs:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-sqs:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/aws/aws-sqs-0.1/src/generated/resources/META-INF/connectors/aws_sqs_source_0.1.json
+++ b/cos-fleet-catalog-connectors/aws/aws-sqs-0.1/src/generated/resources/META-INF/connectors/aws_sqs_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-sqs:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-sqs:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/azure/azure-eventhubs-0.1/src/generated/resources/META-INF/connectors/azure_eventhubs_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/azure/azure-eventhubs-0.1/src/generated/resources/META-INF/connectors/azure_eventhubs_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-azure-eventhubs:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-azure-eventhubs:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/azure/azure-eventhubs-0.1/src/generated/resources/META-INF/connectors/azure_eventhubs_source_0.1.json
+++ b/cos-fleet-catalog-connectors/azure/azure-eventhubs-0.1/src/generated/resources/META-INF/connectors/azure_eventhubs_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-azure-eventhubs:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-azure-eventhubs:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "source",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/azure/azure-functions-0.1/src/generated/resources/META-INF/connectors/azure_functions_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/azure/azure-functions-0.1/src/generated/resources/META-INF/connectors/azure_functions_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-azure-functions:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-azure-functions:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/azure/azure-storage-blob-0.1/src/generated/resources/META-INF/connectors/azure_storage_blob_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/azure/azure-storage-blob-0.1/src/generated/resources/META-INF/connectors/azure_storage_blob_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-azure-storage-blob:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-azure-storage-blob:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/azure/azure-storage-blob-0.1/src/generated/resources/META-INF/connectors/azure_storage_blob_source_0.1.json
+++ b/cos-fleet-catalog-connectors/azure/azure-storage-blob-0.1/src/generated/resources/META-INF/connectors/azure_storage_blob_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-azure-storage-blob:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-azure-storage-blob:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/azure/azure-storage-blob-changefeed-0.1/src/generated/resources/META-INF/connectors/azure_storage_blob_changefeed_source_0.1.json
+++ b/cos-fleet-catalog-connectors/azure/azure-storage-blob-changefeed-0.1/src/generated/resources/META-INF/connectors/azure_storage_blob_changefeed_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-azure-storage-blob-changefeed:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-azure-storage-blob-changefeed:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/azure/azure-storage-queue-0.1/src/generated/resources/META-INF/connectors/azure_storage_queue_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/azure/azure-storage-queue-0.1/src/generated/resources/META-INF/connectors/azure_storage_queue_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-azure-storage-queue:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-azure-storage-queue:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/azure/azure-storage-queue-0.1/src/generated/resources/META-INF/connectors/azure_storage_queue_source_0.1.json
+++ b/cos-fleet-catalog-connectors/azure/azure-storage-queue-0.1/src/generated/resources/META-INF/connectors/azure_storage_queue_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-azure-storage-queue:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-azure-storage-queue:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/gcp/google-bigquery-0.1/src/generated/resources/META-INF/connectors/google_bigquery_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/gcp/google-bigquery-0.1/src/generated/resources/META-INF/connectors/google_bigquery_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-google-bigquery:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-google-bigquery:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/gcp/google-functions-0.1/src/generated/resources/META-INF/connectors/google_functions_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/gcp/google-functions-0.1/src/generated/resources/META-INF/connectors/google_functions_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-google-functions:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-google-functions:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/gcp/google-pubsub-0.1/src/generated/resources/META-INF/connectors/google_pubsub_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/gcp/google-pubsub-0.1/src/generated/resources/META-INF/connectors/google_pubsub_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-google-pubsub:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-google-pubsub:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/gcp/google-pubsub-0.1/src/generated/resources/META-INF/connectors/google_pubsub_source_0.1.json
+++ b/cos-fleet-catalog-connectors/gcp/google-pubsub-0.1/src/generated/resources/META-INF/connectors/google_pubsub_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-google-pubsub:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-google-pubsub:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/gcp/google-storage-0.1/src/generated/resources/META-INF/connectors/google_storage_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/gcp/google-storage-0.1/src/generated/resources/META-INF/connectors/google_storage_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-google-storage:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-google-storage:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/gcp/google-storage-0.1/src/generated/resources/META-INF/connectors/google_storage_source_0.1.json
+++ b/cos-fleet-catalog-connectors/gcp/google-storage-0.1/src/generated/resources/META-INF/connectors/google_storage_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-google-storage:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-google-storage:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/itops/ansible-tower-0.1/src/generated/resources/META-INF/connectors/ansible_tower_job_template_launch_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/itops/ansible-tower-0.1/src/generated/resources/META-INF/connectors/ansible_tower_job_template_launch_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-ansible-tower:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-ansible-tower:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/itops/splunk-0.1/src/generated/resources/META-INF/connectors/splunk_0.1.json
+++ b/cos-fleet-catalog-connectors/itops/splunk-0.1/src/generated/resources/META-INF/connectors/splunk_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-splunk:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-splunk:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/messaging/http-0.1/src/generated/resources/META-INF/connectors/http_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/messaging/http-0.1/src/generated/resources/META-INF/connectors/http_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-http:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-http:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/messaging/jms-amqp-0.1/src/generated/resources/META-INF/connectors/jms_amqp_10_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/messaging/jms-amqp-0.1/src/generated/resources/META-INF/connectors/jms_amqp_10_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-jms-amqp-10:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-jms-amqp-10:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/messaging/jms-amqp-0.1/src/generated/resources/META-INF/connectors/jms_amqp_10_source_0.1.json
+++ b/cos-fleet-catalog-connectors/messaging/jms-amqp-0.1/src/generated/resources/META-INF/connectors/jms_amqp_10_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-jms-amqp-10:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-jms-amqp-10:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/messaging/jms-artemis-0.1/src/generated/resources/META-INF/connectors/jms_apache_artemis_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/messaging/jms-artemis-0.1/src/generated/resources/META-INF/connectors/jms_apache_artemis_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-jms-apache-artemis:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-jms-apache-artemis:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/messaging/jms-artemis-0.1/src/generated/resources/META-INF/connectors/jms_apache_artemis_source_0.1.json
+++ b/cos-fleet-catalog-connectors/messaging/jms-artemis-0.1/src/generated/resources/META-INF/connectors/jms_apache_artemis_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-jms-apache-artemis:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-jms-apache-artemis:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/messaging/openapi-0.1/src/generated/resources/META-INF/connectors/rest_openapi_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/messaging/openapi-0.1/src/generated/resources/META-INF/connectors/rest_openapi_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-rest-openapi:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-rest-openapi:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/misc/data-generator-0.1/src/generated/resources/META-INF/connectors/data_generator_0.1.json
+++ b/cos-fleet-catalog-connectors/misc/data-generator-0.1/src/generated/resources/META-INF/connectors/data_generator_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-data-generator:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-data-generator:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/nosql/cassandra-0.1/src/generated/resources/META-INF/connectors/cassandra_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/nosql/cassandra-0.1/src/generated/resources/META-INF/connectors/cassandra_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-cassandra:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-cassandra:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/nosql/cassandra-0.1/src/generated/resources/META-INF/connectors/cassandra_source_0.1.json
+++ b/cos-fleet-catalog-connectors/nosql/cassandra-0.1/src/generated/resources/META-INF/connectors/cassandra_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-cassandra:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-cassandra:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "source",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/nosql/elasticsearch-0.1/src/generated/resources/META-INF/connectors/elasticsearch_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/nosql/elasticsearch-0.1/src/generated/resources/META-INF/connectors/elasticsearch_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-elasticsearch:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-elasticsearch:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/nosql/mongodb-0.1/src/generated/resources/META-INF/connectors/mongodb_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/nosql/mongodb-0.1/src/generated/resources/META-INF/connectors/mongodb_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-mongodb:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-mongodb:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/nosql/mongodb-0.1/src/generated/resources/META-INF/connectors/mongodb_source_0.1.json
+++ b/cos-fleet-catalog-connectors/nosql/mongodb-0.1/src/generated/resources/META-INF/connectors/mongodb_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-mongodb:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-mongodb:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "source",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/pom.xml
+++ b/cos-fleet-catalog-connectors/pom.xml
@@ -20,6 +20,8 @@
         <quarkus.container-image.registry>${cos.connector.container.repository}</quarkus.container-image.registry>
         <quarkus.container-image.group>${cos.connector.container.organization}</quarkus.container-image.group>
 
+
+        <quarkus.jib.base-jvm-image>registry.access.redhat.com/ubi8/openjdk-11-runtime:1.14</quarkus.jib.base-jvm-image>
         <quarkus.jib.jvm-arguments>-XX:+UseShenandoahGC,-Djava.util.logging.manager=org.jboss.logmanager.LogManager</quarkus.jib.jvm-arguments>
 
         <cos.catalog.validation.mode>FAIL</cos.catalog.validation.mode>

--- a/cos-fleet-catalog-connectors/saas/jira-0.1/src/generated/resources/META-INF/connectors/jira_add_comment_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/saas/jira-0.1/src/generated/resources/META-INF/connectors/jira_add_comment_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-jira:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-jira:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/saas/jira-0.1/src/generated/resources/META-INF/connectors/jira_add_issue_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/saas/jira-0.1/src/generated/resources/META-INF/connectors/jira_add_issue_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-jira:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-jira:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/saas/jira-0.1/src/generated/resources/META-INF/connectors/jira_source_0.1.json
+++ b/cos-fleet-catalog-connectors/saas/jira-0.1/src/generated/resources/META-INF/connectors/jira_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-jira:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-jira:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "source",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/saas/salesforce-0.1/src/generated/resources/META-INF/connectors/salesforce_create_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/saas/salesforce-0.1/src/generated/resources/META-INF/connectors/salesforce_create_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-salesforce:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-salesforce:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/saas/salesforce-0.1/src/generated/resources/META-INF/connectors/salesforce_delete_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/saas/salesforce-0.1/src/generated/resources/META-INF/connectors/salesforce_delete_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-salesforce:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-salesforce:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/saas/salesforce-0.1/src/generated/resources/META-INF/connectors/salesforce_streaming_source_0.1.json
+++ b/cos-fleet-catalog-connectors/saas/salesforce-0.1/src/generated/resources/META-INF/connectors/salesforce_streaming_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-salesforce:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-salesforce:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "source",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/saas/salesforce-0.1/src/generated/resources/META-INF/connectors/salesforce_update_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/saas/salesforce-0.1/src/generated/resources/META-INF/connectors/salesforce_update_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-salesforce:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-salesforce:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/social/slack-0.1/src/generated/resources/META-INF/connectors/slack_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/social/slack-0.1/src/generated/resources/META-INF/connectors/slack_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-slack:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-slack:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/social/slack-0.1/src/generated/resources/META-INF/connectors/slack_source_0.1.json
+++ b/cos-fleet-catalog-connectors/social/slack-0.1/src/generated/resources/META-INF/connectors/slack_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-slack:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-slack:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "source",
         "consumes" : "application/json",
         "consumes_class" : "com.slack.api.model.Message",

--- a/cos-fleet-catalog-connectors/social/telegram-0.1/src/generated/resources/META-INF/connectors/telegram_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/social/telegram-0.1/src/generated/resources/META-INF/connectors/telegram_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-telegram:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-telegram:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/social/telegram-0.1/src/generated/resources/META-INF/connectors/telegram_source_0.1.json
+++ b/cos-fleet-catalog-connectors/social/telegram-0.1/src/generated/resources/META-INF/connectors/telegram_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-telegram:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-telegram:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "source",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/sql/aws-redshift-0.1/src/generated/resources/META-INF/connectors/aws_redshift_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/sql/aws-redshift-0.1/src/generated/resources/META-INF/connectors/aws_redshift_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-redshift:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-redshift:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/sql/aws-redshift-0.1/src/generated/resources/META-INF/connectors/aws_redshift_source_0.1.json
+++ b/cos-fleet-catalog-connectors/sql/aws-redshift-0.1/src/generated/resources/META-INF/connectors/aws_redshift_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-redshift:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-redshift:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "source",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/sql/mariadb-0.1/src/generated/resources/META-INF/connectors/mariadb_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/sql/mariadb-0.1/src/generated/resources/META-INF/connectors/mariadb_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-mariadb:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-mariadb:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/sql/mariadb-0.1/src/generated/resources/META-INF/connectors/mariadb_source_0.1.json
+++ b/cos-fleet-catalog-connectors/sql/mariadb-0.1/src/generated/resources/META-INF/connectors/mariadb_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-mariadb:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-mariadb:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "source",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/sql/mysql-0.1/src/generated/resources/META-INF/connectors/mysql_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/sql/mysql-0.1/src/generated/resources/META-INF/connectors/mysql_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-mysql:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-mysql:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/sql/mysql-0.1/src/generated/resources/META-INF/connectors/mysql_source_0.1.json
+++ b/cos-fleet-catalog-connectors/sql/mysql-0.1/src/generated/resources/META-INF/connectors/mysql_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-mysql:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-mysql:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "source",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/sql/postgresql-0.1/src/generated/resources/META-INF/connectors/postgresql_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/sql/postgresql-0.1/src/generated/resources/META-INF/connectors/postgresql_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-postgresql:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-postgresql:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/sql/postgresql-0.1/src/generated/resources/META-INF/connectors/postgresql_source_0.1.json
+++ b/cos-fleet-catalog-connectors/sql/postgresql-0.1/src/generated/resources/META-INF/connectors/postgresql_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-postgresql:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-postgresql:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "source",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/sql/sqlserver-0.1/src/generated/resources/META-INF/connectors/sqlserver_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/sql/sqlserver-0.1/src/generated/resources/META-INF/connectors/sqlserver_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-sqlserver:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-sqlserver:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/sql/sqlserver-0.1/src/generated/resources/META-INF/connectors/sqlserver_source_0.1.json
+++ b/cos-fleet-catalog-connectors/sql/sqlserver-0.1/src/generated/resources/META-INF/connectors/sqlserver_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-sqlserver:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-sqlserver:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "source",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/storage/ftps-0.1/src/generated/resources/META-INF/connectors/ftps_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/storage/ftps-0.1/src/generated/resources/META-INF/connectors/ftps_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-ftps:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-ftps:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/storage/ftps-0.1/src/generated/resources/META-INF/connectors/ftps_source_0.1.json
+++ b/cos-fleet-catalog-connectors/storage/ftps-0.1/src/generated/resources/META-INF/connectors/ftps_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-ftps:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-ftps:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/storage/minio-0.1/src/generated/resources/META-INF/connectors/minio_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/storage/minio-0.1/src/generated/resources/META-INF/connectors/minio_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-minio:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-minio:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/storage/minio-0.1/src/generated/resources/META-INF/connectors/minio_source_0.1.json
+++ b/cos-fleet-catalog-connectors/storage/minio-0.1/src/generated/resources/META-INF/connectors/minio_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-minio:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-minio:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/storage/sftp-0.1/src/generated/resources/META-INF/connectors/sftp_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/storage/sftp-0.1/src/generated/resources/META-INF/connectors/sftp_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-sftp:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-sftp:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/storage/sftp-0.1/src/generated/resources/META-INF/connectors/sftp_source_0.1.json
+++ b/cos-fleet-catalog-connectors/storage/sftp-0.1/src/generated/resources/META-INF/connectors/sftp_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-sftp:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-sftp:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-aws/aws_cloudwatch_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-aws/aws_cloudwatch_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-cloudwatch:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-cloudwatch:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-aws/aws_ddb_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-aws/aws_ddb_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-ddb:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-ddb:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-aws/aws_ddb_streams_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-aws/aws_ddb_streams_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-ddb-streams:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-ddb-streams:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "source",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-aws/aws_kinesis_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-aws/aws_kinesis_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-kinesis:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-kinesis:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-aws/aws_kinesis_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-aws/aws_kinesis_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-kinesis:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-kinesis:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-aws/aws_lambda_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-aws/aws_lambda_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-lambda:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-lambda:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-aws/aws_s3_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-aws/aws_s3_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-s3:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-s3:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-aws/aws_s3_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-aws/aws_s3_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-s3:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-s3:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-aws/aws_ses_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-aws/aws_ses_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-ses:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-ses:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-aws/aws_sns_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-aws/aws_sns_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-sns:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-sns:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-aws/aws_sqs_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-aws/aws_sqs_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-sqs:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-sqs:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-aws/aws_sqs_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-aws/aws_sqs_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-sqs:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-sqs:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-azure/azure_eventhubs_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-azure/azure_eventhubs_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-azure-eventhubs:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-azure-eventhubs:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-azure/azure_eventhubs_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-azure/azure_eventhubs_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-azure-eventhubs:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-azure-eventhubs:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "source",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-azure/azure_functions_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-azure/azure_functions_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-azure-functions:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-azure-functions:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-azure/azure_storage_blob_changefeed_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-azure/azure_storage_blob_changefeed_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-azure-storage-blob-changefeed:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-azure-storage-blob-changefeed:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-azure/azure_storage_blob_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-azure/azure_storage_blob_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-azure-storage-blob:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-azure-storage-blob:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-azure/azure_storage_blob_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-azure/azure_storage_blob_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-azure-storage-blob:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-azure-storage-blob:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-azure/azure_storage_queue_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-azure/azure_storage_queue_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-azure-storage-queue:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-azure-storage-queue:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-azure/azure_storage_queue_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-azure/azure_storage_queue_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-azure-storage-queue:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-azure-storage-queue:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-gcp/google_bigquery_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-gcp/google_bigquery_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-google-bigquery:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-google-bigquery:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-gcp/google_functions_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-gcp/google_functions_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-google-functions:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-google-functions:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-gcp/google_pubsub_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-gcp/google_pubsub_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-google-pubsub:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-google-pubsub:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-gcp/google_pubsub_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-gcp/google_pubsub_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-google-pubsub:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-google-pubsub:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-gcp/google_storage_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-gcp/google_storage_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-google-storage:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-google-storage:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-gcp/google_storage_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-gcp/google_storage_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-google-storage:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-google-storage:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-itops/ansible_tower_job_template_launch_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-itops/ansible_tower_job_template_launch_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-ansible-tower:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-ansible-tower:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-itops/splunk_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-itops/splunk_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-splunk:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-splunk:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-messaging/http_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-messaging/http_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-http:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-http:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-messaging/jms_amqp_10_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-messaging/jms_amqp_10_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-jms-amqp-10:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-jms-amqp-10:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-messaging/jms_amqp_10_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-messaging/jms_amqp_10_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-jms-amqp-10:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-jms-amqp-10:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-messaging/jms_apache_artemis_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-messaging/jms_apache_artemis_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-jms-apache-artemis:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-jms-apache-artemis:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-messaging/jms_apache_artemis_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-messaging/jms_apache_artemis_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-jms-apache-artemis:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-jms-apache-artemis:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-messaging/rest_openapi_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-messaging/rest_openapi_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-rest-openapi:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-rest-openapi:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-misc/data_generator_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-misc/data_generator_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-data-generator:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-data-generator:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-nosql/cassandra_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-nosql/cassandra_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-cassandra:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-cassandra:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-nosql/cassandra_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-nosql/cassandra_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-cassandra:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-cassandra:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "source",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-nosql/elasticsearch_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-nosql/elasticsearch_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-elasticsearch:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-elasticsearch:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-nosql/mongodb_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-nosql/mongodb_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-mongodb:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-mongodb:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-nosql/mongodb_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-nosql/mongodb_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-mongodb:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-mongodb:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "source",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-saas/jira_add_comment_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-saas/jira_add_comment_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-jira:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-jira:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-saas/jira_add_issue_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-saas/jira_add_issue_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-jira:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-jira:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-saas/jira_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-saas/jira_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-jira:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-jira:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "source",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-saas/salesforce_create_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-saas/salesforce_create_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-salesforce:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-salesforce:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-saas/salesforce_delete_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-saas/salesforce_delete_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-salesforce:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-salesforce:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-saas/salesforce_streaming_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-saas/salesforce_streaming_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-salesforce:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-salesforce:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "source",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-saas/salesforce_update_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-saas/salesforce_update_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-salesforce:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-salesforce:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-social/slack_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-social/slack_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-slack:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-slack:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-social/slack_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-social/slack_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-slack:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-slack:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "source",
         "consumes" : "application/json",
         "consumes_class" : "com.slack.api.model.Message",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-social/telegram_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-social/telegram_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-telegram:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-telegram:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-social/telegram_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-social/telegram_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-telegram:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-telegram:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "source",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-sql/aws_redshift_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-sql/aws_redshift_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-redshift:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-redshift:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-sql/aws_redshift_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-sql/aws_redshift_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-redshift:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-redshift:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "source",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-sql/mariadb_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-sql/mariadb_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-mariadb:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-mariadb:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-sql/mariadb_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-sql/mariadb_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-mariadb:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-mariadb:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "source",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-sql/mysql_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-sql/mysql_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-mysql:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-mysql:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-sql/mysql_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-sql/mysql_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-mysql:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-mysql:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "source",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-sql/postgresql_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-sql/postgresql_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-postgresql:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-postgresql:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-sql/postgresql_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-sql/postgresql_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-postgresql:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-postgresql:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "source",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-sql/sqlserver_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-sql/sqlserver_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-sqlserver:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-sqlserver:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-sql/sqlserver_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-sql/sqlserver_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-sqlserver:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-sqlserver:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "source",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-storage/ftps_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-storage/ftps_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-ftps:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-ftps:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-storage/ftps_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-storage/ftps_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-ftps:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-ftps:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-storage/minio_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-storage/minio_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-minio:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-minio:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-storage/minio_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-storage/minio_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-minio:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-minio:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-storage/sftp_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-storage/sftp_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-sftp:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-sftp:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-storage/sftp_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-storage/sftp_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-sftp:0.1.52",
-        "connector_revision" : 52,
+        "connector_image" : "quay.io/rhoas/cos-connector-sftp:0.1.53",
+        "connector_revision" : 53,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <cos.connector.catalog.group>all</cos.connector.catalog.group>
 
         <cos.connector.version>0.1</cos.connector.version>
-        <cos.connector.revision>52</cos.connector.revision>
+        <cos.connector.revision>53</cos.connector.revision>
         <cos.connector.operator.version>[1.0.0,2.0.0)</cos.connector.operator.version>
         <cos.kamelets.version>0.0.1</cos.kamelets.version>
 


### PR DESCRIPTION
- chore: bump base image to openjdk-11-runtime:1.14
- chore(it): define container images in a single location
- chore(it): reduce kafka log noises
- chore: catalog rev 53
