### PR TITLE
fix: MGDCTRS-1811: Enable processor validation

### DIFF
--- a/cos-fleet-catalog-tools/camel-connector-maven-plugin/pom.xml
+++ b/cos-fleet-catalog-tools/camel-connector-maven-plugin/pom.xml
@@ -350,7 +350,7 @@
             <plugin>
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-yaml-dsl-maven-plugin</artifactId>
-                <version>3.20.0-SNAPSHOT</version>
+                <version>3.21.0-SNAPSHOT</version>
                     <executions>
                         <execution>
                         <id>generate-yaml-schema-kebab-case-restricted</id>
@@ -361,6 +361,7 @@
                         <configuration>
                             <kebabCase>true</kebabCase>
                             <outputFile>src/generated/resources/schema/camel-yaml-dsl-restricted.json</outputFile>
+			    <additionalProperties>false</additionalProperties>
                             <bannedDefinitions>
                                 <bannedDefinition>org.apache.camel.model.AggregateDefinition</bannedDefinition>
                                 <bannedDefinition>org.apache.camel.model.BeanDefinition</bannedDefinition>

--- a/cos-fleet-catalog-tools/camel-connector-maven-plugin/src/generated/resources/schema/camel-yaml-dsl-restricted.json
+++ b/cos-fleet-catalog-tools/camel-connector-maven-plugin/src/generated/resources/schema/camel-yaml-dsl-restricted.json
@@ -7,6 +7,7 @@
       "org.apache.camel.model.ProcessorDefinition" : {
         "type" : "object",
         "maxProperties" : 1,
+        "additionalProperties" : false,
         "properties" : {
           "choice" : {
             "$ref" : "#/items/definitions/org.apache.camel.model.ChoiceDefinition"
@@ -33,6 +34,7 @@
       },
       "org.apache.camel.model.ChoiceDefinition" : {
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "description" : {
             "type" : "string"
@@ -65,6 +67,7 @@
       },
       "org.apache.camel.model.ExpressionSubElementDefinition" : {
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "constant" : {
             "$ref" : "#/items/definitions/org.apache.camel.model.language.ConstantExpression"
@@ -85,6 +88,7 @@
       },
       "org.apache.camel.model.FilterDefinition" : {
         "type" : "object",
+        "additionalProperties" : false,
         "anyOf" : [ {
           "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
         } ],
@@ -114,6 +118,7 @@
       },
       "org.apache.camel.model.OtherwiseDefinition" : {
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "description" : {
             "type" : "string"
@@ -134,6 +139,7 @@
       },
       "org.apache.camel.model.SetBodyDefinition" : {
         "type" : "object",
+        "additionalProperties" : false,
         "anyOf" : [ {
           "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
         } ],
@@ -154,6 +160,7 @@
       },
       "org.apache.camel.model.TransformDefinition" : {
         "type" : "object",
+        "additionalProperties" : false,
         "anyOf" : [ {
           "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
         } ],
@@ -174,6 +181,7 @@
       },
       "org.apache.camel.model.WhenDefinition" : {
         "type" : "object",
+        "additionalProperties" : false,
         "anyOf" : [ {
           "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
         } ],
@@ -203,6 +211,7 @@
           "type" : "string"
         }, {
           "type" : "object",
+          "additionalProperties" : false,
           "properties" : {
             "expression" : {
               "type" : "string"
@@ -225,6 +234,7 @@
           "type" : "string"
         }, {
           "type" : "object",
+          "additionalProperties" : false,
           "properties" : {
             "expression" : {
               "type" : "string"
@@ -241,6 +251,7 @@
       },
       "org.apache.camel.model.language.ExpressionDefinition" : {
         "type" : "object",
+        "additionalProperties" : false,
         "properties" : {
           "constant" : {
             "$ref" : "#/items/definitions/org.apache.camel.model.language.ConstantExpression"
@@ -264,6 +275,7 @@
           "type" : "string"
         }, {
           "type" : "object",
+          "additionalProperties" : false,
           "properties" : {
             "expression" : {
               "type" : "string"
@@ -283,6 +295,7 @@
           "type" : "string"
         }, {
           "type" : "object",
+          "additionalProperties" : false,
           "properties" : {
             "expression" : {
               "type" : "string"


### PR DESCRIPTION
Added `addionalProperties: false` in the connector schema under processors to restrict which processor is allowed. With this change, cos-fleet-manager will return an error against processors which is not allowed in the schema. This is enabled only on connectors which enable the processor schema which is optional.