### PR TITLE
MGDCTRS-1789: OpenAPI rest connector doesn't set the Content-Type header

### DIFF
--- a/cos-fleet-catalog-connectors-it/messaging/http-it/src/test/groovy/org/bf2/cos/connector/camel/it/ConnectorIT.groovy
+++ b/cos-fleet-catalog-connectors-it/messaging/http-it/src/test/groovy/org/bf2/cos/connector/camel/it/ConnectorIT.groovy
@@ -69,6 +69,7 @@ class ConnectorIT extends KafkaConnectorSpec {
                 'http_url': "${SCHEME}://${HOST}:${PORT}/run".toString(),
             ])
 
+            cnt.withCamelComponentDebugEnv()
             cnt.start()
         when:
             KafkaConnectorSpec.kafka.send(topic, payload, [

--- a/cos-fleet-catalog-connectors-it/messaging/openapi-it/src/test/groovy/org/bf2/cos/connector/camel/it/openapi/OpenAPIConnectorIT.groovy
+++ b/cos-fleet-catalog-connectors-it/messaging/openapi-it/src/test/groovy/org/bf2/cos/connector/camel/it/openapi/OpenAPIConnectorIT.groovy
@@ -53,6 +53,8 @@ class OpenAPIConnectorIT extends KafkaConnectorSpec {
         mock.start()
     }
 
+    //swaggerapi/petstore
+
     @Override
     def cleanupSpec() {
         closeQuietly(mock)
@@ -62,7 +64,7 @@ class OpenAPIConnectorIT extends KafkaConnectorSpec {
     def "openapi sink"(String scheme, int port) {
         setup:
             def topic = topic()
-            def payload = '''{ "name": "bar", "photoUrls"; [ "https://foo.bar" ] }'''
+            def payload = '''{ "name": "bar", "photoUrls": [ "https://foo.bar" ] }'''
 
             WireMock.configureFor(scheme, mock.getHost(), mock.getMappedPort(port))
 

--- a/cos-fleet-catalog-connectors-it/messaging/openapi-it/src/test/groovy/org/bf2/cos/connector/camel/it/openapi/OpenAPIConnectorPetStoreIT.groovy
+++ b/cos-fleet-catalog-connectors-it/messaging/openapi-it/src/test/groovy/org/bf2/cos/connector/camel/it/openapi/OpenAPIConnectorPetStoreIT.groovy
@@ -1,0 +1,71 @@
+package org.bf2.cos.connector.camel.it.openapi
+
+import groovy.util.logging.Slf4j
+import org.bf2.cos.connector.camel.it.support.KafkaConnectorSpec
+import org.bf2.cos.connector.camel.it.support.WaitStrategies
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.utility.DockerImageName
+import spock.lang.Unroll
+
+import java.util.concurrent.TimeUnit
+
+@Slf4j
+class OpenAPIConnectorPetStoreIT extends KafkaConnectorSpec {
+    static final int HTTP_PORT = 8080
+    static final String HTTP_SCHEME = 'http'
+    static final String HOST = 'tc-petstore'
+
+    static GenericContainer petStore
+
+    @Override
+    def setupSpec() {
+        petStore = new GenericContainer(DockerImageName.parse('swaggerapi/petstore:latest'))
+        petStore.withLogConsumer(logger(HOST))
+        petStore.withNetwork(network)
+        petStore.withNetworkAliases(HOST)
+        petStore.withExposedPorts(HTTP_PORT)
+        petStore.waitingFor(WaitStrategies.forHttpEndpoint(HTTP_SCHEME, HTTP_PORT, '/api/swagger.json'))
+        petStore.start()
+    }
+
+    @Override
+    def cleanupSpec() {
+        closeQuietly(petStore)
+    }
+
+    @Unroll
+    def "openapi petstore sink"() {
+        setup:
+            def topic = topic()
+            def payload = '''{ "name": "bar", "photoUrls": [ "https://foo.bar" ] }'''
+
+            def cnt = connectorContainer('rest_openapi_sink_0.1.json', [
+                'kafka_topic' : topic,
+                'kafka_bootstrap_servers': kafka.outsideBootstrapServers,
+                'kafka_consumer_group': topic,
+                'rest_openapi_host': "${HTTP_SCHEME}://${HOST}:${HTTP_PORT}".toString(),
+                'rest_openapi_specification': "${HTTP_SCHEME}://${HOST}:${HTTP_PORT}/api/swagger.json".toString(),
+                'rest_openapi_operation': 'addPet',
+            ])
+
+            cnt.withUserProperty('camel.main.name', 'rest_openapi_sink_0.1')
+            cnt.start()
+        when:
+            kafka.send(topic, payload)
+
+        then:
+            def records = kafka.poll(topic)
+            records.size() == 1
+            records.first().value() == payload
+
+            until(5, TimeUnit.SECONDS) {
+                def app =  cnt.request.get('/q/metrics').jsonPath().getMap('application')
+
+                return app['camel.context.exchanges.completed.total;camelContext=rest_openapi_sink_0.1'] == 1
+                    && app['camel.context.exchanges.failed.total;camelContext=rest_openapi_sink_0.1'] == 0
+            }
+
+        cleanup:
+            closeQuietly(cnt)
+    }
+}

--- a/cos-fleet-catalog-connectors-it/messaging/openapi-it/src/test/resources/logback-test.xml
+++ b/cos-fleet-catalog-connectors-it/messaging/openapi-it/src/test/resources/logback-test.xml
@@ -16,6 +16,7 @@
     <logger name="tc-container" level="INFO"/>
     <logger name="tc-kafka" level="WARN"/>
     <logger name="tc-mock" level="INFO"/>
+    <logger name="tc-petstore" level="INFO"/>
 
     <root level="INFO">
         <appender-ref ref="STDOUT"/>

--- a/cos-fleet-catalog-connectors/messaging/openapi-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/messaging/openapi-0.1/pom.xml
@@ -49,13 +49,6 @@
                                 <name>cos-kafka-source</name>
                                 <version>${cos.kamelets.version}</version>
                             </kafka>
-                            <dataShape>
-                                <consumes>
-                                    <formats>
-                                        <format>application/octet-stream</format>
-                                    </formats>
-                                </consumes>
-                            </dataShape>
                         </connector>
                     </connectors>
                 </configuration>

--- a/cos-fleet-catalog-connectors/pom.xml
+++ b/cos-fleet-catalog-connectors/pom.xml
@@ -65,10 +65,6 @@
             <artifactId>camel-quarkus-controlbus</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.camel.quarkus</groupId>
-            <artifactId>camel-quarkus-jq</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.bf2</groupId>
             <artifactId>cos-connector-camel-component-routecontroller</artifactId>
         </dependency>


### PR DESCRIPTION
- MGDCTRS-1789: OpenAPI rest connector doesn't set the Content-Type header
- chore: remove duplicated declaration of camel-quarkus-jq dependency
