### PR TITLE
MGDCTRS-1624: use custom azure kamelet to fix base64 issue

### DIFF
--- a/cos-fleet-catalog-connectors-it-support/src/main/java/org/bf2/cos/connector/camel/it/support/ConnectorContainer.java
+++ b/cos-fleet-catalog-connectors-it-support/src/main/java/org/bf2/cos/connector/camel/it/support/ConnectorContainer.java
@@ -1,5 +1,6 @@
 package org.bf2.cos.connector.camel.it.support;
 
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -410,13 +411,21 @@ public class ConnectorContainer extends GenericContainer<ConnectorContainer> {
 
                     String routeYaml = yaml.writerWithDefaultPrettyPrinter().writeValueAsString(integration);
 
-                    LOGGER.info("route: \n{}", routeYaml);
+                    LOGGER.info("\n\n----------------\nroute: \n{}\n----------------\n\n", routeYaml);
 
                     answer.withFile(DEFAULT_ROUTE_LOCATION, routeYaml);
+
+                    LOGGER.info("\n\n----------------\nuser properties: \n{}\n----------------\n\n", userProperties);
                     answer.withUserProperties(userProperties);
 
                     try (InputStream ip = ConnectorContainer.class.getResourceAsStream("/integration-application.properties")) {
-                        answer.withFile(DEFAULT_APPLICATION_PROPERTIES_LOCATION, ip);
+                        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                        ip.transferTo(baos);
+                        byte[] bytes = baos.toByteArray();
+
+                        LOGGER.info("\n\n----------------\napplication properties: \n{}\n----------------\n\n",
+                                new String(bytes));
+                        answer.withFile(DEFAULT_APPLICATION_PROPERTIES_LOCATION, new ByteArrayInputStream(bytes));
                     }
                 }
 

--- a/cos-fleet-catalog-connectors-it/azure/eventhubs-it/src/test/groovy/org/bf2/cos/connector/camel/it/ConnectorIT.groovy
+++ b/cos-fleet-catalog-connectors-it/azure/eventhubs-it/src/test/groovy/org/bf2/cos/connector/camel/it/ConnectorIT.groovy
@@ -8,8 +8,11 @@ import com.azure.messaging.eventhubs.models.EventPosition
 import groovy.util.logging.Slf4j
 import org.bf2.cos.connector.camel.it.support.KafkaConnectorSpec
 import org.bf2.cos.connector.camel.it.support.TestUtils
+import spock.lang.Ignore
 import spock.lang.IgnoreIf
 
+import java.time.Duration
+import java.time.Instant
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
 
@@ -17,10 +20,14 @@ import java.util.concurrent.TimeUnit
     !hasEnv('AZURE_EVENTHUB_NAME'      ) ||
     !hasEnv('AZURE_NAMESPACE_NAME'     ) ||
     !hasEnv('AZURE_SHARED_ACCESS_NAME' ) ||
-    !hasEnv('AZURE_SHARED_ACCESS_KEY'  )
+    !hasEnv('AZURE_SHARED_ACCESS_KEY'  ) ||
+    !hasEnv('AZURE_BLOB_ACCOUNT_NAME'  ) ||
+    !hasEnv('AZURE_BLOB_ACCESS_KEY'    ) ||
+    !hasEnv('AZURE_BLOB_CONTAINER_NAME')
 })
 @Slf4j
 class ConnectorIT extends KafkaConnectorSpec {
+
     def "azure-eventhubs sink"() {
         setup:
             def topic = topic()
@@ -43,7 +50,7 @@ class ConnectorIT extends KafkaConnectorSpec {
                 'azure_shared_access_key': sharedAccessKey
             ])
 
-            cnt.withEnv("AZURE_LOG_LEVEL", System.getenv().getOrDefault('AZURE_LOG_LEVEL', 'info'))
+            cnt.withEnv("AZURE_LOG_LEVEL", System.getenv().getOrDefault('AZURE_LOG_LEVEL', 'warn'))
             cnt.withUserProperty('quarkus.log.level', 'DEBUG')
             cnt.withUserProperty('quarkus.log.category."org.apache.camel.component".level', 'DEBUG')
             cnt.start()
@@ -94,4 +101,65 @@ class ConnectorIT extends KafkaConnectorSpec {
             closeQuietly(cnt)
             eventHubClient.stop()
     }
+
+    def "azure-eventhubs source"() {
+        setup:
+            def topic = topic()
+            def group = UUID.randomUUID().toString()
+            def payload = '''{ "value": "4", "suit": "hearts" }'''
+
+            def namespaceName = System.getenv('AZURE_NAMESPACE_NAME')
+            def sharedAccessName = System.getenv('AZURE_SHARED_ACCESS_NAME')
+            def sharedAccessKey = System.getenv('AZURE_SHARED_ACCESS_KEY')
+            def eventhubName = System.getenv('AZURE_EVENTHUB_NAME')
+            def blobAccountName = System.getenv('AZURE_BLOB_ACCOUNT_NAME')
+            def blobAccessKey = System.getenv('AZURE_BLOB_ACCESS_KEY')
+            def blobContainerName = System.getenv('AZURE_BLOB_CONTAINER_NAME')
+
+            def cnt = connectorContainer('azure_eventhubs_source_0.1.json', [
+                    'kafka_topic' : topic,
+                    'kafka_bootstrap_servers': kafka.outsideBootstrapServers,
+                    'azure_eventhub_name': eventhubName,
+                    'azure_namespace_name': namespaceName,
+                    'azure_shared_access_name': sharedAccessName,
+                    'azure_shared_access_key': sharedAccessKey,
+                    'azure_blob_account_name': blobAccountName,
+                    'azure_blob_access_key': blobAccessKey,
+                    'azure_blob_container_name': blobContainerName,
+            ])
+
+            cnt.withEnv("AZURE_LOG_LEVEL", System.getenv().getOrDefault('AZURE_LOG_LEVEL', 'warn'))
+            cnt.withUserProperty('quarkus.log.level', 'DEBUG')
+            cnt.withUserProperty('quarkus.log.category."org.apache.camel.component".level', 'DEBUG')
+            cnt.start()
+
+            // azure sdk client to write the message to EventHub
+            def eventHubClient = new EventHubClientBuilder()
+                    .connectionString("Endpoint=sb://${namespaceName}.servicebus.windows.net/;SharedAccessKeyName=${sharedAccessName};SharedAccessKey=${sharedAccessKey};EntityPath=${eventhubName}")
+                    .consumerGroup(EventHubClientBuilder.DEFAULT_CONSUMER_GROUP_NAME)
+                    .transportType(AmqpTransportType.AMQP)
+                    .buildProducerClient();
+
+            def eventData = new EventData(payload)
+
+            def batch = eventHubClient.createBatch();
+            batch.tryAdd(eventData)
+        when:
+            eventHubClient.send(batch)
+            sleep(1000)
+        then:
+            def records = kafka.poll(group, topic)
+            records.size() > 0
+
+            def lastMessage = records.last()
+            lastMessage.value() == payload
+
+            def messageTimestamp = lastMessage.timestamp()
+            Duration.between(Instant.ofEpochMilli(messageTimestamp), Instant.now()).toSeconds() < 5
+
+        cleanup:
+            closeQuietly(cnt)
+            closeQuietly(eventHubClient)
+    }
+
 }

--- a/cos-fleet-catalog-connectors/aws/aws-cloudwatch-0.1/src/generated/resources/META-INF/connectors/aws_cloudwatch_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/aws/aws-cloudwatch-0.1/src/generated/resources/META-INF/connectors/aws_cloudwatch_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-cloudwatch:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-cloudwatch:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/aws/aws-dynamodb-0.1/src/generated/resources/META-INF/connectors/aws_ddb_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/aws/aws-dynamodb-0.1/src/generated/resources/META-INF/connectors/aws_ddb_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-ddb:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-ddb:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/aws/aws-dynamodb-streams-0.1/src/generated/resources/META-INF/connectors/aws_ddb_streams_source_0.1.json
+++ b/cos-fleet-catalog-connectors/aws/aws-dynamodb-streams-0.1/src/generated/resources/META-INF/connectors/aws_ddb_streams_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-ddb-streams:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-ddb-streams:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "source",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/aws/aws-kinesis-0.1/src/generated/resources/META-INF/connectors/aws_kinesis_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/aws/aws-kinesis-0.1/src/generated/resources/META-INF/connectors/aws_kinesis_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-kinesis:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-kinesis:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/aws/aws-kinesis-0.1/src/generated/resources/META-INF/connectors/aws_kinesis_source_0.1.json
+++ b/cos-fleet-catalog-connectors/aws/aws-kinesis-0.1/src/generated/resources/META-INF/connectors/aws_kinesis_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-kinesis:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-kinesis:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/aws/aws-lambda-0.1/src/generated/resources/META-INF/connectors/aws_lambda_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/aws/aws-lambda-0.1/src/generated/resources/META-INF/connectors/aws_lambda_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-lambda:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-lambda:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/aws/aws-s3-0.1/src/generated/resources/META-INF/connectors/aws_s3_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/aws/aws-s3-0.1/src/generated/resources/META-INF/connectors/aws_s3_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-s3:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-s3:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/aws/aws-s3-0.1/src/generated/resources/META-INF/connectors/aws_s3_source_0.1.json
+++ b/cos-fleet-catalog-connectors/aws/aws-s3-0.1/src/generated/resources/META-INF/connectors/aws_s3_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-s3:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-s3:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/aws/aws-ses-0.1/src/generated/resources/META-INF/connectors/aws_ses_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/aws/aws-ses-0.1/src/generated/resources/META-INF/connectors/aws_ses_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-ses:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-ses:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/aws/aws-sns-0.1/src/generated/resources/META-INF/connectors/aws_sns_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/aws/aws-sns-0.1/src/generated/resources/META-INF/connectors/aws_sns_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-sns:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-sns:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/aws/aws-sqs-0.1/src/generated/resources/META-INF/connectors/aws_sqs_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/aws/aws-sqs-0.1/src/generated/resources/META-INF/connectors/aws_sqs_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-sqs:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-sqs:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/aws/aws-sqs-0.1/src/generated/resources/META-INF/connectors/aws_sqs_source_0.1.json
+++ b/cos-fleet-catalog-connectors/aws/aws-sqs-0.1/src/generated/resources/META-INF/connectors/aws_sqs_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-sqs:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-sqs:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/azure/azure-eventhubs-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/azure/azure-eventhubs-0.1/pom.xml
@@ -43,14 +43,21 @@
                             <description>Receive data from Azure Event Hubs.</description>
                             <adapter>
                                 <prefix>azure</prefix>
-                                <name>${cos.connector.type}-source</name>
-                                <version>${camel-kamelets-catalog.version}</version>
+                                <name>cos-${cos.connector.type}-source</name>
+                                <version>${cos.kamelets.version}</version>
                             </adapter>
                             <kafka>
                                 <prefix>kafka</prefix>
                                 <name>cos-kafka-sink</name>
                                 <version>${cos.kamelets.version}</version>
                             </kafka>
+                            <dataShape>
+                                <produces>
+                                    <formats>
+                                        <format>application/octet-stream</format>
+                                    </formats>
+                                </produces>
+                            </dataShape>
                         </connector>
                         <connector>
                             <name>${cos.connector.type}-sink-${cos.connector.version}</name>

--- a/cos-fleet-catalog-connectors/azure/azure-eventhubs-0.1/src/generated/resources/META-INF/connectors/azure_eventhubs_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/azure/azure-eventhubs-0.1/src/generated/resources/META-INF/connectors/azure_eventhubs_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-azure-eventhubs:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-azure-eventhubs:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/azure/azure-eventhubs-0.1/src/generated/resources/META-INF/connectors/azure_eventhubs_source_0.1.json
+++ b/cos-fleet-catalog-connectors/azure/azure-eventhubs-0.1/src/generated/resources/META-INF/connectors/azure_eventhubs_source_0.1.json
@@ -7,14 +7,14 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-azure-eventhubs:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-azure-eventhubs:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "source",
-        "consumes" : "application/json",
+        "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",
         "kamelets" : {
           "adapter" : {
-            "name" : "azure-eventhubs-source",
+            "name" : "cos-azure-eventhubs-source",
             "prefix" : "azure"
           },
           "kafka" : {
@@ -26,7 +26,7 @@
           "type" : "camel-connector-operator",
           "version" : "[1.0.0,2.0.0)"
         } ],
-        "produces" : "application/json"
+        "produces" : "application/octet-stream"
       }
     }
   },
@@ -107,6 +107,9 @@
           "type" : "object",
           "additionalProperties" : false,
           "properties" : {
+            "consumes" : {
+              "$ref" : "#/$defs/data_shape/consumes"
+            },
             "produces" : {
               "$ref" : "#/$defs/data_shape/produces"
             }
@@ -150,6 +153,19 @@
       },
       "$defs" : {
         "data_shape" : {
+          "consumes" : {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "format" ],
+            "properties" : {
+              "format" : {
+                "type" : "string",
+                "description" : "The format of the data that Kafka sends to the sink connector.",
+                "default" : "application/octet-stream",
+                "enum" : [ "application/octet-stream" ]
+              }
+            }
+          },
           "produces" : {
             "type" : "object",
             "additionalProperties" : false,
@@ -158,8 +174,8 @@
               "format" : {
                 "type" : "string",
                 "description" : "The format of the data that the source connector sends to Kafka.",
-                "default" : "application/json",
-                "enum" : [ "application/json" ]
+                "default" : "application/octet-stream",
+                "enum" : [ "application/octet-stream" ]
               }
             }
           }

--- a/cos-fleet-catalog-connectors/azure/azure-eventhubs-0.1/src/main/resources/kamelets/cos-azure-eventhubs-source.kamelet.yaml
+++ b/cos-fleet-catalog-connectors/azure/azure-eventhubs-0.1/src/main/resources/kamelets/cos-azure-eventhubs-source.kamelet.yaml
@@ -1,0 +1,80 @@
+apiVersion: camel.apache.org/v1alpha1
+kind: Kamelet
+metadata:
+  name: cos-azure-eventhubs-source
+  annotations:
+    camel.apache.org/provider: "Red Hat"
+    camel.apache.org/kamelet.version: "${cos.kamelets.version}"
+  labels:
+    camel.apache.org/kamelet.type: "source"
+spec:
+  definition:
+    title: "Azure Eventhubs Source"
+    description: |-
+      Receive events from Azure Event Hubs.
+    required:
+      - namespaceName
+      - eventhubName
+      - sharedAccessName
+      - sharedAccessKey
+      - blobAccountName
+      - blobAccessKey
+      - blobContainerName
+    type: object
+    properties:
+      namespaceName:
+        title: Eventhubs Namespace
+        description: The Event Hubs namespace.
+        type: string
+      eventhubName:
+        title: Eventhubs Name
+        description: The Event Hub name.
+        type: string
+      sharedAccessName:
+        title: Share Access Name
+        description: The Event Hubs SAS key name.
+        type: string
+        x-descriptors:
+          - urn:camel:group:credentials
+      sharedAccessKey:
+        title: Share Access Key
+        description: The key for the Event Hubs SAS key name.
+        type: string
+        format: password
+        x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:password
+          - urn:camel:group:credentials
+      blobAccountName:
+        title: Azure Storage Blob Account Name
+        description: The name of the Storage Blob account.
+        type: string
+      blobContainerName:
+        title: Azure Storage Blob Container Name
+        description: The name of the Storage Blob container.
+        type: string
+      blobAccessKey:
+        title: Azure Storage Blob Access Key
+        description: The key for the Azure Storage Blob service that is associated with the Storage Blob account name.
+        type: string
+        format: password
+        x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:password
+          - urn:camel:group:credentials
+  types:
+    out:
+      mediaType: application/octet-stream
+  dependencies:
+    - "camel:azure-eventhubs"
+    - "camel:kamelet"
+    - "camel:jackson"
+  template:
+    from:
+      uri: 'azure-eventhubs://{{namespaceName}}/{{eventhubName}}'
+      parameters:
+        sharedAccessName: "{{sharedAccessName}}"
+        sharedAccessKey: "{{sharedAccessKey}}"
+        blobAccountName: "{{blobAccountName}}"
+        blobAccessKey: "{{blobAccessKey}}"
+        blobContainerName: "{{blobContainerName}}"
+      steps:
+        - to: "kamelet:sink"

--- a/cos-fleet-catalog-connectors/azure/azure-functions-0.1/src/generated/resources/META-INF/connectors/azure_functions_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/azure/azure-functions-0.1/src/generated/resources/META-INF/connectors/azure_functions_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-azure-functions:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-azure-functions:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/azure/azure-storage-blob-0.1/src/generated/resources/META-INF/connectors/azure_storage_blob_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/azure/azure-storage-blob-0.1/src/generated/resources/META-INF/connectors/azure_storage_blob_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-azure-storage-blob:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-azure-storage-blob:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/azure/azure-storage-blob-0.1/src/generated/resources/META-INF/connectors/azure_storage_blob_source_0.1.json
+++ b/cos-fleet-catalog-connectors/azure/azure-storage-blob-0.1/src/generated/resources/META-INF/connectors/azure_storage_blob_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-azure-storage-blob:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-azure-storage-blob:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/azure/azure-storage-blob-changefeed-0.1/src/generated/resources/META-INF/connectors/azure_storage_blob_changefeed_source_0.1.json
+++ b/cos-fleet-catalog-connectors/azure/azure-storage-blob-changefeed-0.1/src/generated/resources/META-INF/connectors/azure_storage_blob_changefeed_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-azure-storage-blob-changefeed:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-azure-storage-blob-changefeed:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/azure/azure-storage-queue-0.1/src/generated/resources/META-INF/connectors/azure_storage_queue_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/azure/azure-storage-queue-0.1/src/generated/resources/META-INF/connectors/azure_storage_queue_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-azure-storage-queue:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-azure-storage-queue:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/azure/azure-storage-queue-0.1/src/generated/resources/META-INF/connectors/azure_storage_queue_source_0.1.json
+++ b/cos-fleet-catalog-connectors/azure/azure-storage-queue-0.1/src/generated/resources/META-INF/connectors/azure_storage_queue_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-azure-storage-queue:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-azure-storage-queue:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/gcp/google-bigquery-0.1/src/generated/resources/META-INF/connectors/google_bigquery_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/gcp/google-bigquery-0.1/src/generated/resources/META-INF/connectors/google_bigquery_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-google-bigquery:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-google-bigquery:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/gcp/google-functions-0.1/src/generated/resources/META-INF/connectors/google_functions_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/gcp/google-functions-0.1/src/generated/resources/META-INF/connectors/google_functions_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-google-functions:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-google-functions:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/gcp/google-pubsub-0.1/src/generated/resources/META-INF/connectors/google_pubsub_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/gcp/google-pubsub-0.1/src/generated/resources/META-INF/connectors/google_pubsub_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-google-pubsub:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-google-pubsub:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/gcp/google-pubsub-0.1/src/generated/resources/META-INF/connectors/google_pubsub_source_0.1.json
+++ b/cos-fleet-catalog-connectors/gcp/google-pubsub-0.1/src/generated/resources/META-INF/connectors/google_pubsub_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-google-pubsub:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-google-pubsub:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/gcp/google-storage-0.1/src/generated/resources/META-INF/connectors/google_storage_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/gcp/google-storage-0.1/src/generated/resources/META-INF/connectors/google_storage_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-google-storage:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-google-storage:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/gcp/google-storage-0.1/src/generated/resources/META-INF/connectors/google_storage_source_0.1.json
+++ b/cos-fleet-catalog-connectors/gcp/google-storage-0.1/src/generated/resources/META-INF/connectors/google_storage_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-google-storage:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-google-storage:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/itops/ansible-tower-0.1/src/generated/resources/META-INF/connectors/ansible_tower_job_template_launch_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/itops/ansible-tower-0.1/src/generated/resources/META-INF/connectors/ansible_tower_job_template_launch_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-ansible-tower:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-ansible-tower:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/itops/splunk-0.1/src/generated/resources/META-INF/connectors/splunk_0.1.json
+++ b/cos-fleet-catalog-connectors/itops/splunk-0.1/src/generated/resources/META-INF/connectors/splunk_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-splunk:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-splunk:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/messaging/http-0.1/src/generated/resources/META-INF/connectors/http_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/messaging/http-0.1/src/generated/resources/META-INF/connectors/http_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-http:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-http:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/messaging/jms-amqp-0.1/src/generated/resources/META-INF/connectors/jms_amqp_10_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/messaging/jms-amqp-0.1/src/generated/resources/META-INF/connectors/jms_amqp_10_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-jms-amqp-10:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-jms-amqp-10:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/messaging/jms-amqp-0.1/src/generated/resources/META-INF/connectors/jms_amqp_10_source_0.1.json
+++ b/cos-fleet-catalog-connectors/messaging/jms-amqp-0.1/src/generated/resources/META-INF/connectors/jms_amqp_10_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-jms-amqp-10:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-jms-amqp-10:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/messaging/jms-artemis-0.1/src/generated/resources/META-INF/connectors/jms_apache_artemis_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/messaging/jms-artemis-0.1/src/generated/resources/META-INF/connectors/jms_apache_artemis_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-jms-apache-artemis:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-jms-apache-artemis:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/messaging/jms-artemis-0.1/src/generated/resources/META-INF/connectors/jms_apache_artemis_source_0.1.json
+++ b/cos-fleet-catalog-connectors/messaging/jms-artemis-0.1/src/generated/resources/META-INF/connectors/jms_apache_artemis_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-jms-apache-artemis:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-jms-apache-artemis:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/messaging/openapi-0.1/src/generated/resources/META-INF/connectors/rest_openapi_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/messaging/openapi-0.1/src/generated/resources/META-INF/connectors/rest_openapi_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-rest-openapi:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-rest-openapi:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/misc/data-generator-0.1/src/generated/resources/META-INF/connectors/data_generator_0.1.json
+++ b/cos-fleet-catalog-connectors/misc/data-generator-0.1/src/generated/resources/META-INF/connectors/data_generator_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-data-generator:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-data-generator:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/nosql/cassandra-0.1/src/generated/resources/META-INF/connectors/cassandra_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/nosql/cassandra-0.1/src/generated/resources/META-INF/connectors/cassandra_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-cassandra:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-cassandra:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/nosql/cassandra-0.1/src/generated/resources/META-INF/connectors/cassandra_source_0.1.json
+++ b/cos-fleet-catalog-connectors/nosql/cassandra-0.1/src/generated/resources/META-INF/connectors/cassandra_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-cassandra:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-cassandra:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "source",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/nosql/elasticsearch-0.1/src/generated/resources/META-INF/connectors/elasticsearch_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/nosql/elasticsearch-0.1/src/generated/resources/META-INF/connectors/elasticsearch_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-elasticsearch:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-elasticsearch:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/nosql/mongodb-0.1/src/generated/resources/META-INF/connectors/mongodb_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/nosql/mongodb-0.1/src/generated/resources/META-INF/connectors/mongodb_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-mongodb:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-mongodb:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/nosql/mongodb-0.1/src/generated/resources/META-INF/connectors/mongodb_source_0.1.json
+++ b/cos-fleet-catalog-connectors/nosql/mongodb-0.1/src/generated/resources/META-INF/connectors/mongodb_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-mongodb:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-mongodb:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "source",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/saas/jira-0.1/src/generated/resources/META-INF/connectors/jira_add_comment_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/saas/jira-0.1/src/generated/resources/META-INF/connectors/jira_add_comment_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-jira:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-jira:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/saas/jira-0.1/src/generated/resources/META-INF/connectors/jira_add_issue_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/saas/jira-0.1/src/generated/resources/META-INF/connectors/jira_add_issue_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-jira:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-jira:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/saas/jira-0.1/src/generated/resources/META-INF/connectors/jira_source_0.1.json
+++ b/cos-fleet-catalog-connectors/saas/jira-0.1/src/generated/resources/META-INF/connectors/jira_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-jira:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-jira:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "source",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/saas/salesforce-0.1/src/generated/resources/META-INF/connectors/salesforce_create_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/saas/salesforce-0.1/src/generated/resources/META-INF/connectors/salesforce_create_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-salesforce:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-salesforce:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/saas/salesforce-0.1/src/generated/resources/META-INF/connectors/salesforce_delete_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/saas/salesforce-0.1/src/generated/resources/META-INF/connectors/salesforce_delete_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-salesforce:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-salesforce:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/saas/salesforce-0.1/src/generated/resources/META-INF/connectors/salesforce_streaming_source_0.1.json
+++ b/cos-fleet-catalog-connectors/saas/salesforce-0.1/src/generated/resources/META-INF/connectors/salesforce_streaming_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-salesforce:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-salesforce:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "source",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/saas/salesforce-0.1/src/generated/resources/META-INF/connectors/salesforce_update_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/saas/salesforce-0.1/src/generated/resources/META-INF/connectors/salesforce_update_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-salesforce:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-salesforce:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/social/slack-0.1/src/generated/resources/META-INF/connectors/slack_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/social/slack-0.1/src/generated/resources/META-INF/connectors/slack_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-slack:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-slack:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/social/slack-0.1/src/generated/resources/META-INF/connectors/slack_source_0.1.json
+++ b/cos-fleet-catalog-connectors/social/slack-0.1/src/generated/resources/META-INF/connectors/slack_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-slack:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-slack:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "source",
         "consumes" : "application/json",
         "consumes_class" : "com.slack.api.model.Message",

--- a/cos-fleet-catalog-connectors/social/telegram-0.1/src/generated/resources/META-INF/connectors/telegram_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/social/telegram-0.1/src/generated/resources/META-INF/connectors/telegram_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-telegram:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-telegram:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/social/telegram-0.1/src/generated/resources/META-INF/connectors/telegram_source_0.1.json
+++ b/cos-fleet-catalog-connectors/social/telegram-0.1/src/generated/resources/META-INF/connectors/telegram_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-telegram:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-telegram:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "source",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/sql/aws-redshift-0.1/src/generated/resources/META-INF/connectors/aws_redshift_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/sql/aws-redshift-0.1/src/generated/resources/META-INF/connectors/aws_redshift_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-redshift:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-redshift:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/sql/aws-redshift-0.1/src/generated/resources/META-INF/connectors/aws_redshift_source_0.1.json
+++ b/cos-fleet-catalog-connectors/sql/aws-redshift-0.1/src/generated/resources/META-INF/connectors/aws_redshift_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-redshift:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-redshift:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "source",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/sql/mariadb-0.1/src/generated/resources/META-INF/connectors/mariadb_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/sql/mariadb-0.1/src/generated/resources/META-INF/connectors/mariadb_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-mariadb:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-mariadb:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/sql/mariadb-0.1/src/generated/resources/META-INF/connectors/mariadb_source_0.1.json
+++ b/cos-fleet-catalog-connectors/sql/mariadb-0.1/src/generated/resources/META-INF/connectors/mariadb_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-mariadb:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-mariadb:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "source",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/sql/mysql-0.1/src/generated/resources/META-INF/connectors/mysql_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/sql/mysql-0.1/src/generated/resources/META-INF/connectors/mysql_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-mysql:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-mysql:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/sql/mysql-0.1/src/generated/resources/META-INF/connectors/mysql_source_0.1.json
+++ b/cos-fleet-catalog-connectors/sql/mysql-0.1/src/generated/resources/META-INF/connectors/mysql_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-mysql:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-mysql:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "source",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/sql/postgresql-0.1/src/generated/resources/META-INF/connectors/postgresql_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/sql/postgresql-0.1/src/generated/resources/META-INF/connectors/postgresql_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-postgresql:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-postgresql:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/sql/postgresql-0.1/src/generated/resources/META-INF/connectors/postgresql_source_0.1.json
+++ b/cos-fleet-catalog-connectors/sql/postgresql-0.1/src/generated/resources/META-INF/connectors/postgresql_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-postgresql:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-postgresql:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "source",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/sql/sqlserver-0.1/src/generated/resources/META-INF/connectors/sqlserver_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/sql/sqlserver-0.1/src/generated/resources/META-INF/connectors/sqlserver_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-sqlserver:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-sqlserver:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/sql/sqlserver-0.1/src/generated/resources/META-INF/connectors/sqlserver_source_0.1.json
+++ b/cos-fleet-catalog-connectors/sql/sqlserver-0.1/src/generated/resources/META-INF/connectors/sqlserver_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-sqlserver:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-sqlserver:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "source",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/storage/ftps-0.1/src/generated/resources/META-INF/connectors/ftps_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/storage/ftps-0.1/src/generated/resources/META-INF/connectors/ftps_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-ftps:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-ftps:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/storage/ftps-0.1/src/generated/resources/META-INF/connectors/ftps_source_0.1.json
+++ b/cos-fleet-catalog-connectors/storage/ftps-0.1/src/generated/resources/META-INF/connectors/ftps_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-ftps:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-ftps:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/storage/minio-0.1/src/generated/resources/META-INF/connectors/minio_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/storage/minio-0.1/src/generated/resources/META-INF/connectors/minio_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-minio:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-minio:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/storage/minio-0.1/src/generated/resources/META-INF/connectors/minio_source_0.1.json
+++ b/cos-fleet-catalog-connectors/storage/minio-0.1/src/generated/resources/META-INF/connectors/minio_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-minio:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-minio:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/storage/sftp-0.1/src/generated/resources/META-INF/connectors/sftp_sink_0.1.json
+++ b/cos-fleet-catalog-connectors/storage/sftp-0.1/src/generated/resources/META-INF/connectors/sftp_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-sftp:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-sftp:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/cos-fleet-catalog-connectors/storage/sftp-0.1/src/generated/resources/META-INF/connectors/sftp_source_0.1.json
+++ b/cos-fleet-catalog-connectors/storage/sftp-0.1/src/generated/resources/META-INF/connectors/sftp_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-sftp:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-sftp:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-aws/aws_cloudwatch_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-aws/aws_cloudwatch_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-cloudwatch:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-cloudwatch:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-aws/aws_ddb_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-aws/aws_ddb_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-ddb:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-ddb:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-aws/aws_ddb_streams_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-aws/aws_ddb_streams_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-ddb-streams:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-ddb-streams:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "source",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-aws/aws_kinesis_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-aws/aws_kinesis_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-kinesis:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-kinesis:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-aws/aws_kinesis_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-aws/aws_kinesis_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-kinesis:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-kinesis:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-aws/aws_lambda_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-aws/aws_lambda_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-lambda:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-lambda:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-aws/aws_s3_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-aws/aws_s3_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-s3:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-s3:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-aws/aws_s3_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-aws/aws_s3_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-s3:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-s3:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-aws/aws_ses_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-aws/aws_ses_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-ses:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-ses:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-aws/aws_sns_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-aws/aws_sns_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-sns:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-sns:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-aws/aws_sqs_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-aws/aws_sqs_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-sqs:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-sqs:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-aws/aws_sqs_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-aws/aws_sqs_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-sqs:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-sqs:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-azure/azure_eventhubs_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-azure/azure_eventhubs_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-azure-eventhubs:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-azure-eventhubs:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-azure/azure_eventhubs_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-azure/azure_eventhubs_source_0.1.json
@@ -7,14 +7,14 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-azure-eventhubs:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-azure-eventhubs:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "source",
-        "consumes" : "application/json",
+        "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",
         "kamelets" : {
           "adapter" : {
-            "name" : "azure-eventhubs-source",
+            "name" : "cos-azure-eventhubs-source",
             "prefix" : "azure"
           },
           "kafka" : {
@@ -26,7 +26,7 @@
           "type" : "camel-connector-operator",
           "version" : "[1.0.0,2.0.0)"
         } ],
-        "produces" : "application/json"
+        "produces" : "application/octet-stream"
       }
     }
   },
@@ -107,6 +107,9 @@
           "type" : "object",
           "additionalProperties" : false,
           "properties" : {
+            "consumes" : {
+              "$ref" : "#/$defs/data_shape/consumes"
+            },
             "produces" : {
               "$ref" : "#/$defs/data_shape/produces"
             }
@@ -150,6 +153,19 @@
       },
       "$defs" : {
         "data_shape" : {
+          "consumes" : {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "format" ],
+            "properties" : {
+              "format" : {
+                "type" : "string",
+                "description" : "The format of the data that Kafka sends to the sink connector.",
+                "default" : "application/octet-stream",
+                "enum" : [ "application/octet-stream" ]
+              }
+            }
+          },
           "produces" : {
             "type" : "object",
             "additionalProperties" : false,
@@ -158,8 +174,8 @@
               "format" : {
                 "type" : "string",
                 "description" : "The format of the data that the source connector sends to Kafka.",
-                "default" : "application/json",
-                "enum" : [ "application/json" ]
+                "default" : "application/octet-stream",
+                "enum" : [ "application/octet-stream" ]
               }
             }
           }

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-azure/azure_functions_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-azure/azure_functions_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-azure-functions:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-azure-functions:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-azure/azure_storage_blob_changefeed_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-azure/azure_storage_blob_changefeed_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-azure-storage-blob-changefeed:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-azure-storage-blob-changefeed:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-azure/azure_storage_blob_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-azure/azure_storage_blob_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-azure-storage-blob:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-azure-storage-blob:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-azure/azure_storage_blob_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-azure/azure_storage_blob_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-azure-storage-blob:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-azure-storage-blob:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-azure/azure_storage_queue_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-azure/azure_storage_queue_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-azure-storage-queue:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-azure-storage-queue:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-azure/azure_storage_queue_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-azure/azure_storage_queue_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-azure-storage-queue:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-azure-storage-queue:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-gcp/google_bigquery_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-gcp/google_bigquery_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-google-bigquery:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-google-bigquery:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-gcp/google_functions_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-gcp/google_functions_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-google-functions:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-google-functions:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-gcp/google_pubsub_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-gcp/google_pubsub_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-google-pubsub:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-google-pubsub:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-gcp/google_pubsub_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-gcp/google_pubsub_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-google-pubsub:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-google-pubsub:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-gcp/google_storage_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-gcp/google_storage_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-google-storage:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-google-storage:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-gcp/google_storage_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-gcp/google_storage_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-google-storage:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-google-storage:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-itops/ansible_tower_job_template_launch_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-itops/ansible_tower_job_template_launch_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-ansible-tower:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-ansible-tower:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-itops/splunk_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-itops/splunk_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-splunk:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-splunk:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-messaging/http_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-messaging/http_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-http:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-http:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-messaging/jms_amqp_10_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-messaging/jms_amqp_10_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-jms-amqp-10:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-jms-amqp-10:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-messaging/jms_amqp_10_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-messaging/jms_amqp_10_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-jms-amqp-10:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-jms-amqp-10:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-messaging/jms_apache_artemis_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-messaging/jms_apache_artemis_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-jms-apache-artemis:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-jms-apache-artemis:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-messaging/jms_apache_artemis_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-messaging/jms_apache_artemis_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-jms-apache-artemis:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-jms-apache-artemis:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-messaging/rest_openapi_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-messaging/rest_openapi_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-rest-openapi:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-rest-openapi:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-misc/data_generator_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-misc/data_generator_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-data-generator:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-data-generator:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-nosql/cassandra_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-nosql/cassandra_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-cassandra:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-cassandra:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-nosql/cassandra_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-nosql/cassandra_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-cassandra:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-cassandra:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "source",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-nosql/elasticsearch_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-nosql/elasticsearch_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-elasticsearch:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-elasticsearch:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-nosql/mongodb_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-nosql/mongodb_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-mongodb:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-mongodb:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-nosql/mongodb_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-nosql/mongodb_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-mongodb:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-mongodb:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "source",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-saas/jira_add_comment_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-saas/jira_add_comment_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-jira:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-jira:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-saas/jira_add_issue_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-saas/jira_add_issue_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-jira:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-jira:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-saas/jira_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-saas/jira_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-jira:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-jira:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "source",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-saas/salesforce_create_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-saas/salesforce_create_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-salesforce:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-salesforce:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-saas/salesforce_delete_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-saas/salesforce_delete_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-salesforce:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-salesforce:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-saas/salesforce_streaming_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-saas/salesforce_streaming_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-salesforce:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-salesforce:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "source",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-saas/salesforce_update_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-saas/salesforce_update_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-salesforce:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-salesforce:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-social/slack_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-social/slack_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-slack:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-slack:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-social/slack_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-social/slack_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-slack:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-slack:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "source",
         "consumes" : "application/json",
         "consumes_class" : "com.slack.api.model.Message",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-social/telegram_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-social/telegram_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-telegram:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-telegram:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-social/telegram_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-social/telegram_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-telegram:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-telegram:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "source",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-sql/aws_redshift_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-sql/aws_redshift_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-redshift:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-redshift:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-sql/aws_redshift_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-sql/aws_redshift_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-aws-redshift:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-redshift:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "source",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-sql/mariadb_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-sql/mariadb_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-mariadb:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-mariadb:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-sql/mariadb_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-sql/mariadb_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-mariadb:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-mariadb:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "source",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-sql/mysql_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-sql/mysql_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-mysql:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-mysql:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-sql/mysql_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-sql/mysql_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-mysql:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-mysql:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "source",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-sql/postgresql_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-sql/postgresql_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-postgresql:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-postgresql:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-sql/postgresql_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-sql/postgresql_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-postgresql:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-postgresql:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "source",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-sql/sqlserver_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-sql/sqlserver_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-sqlserver:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-sqlserver:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-sql/sqlserver_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-sql/sqlserver_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-sqlserver:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-sqlserver:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "source",
         "consumes" : "application/json",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-storage/ftps_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-storage/ftps_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-ftps:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-ftps:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-storage/ftps_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-storage/ftps_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-ftps:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-ftps:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-storage/minio_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-storage/minio_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-minio:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-minio:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-storage/minio_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-storage/minio_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-minio:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-minio:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-storage/sftp_sink_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-storage/sftp_sink_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-sftp:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-sftp:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "sink",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-storage/sftp_source_0.1.json
+++ b/etc/kubernetes/manifests/base/connectors/connector-catalog-camel-storage/sftp_source_0.1.json
@@ -7,8 +7,8 @@
           "trait.camel.apache.org/container.request-memory" : "128M",
           "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
         },
-        "connector_image" : "quay.io/rhoas/cos-connector-sftp:0.1.55",
-        "connector_revision" : 55,
+        "connector_image" : "quay.io/rhoas/cos-connector-sftp:0.1.56",
+        "connector_revision" : 56,
         "connector_type" : "source",
         "consumes" : "application/octet-stream",
         "error_handler_strategy" : "stop",

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <cos.connector.catalog.group>all</cos.connector.catalog.group>
 
         <cos.connector.version>0.1</cos.connector.version>
-        <cos.connector.revision>55</cos.connector.revision>
+        <cos.connector.revision>56</cos.connector.revision>
         <cos.connector.operator.version>[1.0.0,2.0.0)</cos.connector.operator.version>
         <cos.kamelets.version>0.0.1</cos.kamelets.version>
 

--- a/templates/cos-fleet-catalog-camel.yaml
+++ b/templates/cos-fleet-catalog-camel.yaml
@@ -20,8 +20,8 @@ objects:
                 "trait.camel.apache.org/container.request-memory" : "128M",
                 "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
               },
-              "connector_image" : "quay.io/rhoas/cos-connector-aws-cloudwatch:0.1.55",
-              "connector_revision" : 55,
+              "connector_image" : "quay.io/rhoas/cos-connector-aws-cloudwatch:0.1.56",
+              "connector_revision" : 56,
               "connector_type" : "sink",
               "consumes" : "application/octet-stream",
               "error_handler_strategy" : "stop",
@@ -210,8 +210,8 @@ objects:
                 "trait.camel.apache.org/container.request-memory" : "128M",
                 "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
               },
-              "connector_image" : "quay.io/rhoas/cos-connector-aws-ddb:0.1.55",
-              "connector_revision" : 55,
+              "connector_image" : "quay.io/rhoas/cos-connector-aws-ddb:0.1.56",
+              "connector_revision" : 56,
               "connector_type" : "sink",
               "consumes" : "application/json",
               "error_handler_strategy" : "stop",
@@ -413,8 +413,8 @@ objects:
                 "trait.camel.apache.org/container.request-memory" : "128M",
                 "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
               },
-              "connector_image" : "quay.io/rhoas/cos-connector-aws-ddb-streams:0.1.55",
-              "connector_revision" : 55,
+              "connector_image" : "quay.io/rhoas/cos-connector-aws-ddb-streams:0.1.56",
+              "connector_revision" : 56,
               "connector_type" : "source",
               "consumes" : "application/json",
               "error_handler_strategy" : "stop",
@@ -615,8 +615,8 @@ objects:
                 "trait.camel.apache.org/container.request-memory" : "128M",
                 "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
               },
-              "connector_image" : "quay.io/rhoas/cos-connector-aws-kinesis:0.1.55",
-              "connector_revision" : 55,
+              "connector_image" : "quay.io/rhoas/cos-connector-aws-kinesis:0.1.56",
+              "connector_revision" : 56,
               "connector_type" : "sink",
               "consumes" : "application/octet-stream",
               "error_handler_strategy" : "stop",
@@ -821,8 +821,8 @@ objects:
                 "trait.camel.apache.org/container.request-memory" : "128M",
                 "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
               },
-              "connector_image" : "quay.io/rhoas/cos-connector-aws-kinesis:0.1.55",
-              "connector_revision" : 55,
+              "connector_image" : "quay.io/rhoas/cos-connector-aws-kinesis:0.1.56",
+              "connector_revision" : 56,
               "connector_type" : "source",
               "consumes" : "application/octet-stream",
               "error_handler_strategy" : "stop",
@@ -1033,8 +1033,8 @@ objects:
                 "trait.camel.apache.org/container.request-memory" : "128M",
                 "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
               },
-              "connector_image" : "quay.io/rhoas/cos-connector-aws-lambda:0.1.55",
-              "connector_revision" : 55,
+              "connector_image" : "quay.io/rhoas/cos-connector-aws-lambda:0.1.56",
+              "connector_revision" : 56,
               "connector_type" : "sink",
               "consumes" : "application/octet-stream",
               "error_handler_strategy" : "stop",
@@ -1212,8 +1212,8 @@ objects:
                 "trait.camel.apache.org/container.request-memory" : "128M",
                 "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
               },
-              "connector_image" : "quay.io/rhoas/cos-connector-aws-s3:0.1.55",
-              "connector_revision" : 55,
+              "connector_image" : "quay.io/rhoas/cos-connector-aws-s3:0.1.56",
+              "connector_revision" : 56,
               "connector_type" : "sink",
               "consumes" : "application/octet-stream",
               "error_handler_strategy" : "stop",
@@ -1413,8 +1413,8 @@ objects:
                 "trait.camel.apache.org/container.request-memory" : "128M",
                 "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
               },
-              "connector_image" : "quay.io/rhoas/cos-connector-aws-s3:0.1.55",
-              "connector_revision" : 55,
+              "connector_image" : "quay.io/rhoas/cos-connector-aws-s3:0.1.56",
+              "connector_revision" : 56,
               "connector_type" : "source",
               "consumes" : "application/octet-stream",
               "error_handler_strategy" : "stop",
@@ -1639,8 +1639,8 @@ objects:
                 "trait.camel.apache.org/container.request-memory" : "128M",
                 "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
               },
-              "connector_image" : "quay.io/rhoas/cos-connector-aws-ses:0.1.55",
-              "connector_revision" : 55,
+              "connector_image" : "quay.io/rhoas/cos-connector-aws-ses:0.1.56",
+              "connector_revision" : 56,
               "connector_type" : "sink",
               "consumes" : "application/octet-stream",
               "error_handler_strategy" : "stop",
@@ -1819,8 +1819,8 @@ objects:
                 "trait.camel.apache.org/container.request-memory" : "128M",
                 "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
               },
-              "connector_image" : "quay.io/rhoas/cos-connector-aws-sns:0.1.55",
-              "connector_revision" : 55,
+              "connector_image" : "quay.io/rhoas/cos-connector-aws-sns:0.1.56",
+              "connector_revision" : 56,
               "connector_type" : "sink",
               "consumes" : "application/octet-stream",
               "error_handler_strategy" : "stop",
@@ -2015,8 +2015,8 @@ objects:
                 "trait.camel.apache.org/container.request-memory" : "128M",
                 "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
               },
-              "connector_image" : "quay.io/rhoas/cos-connector-aws-sqs:0.1.55",
-              "connector_revision" : 55,
+              "connector_image" : "quay.io/rhoas/cos-connector-aws-sqs:0.1.56",
+              "connector_revision" : 56,
               "connector_type" : "sink",
               "consumes" : "application/octet-stream",
               "error_handler_strategy" : "stop",
@@ -2224,8 +2224,8 @@ objects:
                 "trait.camel.apache.org/container.request-memory" : "128M",
                 "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
               },
-              "connector_image" : "quay.io/rhoas/cos-connector-aws-sqs:0.1.55",
-              "connector_revision" : 55,
+              "connector_image" : "quay.io/rhoas/cos-connector-aws-sqs:0.1.56",
+              "connector_revision" : 56,
               "connector_type" : "source",
               "consumes" : "application/octet-stream",
               "error_handler_strategy" : "stop",
@@ -2457,8 +2457,8 @@ objects:
                 "trait.camel.apache.org/container.request-memory" : "128M",
                 "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
               },
-              "connector_image" : "quay.io/rhoas/cos-connector-azure-eventhubs:0.1.55",
-              "connector_revision" : 55,
+              "connector_image" : "quay.io/rhoas/cos-connector-azure-eventhubs:0.1.56",
+              "connector_revision" : 56,
               "connector_type" : "sink",
               "consumes" : "application/octet-stream",
               "error_handler_strategy" : "stop",
@@ -2627,14 +2627,14 @@ objects:
                 "trait.camel.apache.org/container.request-memory" : "128M",
                 "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
               },
-              "connector_image" : "quay.io/rhoas/cos-connector-azure-eventhubs:0.1.55",
-              "connector_revision" : 55,
+              "connector_image" : "quay.io/rhoas/cos-connector-azure-eventhubs:0.1.56",
+              "connector_revision" : 56,
               "connector_type" : "source",
-              "consumes" : "application/json",
+              "consumes" : "application/octet-stream",
               "error_handler_strategy" : "stop",
               "kamelets" : {
                 "adapter" : {
-                  "name" : "azure-eventhubs-source",
+                  "name" : "cos-azure-eventhubs-source",
                   "prefix" : "azure"
                 },
                 "kafka" : {
@@ -2646,7 +2646,7 @@ objects:
                 "type" : "camel-connector-operator",
                 "version" : "[1.0.0,2.0.0)"
               } ],
-              "produces" : "application/json"
+              "produces" : "application/octet-stream"
             }
           }
         },
@@ -2727,6 +2727,9 @@ objects:
                 "type" : "object",
                 "additionalProperties" : false,
                 "properties" : {
+                  "consumes" : {
+                    "$ref" : "#/$defs/data_shape/consumes"
+                  },
                   "produces" : {
                     "$ref" : "#/$defs/data_shape/produces"
                   }
@@ -2770,6 +2773,19 @@ objects:
             },
             "$defs" : {
               "data_shape" : {
+                "consumes" : {
+                  "type" : "object",
+                  "additionalProperties" : false,
+                  "required" : [ "format" ],
+                  "properties" : {
+                    "format" : {
+                      "type" : "string",
+                      "description" : "The format of the data that Kafka sends to the sink connector.",
+                      "default" : "application/octet-stream",
+                      "enum" : [ "application/octet-stream" ]
+                    }
+                  }
+                },
                 "produces" : {
                   "type" : "object",
                   "additionalProperties" : false,
@@ -2778,8 +2794,8 @@ objects:
                     "format" : {
                       "type" : "string",
                       "description" : "The format of the data that the source connector sends to Kafka.",
-                      "default" : "application/json",
-                      "enum" : [ "application/json" ]
+                      "default" : "application/octet-stream",
+                      "enum" : [ "application/octet-stream" ]
                     }
                   }
                 }
@@ -2821,8 +2837,8 @@ objects:
                 "trait.camel.apache.org/container.request-memory" : "128M",
                 "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
               },
-              "connector_image" : "quay.io/rhoas/cos-connector-azure-functions:0.1.55",
-              "connector_revision" : 55,
+              "connector_image" : "quay.io/rhoas/cos-connector-azure-functions:0.1.56",
+              "connector_revision" : 56,
               "connector_type" : "sink",
               "consumes" : "application/octet-stream",
               "error_handler_strategy" : "stop",
@@ -2988,8 +3004,8 @@ objects:
                 "trait.camel.apache.org/container.request-memory" : "128M",
                 "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
               },
-              "connector_image" : "quay.io/rhoas/cos-connector-azure-storage-blob-changefeed:0.1.55",
-              "connector_revision" : 55,
+              "connector_image" : "quay.io/rhoas/cos-connector-azure-storage-blob-changefeed:0.1.56",
+              "connector_revision" : 56,
               "connector_type" : "source",
               "consumes" : "application/octet-stream",
               "error_handler_strategy" : "stop",
@@ -3154,8 +3170,8 @@ objects:
                 "trait.camel.apache.org/container.request-memory" : "128M",
                 "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
               },
-              "connector_image" : "quay.io/rhoas/cos-connector-azure-storage-blob:0.1.55",
-              "connector_revision" : 55,
+              "connector_image" : "quay.io/rhoas/cos-connector-azure-storage-blob:0.1.56",
+              "connector_revision" : 56,
               "connector_type" : "sink",
               "consumes" : "application/octet-stream",
               "error_handler_strategy" : "stop",
@@ -3331,8 +3347,8 @@ objects:
                 "trait.camel.apache.org/container.request-memory" : "128M",
                 "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
               },
-              "connector_image" : "quay.io/rhoas/cos-connector-azure-storage-blob:0.1.55",
-              "connector_revision" : 55,
+              "connector_image" : "quay.io/rhoas/cos-connector-azure-storage-blob:0.1.56",
+              "connector_revision" : 56,
               "connector_type" : "source",
               "consumes" : "application/octet-stream",
               "error_handler_strategy" : "stop",
@@ -3508,8 +3524,8 @@ objects:
                 "trait.camel.apache.org/container.request-memory" : "128M",
                 "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
               },
-              "connector_image" : "quay.io/rhoas/cos-connector-azure-storage-queue:0.1.55",
-              "connector_revision" : 55,
+              "connector_image" : "quay.io/rhoas/cos-connector-azure-storage-queue:0.1.56",
+              "connector_revision" : 56,
               "connector_type" : "sink",
               "consumes" : "application/octet-stream",
               "error_handler_strategy" : "stop",
@@ -3673,8 +3689,8 @@ objects:
                 "trait.camel.apache.org/container.request-memory" : "128M",
                 "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
               },
-              "connector_image" : "quay.io/rhoas/cos-connector-azure-storage-queue:0.1.55",
-              "connector_revision" : 55,
+              "connector_image" : "quay.io/rhoas/cos-connector-azure-storage-queue:0.1.56",
+              "connector_revision" : 56,
               "connector_type" : "source",
               "consumes" : "application/octet-stream",
               "error_handler_strategy" : "stop",
@@ -3851,8 +3867,8 @@ objects:
                 "trait.camel.apache.org/container.request-memory" : "128M",
                 "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
               },
-              "connector_image" : "quay.io/rhoas/cos-connector-google-bigquery:0.1.55",
-              "connector_revision" : 55,
+              "connector_image" : "quay.io/rhoas/cos-connector-google-bigquery:0.1.56",
+              "connector_revision" : 56,
               "connector_type" : "sink",
               "consumes" : "application/json",
               "error_handler_strategy" : "stop",
@@ -4020,8 +4036,8 @@ objects:
                 "trait.camel.apache.org/container.request-memory" : "128M",
                 "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
               },
-              "connector_image" : "quay.io/rhoas/cos-connector-google-functions:0.1.55",
-              "connector_revision" : 55,
+              "connector_image" : "quay.io/rhoas/cos-connector-google-functions:0.1.56",
+              "connector_revision" : 56,
               "connector_type" : "sink",
               "consumes" : "application/octet-stream",
               "error_handler_strategy" : "stop",
@@ -4189,8 +4205,8 @@ objects:
                 "trait.camel.apache.org/container.request-memory" : "128M",
                 "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
               },
-              "connector_image" : "quay.io/rhoas/cos-connector-google-pubsub:0.1.55",
-              "connector_revision" : 55,
+              "connector_image" : "quay.io/rhoas/cos-connector-google-pubsub:0.1.56",
+              "connector_revision" : 56,
               "connector_type" : "sink",
               "consumes" : "application/octet-stream",
               "error_handler_strategy" : "stop",
@@ -4353,8 +4369,8 @@ objects:
                 "trait.camel.apache.org/container.request-memory" : "128M",
                 "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
               },
-              "connector_image" : "quay.io/rhoas/cos-connector-google-pubsub:0.1.55",
-              "connector_revision" : 55,
+              "connector_image" : "quay.io/rhoas/cos-connector-google-pubsub:0.1.56",
+              "connector_revision" : 56,
               "connector_type" : "source",
               "consumes" : "application/octet-stream",
               "error_handler_strategy" : "stop",
@@ -4535,8 +4551,8 @@ objects:
                 "trait.camel.apache.org/container.request-memory" : "128M",
                 "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
               },
-              "connector_image" : "quay.io/rhoas/cos-connector-google-storage:0.1.55",
-              "connector_revision" : 55,
+              "connector_image" : "quay.io/rhoas/cos-connector-google-storage:0.1.56",
+              "connector_revision" : 56,
               "connector_type" : "sink",
               "consumes" : "application/octet-stream",
               "error_handler_strategy" : "stop",
@@ -4700,8 +4716,8 @@ objects:
                 "trait.camel.apache.org/container.request-memory" : "128M",
                 "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
               },
-              "connector_image" : "quay.io/rhoas/cos-connector-google-storage:0.1.55",
-              "connector_revision" : 55,
+              "connector_image" : "quay.io/rhoas/cos-connector-google-storage:0.1.56",
+              "connector_revision" : 56,
               "connector_type" : "source",
               "consumes" : "application/octet-stream",
               "error_handler_strategy" : "stop",
@@ -4878,8 +4894,8 @@ objects:
                 "trait.camel.apache.org/container.request-memory" : "128M",
                 "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
               },
-              "connector_image" : "quay.io/rhoas/cos-connector-ansible-tower:0.1.55",
-              "connector_revision" : 55,
+              "connector_image" : "quay.io/rhoas/cos-connector-ansible-tower:0.1.56",
+              "connector_revision" : 56,
               "connector_type" : "sink",
               "consumes" : "application/json",
               "error_handler_strategy" : "stop",
@@ -5060,8 +5076,8 @@ objects:
                 "trait.camel.apache.org/container.request-memory" : "128M",
                 "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
               },
-              "connector_image" : "quay.io/rhoas/cos-connector-splunk:0.1.55",
-              "connector_revision" : 55,
+              "connector_image" : "quay.io/rhoas/cos-connector-splunk:0.1.56",
+              "connector_revision" : 56,
               "connector_type" : "sink",
               "consumes" : "application/json",
               "error_handler_strategy" : "stop",
@@ -5278,8 +5294,8 @@ objects:
                 "trait.camel.apache.org/container.request-memory" : "128M",
                 "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
               },
-              "connector_image" : "quay.io/rhoas/cos-connector-http:0.1.55",
-              "connector_revision" : 55,
+              "connector_image" : "quay.io/rhoas/cos-connector-http:0.1.56",
+              "connector_revision" : 56,
               "connector_type" : "sink",
               "consumes" : "application/octet-stream",
               "error_handler_strategy" : "stop",
@@ -5431,8 +5447,8 @@ objects:
                 "trait.camel.apache.org/container.request-memory" : "128M",
                 "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
               },
-              "connector_image" : "quay.io/rhoas/cos-connector-jms-amqp-10:0.1.55",
-              "connector_revision" : 55,
+              "connector_image" : "quay.io/rhoas/cos-connector-jms-amqp-10:0.1.56",
+              "connector_revision" : 56,
               "connector_type" : "sink",
               "consumes" : "application/octet-stream",
               "error_handler_strategy" : "stop",
@@ -5588,8 +5604,8 @@ objects:
                 "trait.camel.apache.org/container.request-memory" : "128M",
                 "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
               },
-              "connector_image" : "quay.io/rhoas/cos-connector-jms-amqp-10:0.1.55",
-              "connector_revision" : 55,
+              "connector_image" : "quay.io/rhoas/cos-connector-jms-amqp-10:0.1.56",
+              "connector_revision" : 56,
               "connector_type" : "source",
               "consumes" : "application/octet-stream",
               "error_handler_strategy" : "stop",
@@ -5745,8 +5761,8 @@ objects:
                 "trait.camel.apache.org/container.request-memory" : "128M",
                 "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
               },
-              "connector_image" : "quay.io/rhoas/cos-connector-jms-apache-artemis:0.1.55",
-              "connector_revision" : 55,
+              "connector_image" : "quay.io/rhoas/cos-connector-jms-apache-artemis:0.1.56",
+              "connector_revision" : 56,
               "connector_type" : "sink",
               "consumes" : "application/octet-stream",
               "error_handler_strategy" : "stop",
@@ -5903,8 +5919,8 @@ objects:
                 "trait.camel.apache.org/container.request-memory" : "128M",
                 "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
               },
-              "connector_image" : "quay.io/rhoas/cos-connector-jms-apache-artemis:0.1.55",
-              "connector_revision" : 55,
+              "connector_image" : "quay.io/rhoas/cos-connector-jms-apache-artemis:0.1.56",
+              "connector_revision" : 56,
               "connector_type" : "source",
               "consumes" : "application/octet-stream",
               "error_handler_strategy" : "stop",
@@ -6060,8 +6076,8 @@ objects:
                 "trait.camel.apache.org/container.request-memory" : "128M",
                 "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
               },
-              "connector_image" : "quay.io/rhoas/cos-connector-rest-openapi:0.1.55",
-              "connector_revision" : 55,
+              "connector_image" : "quay.io/rhoas/cos-connector-rest-openapi:0.1.56",
+              "connector_revision" : 56,
               "connector_type" : "sink",
               "consumes" : "application/octet-stream",
               "error_handler_strategy" : "stop",
@@ -6219,8 +6235,8 @@ objects:
                 "trait.camel.apache.org/container.request-memory" : "128M",
                 "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
               },
-              "connector_image" : "quay.io/rhoas/cos-connector-data-generator:0.1.55",
-              "connector_revision" : 55,
+              "connector_image" : "quay.io/rhoas/cos-connector-data-generator:0.1.56",
+              "connector_revision" : 56,
               "connector_type" : "source",
               "consumes" : "application/octet-stream",
               "error_handler_strategy" : "stop",
@@ -6384,8 +6400,8 @@ objects:
                 "trait.camel.apache.org/container.request-memory" : "128M",
                 "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
               },
-              "connector_image" : "quay.io/rhoas/cos-connector-cassandra:0.1.55",
-              "connector_revision" : 55,
+              "connector_image" : "quay.io/rhoas/cos-connector-cassandra:0.1.56",
+              "connector_revision" : 56,
               "connector_type" : "sink",
               "consumes" : "application/json",
               "error_handler_strategy" : "stop",
@@ -6579,8 +6595,8 @@ objects:
                 "trait.camel.apache.org/container.request-memory" : "128M",
                 "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
               },
-              "connector_image" : "quay.io/rhoas/cos-connector-cassandra:0.1.55",
-              "connector_revision" : 55,
+              "connector_image" : "quay.io/rhoas/cos-connector-cassandra:0.1.56",
+              "connector_revision" : 56,
               "connector_type" : "source",
               "consumes" : "application/json",
               "error_handler_strategy" : "stop",
@@ -6774,8 +6790,8 @@ objects:
                 "trait.camel.apache.org/container.request-memory" : "128M",
                 "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
               },
-              "connector_image" : "quay.io/rhoas/cos-connector-elasticsearch:0.1.55",
-              "connector_revision" : 55,
+              "connector_image" : "quay.io/rhoas/cos-connector-elasticsearch:0.1.56",
+              "connector_revision" : 56,
               "connector_type" : "sink",
               "consumes" : "application/json",
               "error_handler_strategy" : "stop",
@@ -6958,8 +6974,8 @@ objects:
                 "trait.camel.apache.org/container.request-memory" : "128M",
                 "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
               },
-              "connector_image" : "quay.io/rhoas/cos-connector-mongodb:0.1.55",
-              "connector_revision" : 55,
+              "connector_image" : "quay.io/rhoas/cos-connector-mongodb:0.1.56",
+              "connector_revision" : 56,
               "connector_type" : "sink",
               "consumes" : "application/json",
               "error_handler_strategy" : "stop",
@@ -7144,8 +7160,8 @@ objects:
                 "trait.camel.apache.org/container.request-memory" : "128M",
                 "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
               },
-              "connector_image" : "quay.io/rhoas/cos-connector-mongodb:0.1.55",
-              "connector_revision" : 55,
+              "connector_image" : "quay.io/rhoas/cos-connector-mongodb:0.1.56",
+              "connector_revision" : 56,
               "connector_type" : "source",
               "consumes" : "application/json",
               "error_handler_strategy" : "stop",
@@ -7337,8 +7353,8 @@ objects:
                 "trait.camel.apache.org/container.request-memory" : "128M",
                 "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
               },
-              "connector_image" : "quay.io/rhoas/cos-connector-jira:0.1.55",
-              "connector_revision" : 55,
+              "connector_image" : "quay.io/rhoas/cos-connector-jira:0.1.56",
+              "connector_revision" : 56,
               "connector_type" : "sink",
               "consumes" : "application/json",
               "error_handler_strategy" : "stop",
@@ -7503,8 +7519,8 @@ objects:
                 "trait.camel.apache.org/container.request-memory" : "128M",
                 "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
               },
-              "connector_image" : "quay.io/rhoas/cos-connector-jira:0.1.55",
-              "connector_revision" : 55,
+              "connector_image" : "quay.io/rhoas/cos-connector-jira:0.1.56",
+              "connector_revision" : 56,
               "connector_type" : "sink",
               "consumes" : "application/json",
               "error_handler_strategy" : "stop",
@@ -7669,8 +7685,8 @@ objects:
                 "trait.camel.apache.org/container.request-memory" : "128M",
                 "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
               },
-              "connector_image" : "quay.io/rhoas/cos-connector-jira:0.1.55",
-              "connector_revision" : 55,
+              "connector_image" : "quay.io/rhoas/cos-connector-jira:0.1.56",
+              "connector_revision" : 56,
               "connector_type" : "source",
               "consumes" : "application/json",
               "error_handler_strategy" : "stop",
@@ -7841,8 +7857,8 @@ objects:
                 "trait.camel.apache.org/container.request-memory" : "128M",
                 "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
               },
-              "connector_image" : "quay.io/rhoas/cos-connector-salesforce:0.1.55",
-              "connector_revision" : 55,
+              "connector_image" : "quay.io/rhoas/cos-connector-salesforce:0.1.56",
+              "connector_revision" : 56,
               "connector_type" : "sink",
               "consumes" : "application/json",
               "error_handler_strategy" : "stop",
@@ -8033,8 +8049,8 @@ objects:
                 "trait.camel.apache.org/container.request-memory" : "128M",
                 "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
               },
-              "connector_image" : "quay.io/rhoas/cos-connector-salesforce:0.1.55",
-              "connector_revision" : 55,
+              "connector_image" : "quay.io/rhoas/cos-connector-salesforce:0.1.56",
+              "connector_revision" : 56,
               "connector_type" : "sink",
               "consumes" : "application/json",
               "error_handler_strategy" : "stop",
@@ -8219,8 +8235,8 @@ objects:
                 "trait.camel.apache.org/container.request-memory" : "128M",
                 "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
               },
-              "connector_image" : "quay.io/rhoas/cos-connector-salesforce:0.1.55",
-              "connector_revision" : 55,
+              "connector_image" : "quay.io/rhoas/cos-connector-salesforce:0.1.56",
+              "connector_revision" : 56,
               "connector_type" : "source",
               "consumes" : "application/json",
               "error_handler_strategy" : "stop",
@@ -8410,8 +8426,8 @@ objects:
                 "trait.camel.apache.org/container.request-memory" : "128M",
                 "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
               },
-              "connector_image" : "quay.io/rhoas/cos-connector-salesforce:0.1.55",
-              "connector_revision" : 55,
+              "connector_image" : "quay.io/rhoas/cos-connector-salesforce:0.1.56",
+              "connector_revision" : 56,
               "connector_type" : "sink",
               "consumes" : "application/json",
               "error_handler_strategy" : "stop",
@@ -8614,8 +8630,8 @@ objects:
                 "trait.camel.apache.org/container.request-memory" : "128M",
                 "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
               },
-              "connector_image" : "quay.io/rhoas/cos-connector-slack:0.1.55",
-              "connector_revision" : 55,
+              "connector_image" : "quay.io/rhoas/cos-connector-slack:0.1.56",
+              "connector_revision" : 56,
               "connector_type" : "sink",
               "consumes" : "application/octet-stream",
               "error_handler_strategy" : "stop",
@@ -8789,8 +8805,8 @@ objects:
                 "trait.camel.apache.org/container.request-memory" : "128M",
                 "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
               },
-              "connector_image" : "quay.io/rhoas/cos-connector-slack:0.1.55",
-              "connector_revision" : 55,
+              "connector_image" : "quay.io/rhoas/cos-connector-slack:0.1.56",
+              "connector_revision" : 56,
               "connector_type" : "source",
               "consumes" : "application/json",
               "consumes_class" : "com.slack.api.model.Message",
@@ -8956,8 +8972,8 @@ objects:
                 "trait.camel.apache.org/container.request-memory" : "128M",
                 "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
               },
-              "connector_image" : "quay.io/rhoas/cos-connector-telegram:0.1.55",
-              "connector_revision" : 55,
+              "connector_image" : "quay.io/rhoas/cos-connector-telegram:0.1.56",
+              "connector_revision" : 56,
               "connector_type" : "sink",
               "consumes" : "application/octet-stream",
               "error_handler_strategy" : "stop",
@@ -9115,8 +9131,8 @@ objects:
                 "trait.camel.apache.org/container.request-memory" : "128M",
                 "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
               },
-              "connector_image" : "quay.io/rhoas/cos-connector-telegram:0.1.55",
-              "connector_revision" : 55,
+              "connector_image" : "quay.io/rhoas/cos-connector-telegram:0.1.56",
+              "connector_revision" : 56,
               "connector_type" : "source",
               "consumes" : "application/json",
               "error_handler_strategy" : "stop",
@@ -9276,8 +9292,8 @@ objects:
                 "trait.camel.apache.org/container.request-memory" : "128M",
                 "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
               },
-              "connector_image" : "quay.io/rhoas/cos-connector-aws-redshift:0.1.55",
-              "connector_revision" : 55,
+              "connector_image" : "quay.io/rhoas/cos-connector-aws-redshift:0.1.56",
+              "connector_revision" : 56,
               "connector_type" : "sink",
               "consumes" : "application/json",
               "error_handler_strategy" : "stop",
@@ -9459,8 +9475,8 @@ objects:
                 "trait.camel.apache.org/container.request-memory" : "128M",
                 "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
               },
-              "connector_image" : "quay.io/rhoas/cos-connector-aws-redshift:0.1.55",
-              "connector_revision" : 55,
+              "connector_image" : "quay.io/rhoas/cos-connector-aws-redshift:0.1.56",
+              "connector_revision" : 56,
               "connector_type" : "source",
               "consumes" : "application/json",
               "error_handler_strategy" : "stop",
@@ -9654,8 +9670,8 @@ objects:
                 "trait.camel.apache.org/container.request-memory" : "128M",
                 "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
               },
-              "connector_image" : "quay.io/rhoas/cos-connector-mariadb:0.1.55",
-              "connector_revision" : 55,
+              "connector_image" : "quay.io/rhoas/cos-connector-mariadb:0.1.56",
+              "connector_revision" : 56,
               "connector_type" : "sink",
               "consumes" : "application/json",
               "error_handler_strategy" : "stop",
@@ -9837,8 +9853,8 @@ objects:
                 "trait.camel.apache.org/container.request-memory" : "128M",
                 "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
               },
-              "connector_image" : "quay.io/rhoas/cos-connector-mariadb:0.1.55",
-              "connector_revision" : 55,
+              "connector_image" : "quay.io/rhoas/cos-connector-mariadb:0.1.56",
+              "connector_revision" : 56,
               "connector_type" : "source",
               "consumes" : "application/json",
               "error_handler_strategy" : "stop",
@@ -10026,8 +10042,8 @@ objects:
                 "trait.camel.apache.org/container.request-memory" : "128M",
                 "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
               },
-              "connector_image" : "quay.io/rhoas/cos-connector-mysql:0.1.55",
-              "connector_revision" : 55,
+              "connector_image" : "quay.io/rhoas/cos-connector-mysql:0.1.56",
+              "connector_revision" : 56,
               "connector_type" : "sink",
               "consumes" : "application/json",
               "error_handler_strategy" : "stop",
@@ -10209,8 +10225,8 @@ objects:
                 "trait.camel.apache.org/container.request-memory" : "128M",
                 "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
               },
-              "connector_image" : "quay.io/rhoas/cos-connector-mysql:0.1.55",
-              "connector_revision" : 55,
+              "connector_image" : "quay.io/rhoas/cos-connector-mysql:0.1.56",
+              "connector_revision" : 56,
               "connector_type" : "source",
               "consumes" : "application/json",
               "error_handler_strategy" : "stop",
@@ -10398,8 +10414,8 @@ objects:
                 "trait.camel.apache.org/container.request-memory" : "128M",
                 "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
               },
-              "connector_image" : "quay.io/rhoas/cos-connector-postgresql:0.1.55",
-              "connector_revision" : 55,
+              "connector_image" : "quay.io/rhoas/cos-connector-postgresql:0.1.56",
+              "connector_revision" : 56,
               "connector_type" : "sink",
               "consumes" : "application/json",
               "error_handler_strategy" : "stop",
@@ -10581,8 +10597,8 @@ objects:
                 "trait.camel.apache.org/container.request-memory" : "128M",
                 "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
               },
-              "connector_image" : "quay.io/rhoas/cos-connector-postgresql:0.1.55",
-              "connector_revision" : 55,
+              "connector_image" : "quay.io/rhoas/cos-connector-postgresql:0.1.56",
+              "connector_revision" : 56,
               "connector_type" : "source",
               "consumes" : "application/json",
               "error_handler_strategy" : "stop",
@@ -10770,8 +10786,8 @@ objects:
                 "trait.camel.apache.org/container.request-memory" : "128M",
                 "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
               },
-              "connector_image" : "quay.io/rhoas/cos-connector-sqlserver:0.1.55",
-              "connector_revision" : 55,
+              "connector_image" : "quay.io/rhoas/cos-connector-sqlserver:0.1.56",
+              "connector_revision" : 56,
               "connector_type" : "sink",
               "consumes" : "application/json",
               "error_handler_strategy" : "stop",
@@ -10959,8 +10975,8 @@ objects:
                 "trait.camel.apache.org/container.request-memory" : "128M",
                 "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
               },
-              "connector_image" : "quay.io/rhoas/cos-connector-sqlserver:0.1.55",
-              "connector_revision" : 55,
+              "connector_image" : "quay.io/rhoas/cos-connector-sqlserver:0.1.56",
+              "connector_revision" : 56,
               "connector_type" : "source",
               "consumes" : "application/json",
               "error_handler_strategy" : "stop",
@@ -11155,8 +11171,8 @@ objects:
                 "trait.camel.apache.org/container.request-memory" : "128M",
                 "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
               },
-              "connector_image" : "quay.io/rhoas/cos-connector-ftps:0.1.55",
-              "connector_revision" : 55,
+              "connector_image" : "quay.io/rhoas/cos-connector-ftps:0.1.56",
+              "connector_revision" : 56,
               "connector_type" : "sink",
               "consumes" : "application/octet-stream",
               "error_handler_strategy" : "stop",
@@ -11343,8 +11359,8 @@ objects:
                 "trait.camel.apache.org/container.request-memory" : "128M",
                 "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
               },
-              "connector_image" : "quay.io/rhoas/cos-connector-ftps:0.1.55",
-              "connector_revision" : 55,
+              "connector_image" : "quay.io/rhoas/cos-connector-ftps:0.1.56",
+              "connector_revision" : 56,
               "connector_type" : "source",
               "consumes" : "application/octet-stream",
               "error_handler_strategy" : "stop",
@@ -11537,8 +11553,8 @@ objects:
                 "trait.camel.apache.org/container.request-memory" : "128M",
                 "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
               },
-              "connector_image" : "quay.io/rhoas/cos-connector-minio:0.1.55",
-              "connector_revision" : 55,
+              "connector_image" : "quay.io/rhoas/cos-connector-minio:0.1.56",
+              "connector_revision" : 56,
               "connector_type" : "sink",
               "consumes" : "application/octet-stream",
               "error_handler_strategy" : "stop",
@@ -11722,8 +11738,8 @@ objects:
                 "trait.camel.apache.org/container.request-memory" : "128M",
                 "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
               },
-              "connector_image" : "quay.io/rhoas/cos-connector-minio:0.1.55",
-              "connector_revision" : 55,
+              "connector_image" : "quay.io/rhoas/cos-connector-minio:0.1.56",
+              "connector_revision" : 56,
               "connector_type" : "source",
               "consumes" : "application/octet-stream",
               "error_handler_strategy" : "stop",
@@ -11913,8 +11929,8 @@ objects:
                 "trait.camel.apache.org/container.request-memory" : "128M",
                 "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
               },
-              "connector_image" : "quay.io/rhoas/cos-connector-sftp:0.1.55",
-              "connector_revision" : 55,
+              "connector_image" : "quay.io/rhoas/cos-connector-sftp:0.1.56",
+              "connector_revision" : 56,
               "connector_type" : "sink",
               "consumes" : "application/octet-stream",
               "error_handler_strategy" : "stop",
@@ -12101,8 +12117,8 @@ objects:
                 "trait.camel.apache.org/container.request-memory" : "128M",
                 "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
               },
-              "connector_image" : "quay.io/rhoas/cos-connector-sftp:0.1.55",
-              "connector_revision" : 55,
+              "connector_image" : "quay.io/rhoas/cos-connector-sftp:0.1.56",
+              "connector_revision" : 56,
               "connector_type" : "source",
               "consumes" : "application/octet-stream",
               "error_handler_strategy" : "stop",


### PR DESCRIPTION
This copies the fixed azure kamelet from upstream and use it locally.
Also adds a test for azure eventhubs source and fixes the datashape.