### PR TITLE
MGDCTRS-1729: connector still running even if internal KafkaConsumer thread was shut down

### DIFF
--- a/cos-fleet-catalog-kamelets/kafka/src/main/resources/kamelets/cos-kafka-source.kamelet.yaml
+++ b/cos-fleet-catalog-kamelets/kafka/src/main/resources/kamelets/cos-kafka-source.kamelet.yaml
@@ -51,6 +51,7 @@ spec:
         valueDeserializer: "{{valueDeserializer:org.bf2.cos.connector.camel.serdes.bytes.ByteArrayDeserializer}}"
         kafkaClientFactory: "#{{kafka-client-factory}}"
         headerDeserializer: "#class:org.bf2.cos.connector.camel.kafka.ToStringHeaderDeserializer"
+        pollOnError: "{{pollOnError:RECONNECT}}"
       steps:
       - removeHeader:
           name: "kafka.HEADERS"


### PR DESCRIPTION
The default strategy for the KafkaConsumer is to delegate the error
handling to the Camel's error handler in case of an error while polling
kafka for messages and it then should continue polling for messages
however, in case of authentication errors, the consumer is stopped and
no more attempts are made.

Because the message goes to the error handler (i.e. to a dead letter
queue), then the error is swallowed and the connector is not reported as
failed.

This commit changes the default behavior of the the KafkaConsumer to
retry to connect at least once which would also report the connector
as failed.
