### PR TITLE
Add explicit dependency to everit-json-schema

### DIFF
--- a/cos-fleet-catalog-tools/camel-connector-maven-plugin/pom.xml
+++ b/cos-fleet-catalog-tools/camel-connector-maven-plugin/pom.xml
@@ -111,6 +111,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.github.erosb</groupId>
+            <artifactId>everit-json-schema</artifactId>
+            <version>1.14.1</version>
+        </dependency>
+
+        <dependency>
             <groupId>io.github.classgraph</groupId>
             <artifactId>classgraph</artifactId>
         </dependency>

--- a/cos-fleet-catalog-tools/camel-connector-maven-plugin/pom.xml
+++ b/cos-fleet-catalog-tools/camel-connector-maven-plugin/pom.xml
@@ -108,6 +108,12 @@
         <dependency>
             <groupId>io.apicurio</groupId>
             <artifactId>apicurio-registry-schema-util-json</artifactId>
+            <exclusions>
+                <exclusion>
+                  <groupId>com.github.everit-org.json-schema</groupId>
+                  <artifactId>org.everit.json.schema</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/cos-fleet-catalog-tools/camel-connector-maven-plugin/pom.xml
+++ b/cos-fleet-catalog-tools/camel-connector-maven-plugin/pom.xml
@@ -109,6 +109,7 @@
             <groupId>io.apicurio</groupId>
             <artifactId>apicurio-registry-schema-util-json</artifactId>
             <exclusions>
+                <!-- Exclusion to avoid accessing jitpack repo. Replaced by com.github.erosb:everit-json-schema -->
                 <exclusion>
                   <groupId>com.github.everit-org.json-schema</groupId>
                   <artifactId>org.everit.json.schema</artifactId>
@@ -119,7 +120,6 @@
         <dependency>
             <groupId>com.github.erosb</groupId>
             <artifactId>everit-json-schema</artifactId>
-            <version>1.14.1</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
         <commons-collections4.version>4.4</commons-collections4.version>
         <wiremock.version>2.35.0</wiremock.version>
         <assertj-core.version>3.23.1</assertj-core.version>
+        <everit-json-schema.version>1.14.1</everit-json-schema.version>
 
         <maven.version>3.8.6</maven.version>
 
@@ -357,7 +358,11 @@
                 <artifactId>apicurio-registry-schema-util-json</artifactId>
                 <version>${apicurio.version}</version>
             </dependency>
-
+            <dependency>
+                <groupId>com.github.erosb</groupId>
+                <artifactId>everit-json-schema</artifactId>
+                <version>${everit-json-schema.version}</version>
+            </dependency>
             <dependency>
                 <groupId>com.github.java-json-tools</groupId>
                 <artifactId>json-schema-avro</artifactId>


### PR DESCRIPTION
Adding this explicit declaration overrides apicurio's transitive dependency of com.github.everit-org.json-schema:org.everit.json.schema:jar:1.14.0 which uses jitpack