### PR TITLE
Add pom dependencies generation

### DIFF
--- a/cos-fleet-catalog-connectors/aws/aws-cloudwatch-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/aws/aws-cloudwatch-0.1/pom.xml
@@ -1,59 +1,61 @@
-<?xml version="1.0"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-
-    <parent>
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>org.bf2</groupId>
+    <artifactId>cos-fleet-catalog-connectors-aws</artifactId>
+    <version>999-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>cos-connector-aws-cloudwatch-0.1</artifactId>
+  <name>Amazon CloudWatch Metrics</name>
+  <description>Amazon CloudWatch Metrics</description>
+  <packaging>jar</packaging>
+  <properties>
+    <cos.connector.type>aws-cloudwatch</cos.connector.type>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.camel.quarkus</groupId>
+      <artifactId>camel-quarkus-aws2-cw</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>utils</artifactId>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
         <groupId>org.bf2</groupId>
-        <artifactId>cos-fleet-catalog-connectors-aws</artifactId>
-        <version>999-SNAPSHOT</version>
-    </parent>
-
-    <modelVersion>4.0.0</modelVersion>
-    <artifactId>cos-connector-aws-cloudwatch-0.1</artifactId>
-
-    <name>Amazon CloudWatch Metrics</name>
-    <description>Amazon CloudWatch Metrics</description>
-
-    <packaging>jar</packaging>
-
-    <properties>
-        <cos.connector.type>aws-cloudwatch</cos.connector.type>
-    </properties>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.bf2</groupId>
-                <artifactId>camel-connector-maven-plugin</artifactId>
-                <configuration>
-                    <connectors>
-                        <connector>
-                            <name>${cos.connector.type}-sink-${cos.connector.version}</name>
-                            <title>${project.name} sink</title>
-                            <description>Send data to Amazon CloudWatch metrics.</description>
-                            <adapter>
-                                <prefix>aws</prefix>
-                                <name>${cos.connector.type}-sink</name>
-                                <version>${camel-kamelets-catalog.version}</version>
-                            </adapter>
-                            <kafka>
-                                <prefix>kafka</prefix>
-                                <name>cos-kafka-source</name>
-                                <version>${cos.kamelets.version}</version>
-                            </kafka>
-                            <dataShape>
-                                <consumes>
-                                    <formats>
-                                        <format>application/octet-stream</format>
-                                    </formats>
-                                </consumes>
-                            </dataShape>
-                        </connector>
-                    </connectors>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
+        <artifactId>camel-connector-maven-plugin</artifactId>
+        <configuration>
+          <connectors>
+            <connector>
+              <name>${cos.connector.type}-sink-${cos.connector.version}</name>
+              <title>${project.name} sink</title>
+              <description>Send data to Amazon CloudWatch metrics.</description>
+              <adapter>
+                <prefix>aws</prefix>
+                <name>${cos.connector.type}-sink</name>
+                <version>${camel-kamelets-catalog.version}</version>
+              </adapter>
+              <kafka>
+                <prefix>kafka</prefix>
+                <name>cos-kafka-source</name>
+                <version>${cos.kamelets.version}</version>
+              </kafka>
+              <dataShape>
+                <consumes>
+                  <formats>
+                    <format>application/octet-stream</format>
+                  </formats>
+                </consumes>
+              </dataShape>
+            </connector>
+          </connectors>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>
+

--- a/cos-fleet-catalog-connectors/aws/aws-dynamodb-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/aws/aws-dynamodb-0.1/pom.xml
@@ -1,52 +1,58 @@
-<?xml version="1.0"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-
-    <parent>
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>org.bf2</groupId>
+    <artifactId>cos-fleet-catalog-connectors-aws</artifactId>
+    <version>999-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>cos-connector-aws-dynamodb-0.1</artifactId>
+  <name>Amazon DynamoDB</name>
+  <description>Amazon DynamoDB</description>
+  <packaging>jar</packaging>
+  <properties>
+    <cos.connector.type>aws-ddb</cos.connector.type>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.camel.quarkus</groupId>
+      <artifactId>camel-quarkus-aws2-ddb</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel.quarkus</groupId>
+      <artifactId>camel-quarkus-jackson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>utils</artifactId>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
         <groupId>org.bf2</groupId>
-        <artifactId>cos-fleet-catalog-connectors-aws</artifactId>
-        <version>999-SNAPSHOT</version>
-    </parent>
-
-    <modelVersion>4.0.0</modelVersion>
-    <artifactId>cos-connector-aws-dynamodb-0.1</artifactId>
-
-    <name>Amazon DynamoDB</name>
-    <description>Amazon DynamoDB</description>
-
-    <packaging>jar</packaging>
-
-    <properties>
-        <cos.connector.type>aws-ddb</cos.connector.type>
-    </properties>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.bf2</groupId>
-                <artifactId>camel-connector-maven-plugin</artifactId>
-                <configuration>
-                    <connectors>
-                        <connector>
-                            <name>${cos.connector.type}-sink-${cos.connector.version}</name>
-                            <title>${project.name} sink</title>
-                            <description> Send data to Amazon DynamoDB NoSQL database service. The sent data inserts, updates, or deletes an item in the specified Amazon DynamoDB table.</description>
-                            <adapter>
-                                <prefix>aws</prefix>
-                                <name>${cos.connector.type}-sink</name>
-                                <version>${camel-kamelets-catalog.version}</version>
-                            </adapter>
-                            <kafka>
-                                <prefix>kafka</prefix>
-                                <name>cos-kafka-source</name>
-                                <version>${cos.kamelets.version}</version>
-                            </kafka>
-                        </connector>
-                    </connectors>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
+        <artifactId>camel-connector-maven-plugin</artifactId>
+        <configuration>
+          <connectors>
+            <connector>
+              <name>${cos.connector.type}-sink-${cos.connector.version}</name>
+              <title>${project.name} sink</title>
+              <description>Send data to Amazon DynamoDB NoSQL database service. The sent data inserts, updates, or deletes an item in the specified Amazon DynamoDB table.</description>
+              <adapter>
+                <prefix>aws</prefix>
+                <name>${cos.connector.type}-sink</name>
+                <version>${camel-kamelets-catalog.version}</version>
+              </adapter>
+              <kafka>
+                <prefix>kafka</prefix>
+                <name>cos-kafka-source</name>
+                <version>${cos.kamelets.version}</version>
+              </kafka>
+            </connector>
+          </connectors>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>
+

--- a/cos-fleet-catalog-connectors/aws/aws-dynamodb-streams-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/aws/aws-dynamodb-streams-0.1/pom.xml
@@ -1,52 +1,58 @@
-<?xml version="1.0"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-
-    <parent>
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>org.bf2</groupId>
+    <artifactId>cos-fleet-catalog-connectors-aws</artifactId>
+    <version>999-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>cos-connector-aws-dynamodb-streams-0.1</artifactId>
+  <name>Amazon DynamoDB Stream</name>
+  <description>Amazon DynamoDB Stream</description>
+  <packaging>jar</packaging>
+  <properties>
+    <cos.connector.type>aws-ddb-streams</cos.connector.type>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.camel.quarkus</groupId>
+      <artifactId>camel-quarkus-aws2-ddb</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel.quarkus</groupId>
+      <artifactId>camel-quarkus-gson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>utils</artifactId>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
         <groupId>org.bf2</groupId>
-        <artifactId>cos-fleet-catalog-connectors-aws</artifactId>
-        <version>999-SNAPSHOT</version>
-    </parent>
-
-    <modelVersion>4.0.0</modelVersion>
-    <artifactId>cos-connector-aws-dynamodb-streams-0.1</artifactId>
-
-    <name>Amazon DynamoDB Stream</name>
-    <description>Amazon DynamoDB Stream</description>
-
-    <packaging>jar</packaging>
-
-    <properties>
-        <cos.connector.type>aws-ddb-streams</cos.connector.type>
-    </properties>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.bf2</groupId>
-                <artifactId>camel-connector-maven-plugin</artifactId>
-                <configuration>
-                    <connectors>
-                        <connector>
-                            <name>${cos.connector.type}-source-${cos.connector.version}</name>
-                            <title>${project.name} source</title>
-                            <description>Receive data from Amazon DynamoDB Streams.</description>
-                            <adapter>
-                                <prefix>aws</prefix>
-                                <name>${cos.connector.type}-source</name>
-                                <version>${camel-kamelets-catalog.version}</version>
-                            </adapter>
-                            <kafka>
-                                <prefix>kafka</prefix>
-                                <name>cos-kafka-sink</name>
-                                <version>${cos.kamelets.version}</version>
-                            </kafka>
-                        </connector>
-                    </connectors>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
+        <artifactId>camel-connector-maven-plugin</artifactId>
+        <configuration>
+          <connectors>
+            <connector>
+              <name>${cos.connector.type}-source-${cos.connector.version}</name>
+              <title>${project.name} source</title>
+              <description>Receive data from Amazon DynamoDB Streams.</description>
+              <adapter>
+                <prefix>aws</prefix>
+                <name>${cos.connector.type}-source</name>
+                <version>${camel-kamelets-catalog.version}</version>
+              </adapter>
+              <kafka>
+                <prefix>kafka</prefix>
+                <name>cos-kafka-sink</name>
+                <version>${cos.kamelets.version}</version>
+              </kafka>
+            </connector>
+          </connectors>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>
+

--- a/cos-fleet-catalog-connectors/aws/aws-kinesis-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/aws/aws-kinesis-0.1/pom.xml
@@ -1,74 +1,76 @@
-<?xml version="1.0"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-
-    <parent>
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>org.bf2</groupId>
+    <artifactId>cos-fleet-catalog-connectors-aws</artifactId>
+    <version>999-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>cos-connector-aws-kinesis-0.1</artifactId>
+  <name>Amazon Kinesis</name>
+  <description>Amazon Kinesis</description>
+  <packaging>jar</packaging>
+  <properties>
+    <cos.connector.type>aws-kinesis</cos.connector.type>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.camel.quarkus</groupId>
+      <artifactId>camel-quarkus-aws2-kinesis</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>utils</artifactId>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
         <groupId>org.bf2</groupId>
-        <artifactId>cos-fleet-catalog-connectors-aws</artifactId>
-        <version>999-SNAPSHOT</version>
-    </parent>
-
-    <modelVersion>4.0.0</modelVersion>
-    <artifactId>cos-connector-aws-kinesis-0.1</artifactId>
-
-    <name>Amazon Kinesis</name>
-    <description>Amazon Kinesis</description>
-
-    <packaging>jar</packaging>
-
-    <properties>
-        <cos.connector.type>aws-kinesis</cos.connector.type>
-    </properties>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.bf2</groupId>
-                <artifactId>camel-connector-maven-plugin</artifactId>
-                <configuration>
-                    <connectors>
-                        <connector>
-                            <name>${cos.connector.type}-source-${cos.connector.version}</name>
-                            <title>${project.name} source</title>
-                            <description>Receive data from Amazon Kinesis.</description>
-                            <adapter>
-                                <prefix>aws</prefix>
-                                <name>${cos.connector.type}-source</name>
-                                <version>${camel-kamelets-catalog.version}</version>
-                            </adapter>
-                            <kafka>
-                                <prefix>kafka</prefix>
-                                <name>cos-kafka-sink</name>
-                                <version>${cos.kamelets.version}</version>
-                            </kafka>
-                        </connector>
-                        <connector>
-                            <name>${cos.connector.type}-sink-${cos.connector.version}</name>
-                            <title>${project.name} sink</title>
-                            <description>Send data to Amazon Kinesis.</description>
-                            <adapter>
-                                <prefix>aws</prefix>
-                                <name>${cos.connector.type}-sink</name>
-                                <version>${camel-kamelets-catalog.version}</version>
-                            </adapter>
-                            <kafka>
-                                <prefix>kafka</prefix>
-                                <name>cos-kafka-source</name>
-                                <version>${cos.kamelets.version}</version>
-                            </kafka>
-                            <dataShape>
-                                <consumes>
-                                    <formats>
-                                        <format>application/octet-stream</format>
-                                    </formats>
-                                </consumes>
-                            </dataShape>
-                        </connector>
-                    </connectors>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
+        <artifactId>camel-connector-maven-plugin</artifactId>
+        <configuration>
+          <connectors>
+            <connector>
+              <name>${cos.connector.type}-source-${cos.connector.version}</name>
+              <title>${project.name} source</title>
+              <description>Receive data from Amazon Kinesis.</description>
+              <adapter>
+                <prefix>aws</prefix>
+                <name>${cos.connector.type}-source</name>
+                <version>${camel-kamelets-catalog.version}</version>
+              </adapter>
+              <kafka>
+                <prefix>kafka</prefix>
+                <name>cos-kafka-sink</name>
+                <version>${cos.kamelets.version}</version>
+              </kafka>
+            </connector>
+            <connector>
+              <name>${cos.connector.type}-sink-${cos.connector.version}</name>
+              <title>${project.name} sink</title>
+              <description>Send data to Amazon Kinesis.</description>
+              <adapter>
+                <prefix>aws</prefix>
+                <name>${cos.connector.type}-sink</name>
+                <version>${camel-kamelets-catalog.version}</version>
+              </adapter>
+              <kafka>
+                <prefix>kafka</prefix>
+                <name>cos-kafka-source</name>
+                <version>${cos.kamelets.version}</version>
+              </kafka>
+              <dataShape>
+                <consumes>
+                  <formats>
+                    <format>application/octet-stream</format>
+                  </formats>
+                </consumes>
+              </dataShape>
+            </connector>
+          </connectors>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>
+

--- a/cos-fleet-catalog-connectors/aws/aws-lambda-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/aws/aws-lambda-0.1/pom.xml
@@ -1,59 +1,61 @@
-<?xml version="1.0"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-
-    <parent>
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>org.bf2</groupId>
+    <artifactId>cos-fleet-catalog-connectors-aws</artifactId>
+    <version>999-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>cos-connector-aws-lambda-0.1</artifactId>
+  <name>Amazon Lambda</name>
+  <description>Amazon Lambda</description>
+  <packaging>jar</packaging>
+  <properties>
+    <cos.connector.type>aws-lambda</cos.connector.type>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.camel.quarkus</groupId>
+      <artifactId>camel-quarkus-aws2-lambda</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>utils</artifactId>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
         <groupId>org.bf2</groupId>
-        <artifactId>cos-fleet-catalog-connectors-aws</artifactId>
-        <version>999-SNAPSHOT</version>
-    </parent>
-
-    <modelVersion>4.0.0</modelVersion>
-    <artifactId>cos-connector-aws-lambda-0.1</artifactId>
-
-    <name>Amazon Lambda</name>
-    <description>Amazon Lambda</description>
-
-    <packaging>jar</packaging>
-
-    <properties>
-        <cos.connector.type>aws-lambda</cos.connector.type>
-    </properties>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.bf2</groupId>
-                <artifactId>camel-connector-maven-plugin</artifactId>
-                <configuration>
-                    <connectors>
-                        <connector>
-                            <name>${cos.connector.type}-sink-${cos.connector.version}</name>
-                            <title>${project.name} sink</title>
-                            <description>Send data to an Amazon Lambda function.</description>
-                            <adapter>
-                                <prefix>aws</prefix>
-                                <name>${cos.connector.type}-sink</name>
-                                <version>${camel-kamelets-catalog.version}</version>
-                            </adapter>
-                            <kafka>
-                                <prefix>kafka</prefix>
-                                <name>cos-kafka-source</name>
-                                <version>${cos.kamelets.version}</version>
-                            </kafka>
-                            <dataShape>
-                                <consumes>
-                                    <formats>
-                                        <format>application/octet-stream</format>
-                                    </formats>
-                                </consumes>
-                            </dataShape>
-                        </connector>
-                    </connectors>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
+        <artifactId>camel-connector-maven-plugin</artifactId>
+        <configuration>
+          <connectors>
+            <connector>
+              <name>${cos.connector.type}-sink-${cos.connector.version}</name>
+              <title>${project.name} sink</title>
+              <description>Send data to an Amazon Lambda function.</description>
+              <adapter>
+                <prefix>aws</prefix>
+                <name>${cos.connector.type}-sink</name>
+                <version>${camel-kamelets-catalog.version}</version>
+              </adapter>
+              <kafka>
+                <prefix>kafka</prefix>
+                <name>cos-kafka-source</name>
+                <version>${cos.kamelets.version}</version>
+              </kafka>
+              <dataShape>
+                <consumes>
+                  <formats>
+                    <format>application/octet-stream</format>
+                  </formats>
+                </consumes>
+              </dataShape>
+            </connector>
+          </connectors>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>
+

--- a/cos-fleet-catalog-connectors/aws/aws-s3-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/aws/aws-s3-0.1/pom.xml
@@ -1,81 +1,83 @@
-<?xml version="1.0"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-
-    <parent>
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>org.bf2</groupId>
+    <artifactId>cos-fleet-catalog-connectors-aws</artifactId>
+    <version>999-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>cos-connector-aws-s3-0.1</artifactId>
+  <name>Amazon S3</name>
+  <description>Amazon S3</description>
+  <packaging>jar</packaging>
+  <properties>
+    <cos.connector.type>aws-s3</cos.connector.type>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.camel.quarkus</groupId>
+      <artifactId>camel-quarkus-aws2-s3</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>utils</artifactId>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
         <groupId>org.bf2</groupId>
-        <artifactId>cos-fleet-catalog-connectors-aws</artifactId>
-        <version>999-SNAPSHOT</version>
-    </parent>
-
-    <modelVersion>4.0.0</modelVersion>
-    <artifactId>cos-connector-aws-s3-0.1</artifactId>
-
-    <name>Amazon S3</name>
-    <description>Amazon S3</description>
-
-    <packaging>jar</packaging>
-
-    <properties>
-        <cos.connector.type>aws-s3</cos.connector.type>
-    </properties>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.bf2</groupId>
-                <artifactId>camel-connector-maven-plugin</artifactId>
-                <configuration>
-                    <connectors>
-                        <connector>
-                            <name>${cos.connector.type}-source-${cos.connector.version}</name>
-                            <title>${project.name} source</title>
-                            <description>Receive data from an Amazon S3 bucket.</description>
-                            <adapter>
-                                <prefix>aws</prefix>
-                                <name>${cos.connector.type}-source</name>
-                                <version>${camel-kamelets-catalog.version}</version>
-                            </adapter>
-                            <kafka>
-                                <prefix>kafka</prefix>
-                                <name>cos-kafka-sink</name>
-                                <version>${cos.kamelets.version}</version>
-                            </kafka>
-                            <dataShape>
-                                <produces>
-                                    <formats>
-                                        <format>application/octet-stream</format>
-                                    </formats>
-                                </produces>
-                            </dataShape>
-                        </connector>
-                        <connector>
-                            <name>${cos.connector.type}-sink-${cos.connector.version}</name>
-                            <title>${project.name} sink</title>
-                            <description>Send data to an Amazon S3 bucket.</description>
-                            <adapter>
-                                <prefix>aws</prefix>
-                                <name>${cos.connector.type}-sink</name>
-                                <version>${camel-kamelets-catalog.version}</version>
-                            </adapter>
-                            <kafka>
-                                <prefix>kafka</prefix>
-                                <name>cos-kafka-source</name>
-                                <version>${cos.kamelets.version}</version>
-                            </kafka>
-                            <dataShape>
-                                <consumes>
-                                    <formats>
-                                        <format>application/octet-stream</format>
-                                    </formats>
-                                </consumes>
-                            </dataShape>
-                        </connector>
-                    </connectors>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
+        <artifactId>camel-connector-maven-plugin</artifactId>
+        <configuration>
+          <connectors>
+            <connector>
+              <name>${cos.connector.type}-source-${cos.connector.version}</name>
+              <title>${project.name} source</title>
+              <description>Receive data from an Amazon S3 bucket.</description>
+              <adapter>
+                <prefix>aws</prefix>
+                <name>${cos.connector.type}-source</name>
+                <version>${camel-kamelets-catalog.version}</version>
+              </adapter>
+              <kafka>
+                <prefix>kafka</prefix>
+                <name>cos-kafka-sink</name>
+                <version>${cos.kamelets.version}</version>
+              </kafka>
+              <dataShape>
+                <produces>
+                  <formats>
+                    <format>application/octet-stream</format>
+                  </formats>
+                </produces>
+              </dataShape>
+            </connector>
+            <connector>
+              <name>${cos.connector.type}-sink-${cos.connector.version}</name>
+              <title>${project.name} sink</title>
+              <description>Send data to an Amazon S3 bucket.</description>
+              <adapter>
+                <prefix>aws</prefix>
+                <name>${cos.connector.type}-sink</name>
+                <version>${camel-kamelets-catalog.version}</version>
+              </adapter>
+              <kafka>
+                <prefix>kafka</prefix>
+                <name>cos-kafka-source</name>
+                <version>${cos.kamelets.version}</version>
+              </kafka>
+              <dataShape>
+                <consumes>
+                  <formats>
+                    <format>application/octet-stream</format>
+                  </formats>
+                </consumes>
+              </dataShape>
+            </connector>
+          </connectors>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>
+

--- a/cos-fleet-catalog-connectors/aws/aws-ses-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/aws/aws-ses-0.1/pom.xml
@@ -1,59 +1,61 @@
-<?xml version="1.0"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-
-    <parent>
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>org.bf2</groupId>
+    <artifactId>cos-fleet-catalog-connectors-aws</artifactId>
+    <version>999-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>cos-connector-aws-ses-0.1</artifactId>
+  <name>Amazon Simple Email Service</name>
+  <description>Amazon Simple Email Service</description>
+  <packaging>jar</packaging>
+  <properties>
+    <cos.connector.type>aws-ses</cos.connector.type>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.camel.quarkus</groupId>
+      <artifactId>camel-quarkus-aws2-ses</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>utils</artifactId>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
         <groupId>org.bf2</groupId>
-        <artifactId>cos-fleet-catalog-connectors-aws</artifactId>
-        <version>999-SNAPSHOT</version>
-    </parent>
-
-    <modelVersion>4.0.0</modelVersion>
-    <artifactId>cos-connector-aws-ses-0.1</artifactId>
-
-    <name>Amazon Simple Email Service</name>
-    <description>Amazon Simple Email Service</description>
-
-    <packaging>jar</packaging>
-
-    <properties>
-        <cos.connector.type>aws-ses</cos.connector.type>
-    </properties>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.bf2</groupId>
-                <artifactId>camel-connector-maven-plugin</artifactId>
-                <configuration>
-                    <connectors>
-                        <connector>
-                            <name>${cos.connector.type}-sink-${cos.connector.version}</name>
-                            <title>${project.name} sink</title>
-                            <description>Send email through the Amazon Simple Email Service (SES).</description>
-                            <adapter>
-                                <prefix>aws</prefix>
-                                <name>${cos.connector.type}-sink</name>
-                                <version>${camel-kamelets-catalog.version}</version>
-                            </adapter>
-                            <kafka>
-                                <prefix>kafka</prefix>
-                                <name>cos-kafka-source</name>
-                                <version>${cos.kamelets.version}</version>
-                            </kafka>
-                            <dataShape>
-                                <consumes>
-                                    <formats>
-                                        <format>application/octet-stream</format>
-                                    </formats>
-                                </consumes>
-                            </dataShape>
-                        </connector>
-                    </connectors>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
+        <artifactId>camel-connector-maven-plugin</artifactId>
+        <configuration>
+          <connectors>
+            <connector>
+              <name>${cos.connector.type}-sink-${cos.connector.version}</name>
+              <title>${project.name} sink</title>
+              <description>Send email through the Amazon Simple Email Service (SES).</description>
+              <adapter>
+                <prefix>aws</prefix>
+                <name>${cos.connector.type}-sink</name>
+                <version>${camel-kamelets-catalog.version}</version>
+              </adapter>
+              <kafka>
+                <prefix>kafka</prefix>
+                <name>cos-kafka-source</name>
+                <version>${cos.kamelets.version}</version>
+              </kafka>
+              <dataShape>
+                <consumes>
+                  <formats>
+                    <format>application/octet-stream</format>
+                  </formats>
+                </consumes>
+              </dataShape>
+            </connector>
+          </connectors>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>
+

--- a/cos-fleet-catalog-connectors/aws/aws-sns-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/aws/aws-sns-0.1/pom.xml
@@ -1,59 +1,61 @@
-<?xml version="1.0"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-
-    <parent>
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>org.bf2</groupId>
+    <artifactId>cos-fleet-catalog-connectors-aws</artifactId>
+    <version>999-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>cos-connector-aws-sns-0.1</artifactId>
+  <name>Amazon Simple Notification Service</name>
+  <description>Amazon Simple Notification Service</description>
+  <packaging>jar</packaging>
+  <properties>
+    <cos.connector.type>aws-sns</cos.connector.type>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.camel.quarkus</groupId>
+      <artifactId>camel-quarkus-aws2-sns</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>utils</artifactId>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
         <groupId>org.bf2</groupId>
-        <artifactId>cos-fleet-catalog-connectors-aws</artifactId>
-        <version>999-SNAPSHOT</version>
-    </parent>
-
-    <modelVersion>4.0.0</modelVersion>
-    <artifactId>cos-connector-aws-sns-0.1</artifactId>
-
-    <name>Amazon Simple Notification Service</name>
-    <description>Amazon Simple Notification Service</description>
-
-    <packaging>jar</packaging>
-
-    <properties>
-        <cos.connector.type>aws-sns</cos.connector.type>
-    </properties>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.bf2</groupId>
-                <artifactId>camel-connector-maven-plugin</artifactId>
-                <configuration>
-                    <connectors>
-                        <connector>
-                            <name>${cos.connector.type}-sink-${cos.connector.version}</name>
-                            <title>${project.name} sink</title>
-                            <description>Send data to an Amazon Simple Notification Service (SNS) topic.</description>
-                            <adapter>
-                                <prefix>aws</prefix>
-                                <name>${cos.connector.type}-sink</name>
-                                <version>${camel-kamelets-catalog.version}</version>
-                            </adapter>
-                            <kafka>
-                                <prefix>kafka</prefix>
-                                <name>cos-kafka-source</name>
-                                <version>${cos.kamelets.version}</version>
-                            </kafka>
-                            <dataShape>
-                                <consumes>
-                                    <formats>
-                                        <format>application/octet-stream</format>
-                                    </formats>
-                                </consumes>
-                            </dataShape>
-                        </connector>
-                    </connectors>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
+        <artifactId>camel-connector-maven-plugin</artifactId>
+        <configuration>
+          <connectors>
+            <connector>
+              <name>${cos.connector.type}-sink-${cos.connector.version}</name>
+              <title>${project.name} sink</title>
+              <description>Send data to an Amazon Simple Notification Service (SNS) topic.</description>
+              <adapter>
+                <prefix>aws</prefix>
+                <name>${cos.connector.type}-sink</name>
+                <version>${camel-kamelets-catalog.version}</version>
+              </adapter>
+              <kafka>
+                <prefix>kafka</prefix>
+                <name>cos-kafka-source</name>
+                <version>${cos.kamelets.version}</version>
+              </kafka>
+              <dataShape>
+                <consumes>
+                  <formats>
+                    <format>application/octet-stream</format>
+                  </formats>
+                </consumes>
+              </dataShape>
+            </connector>
+          </connectors>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>
+

--- a/cos-fleet-catalog-connectors/aws/aws-sqs-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/aws/aws-sqs-0.1/pom.xml
@@ -1,81 +1,83 @@
-<?xml version="1.0"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-
-    <parent>
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>org.bf2</groupId>
+    <artifactId>cos-fleet-catalog-connectors-aws</artifactId>
+    <version>999-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>cos-connector-aws-sqs-0.1</artifactId>
+  <name>Amazon Simple Queue Service</name>
+  <description>Amazon Simple Queue Service</description>
+  <packaging>jar</packaging>
+  <properties>
+    <cos.connector.type>aws-sqs</cos.connector.type>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.camel.quarkus</groupId>
+      <artifactId>camel-quarkus-aws2-sqs</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>utils</artifactId>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
         <groupId>org.bf2</groupId>
-        <artifactId>cos-fleet-catalog-connectors-aws</artifactId>
-        <version>999-SNAPSHOT</version>
-    </parent>
-
-    <modelVersion>4.0.0</modelVersion>
-    <artifactId>cos-connector-aws-sqs-0.1</artifactId>
-
-    <name>Amazon Simple Queue Service</name>
-    <description>Amazon Simple Queue Service</description>
-
-    <packaging>jar</packaging>
-
-    <properties>
-        <cos.connector.type>aws-sqs</cos.connector.type>
-    </properties>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.bf2</groupId>
-                <artifactId>camel-connector-maven-plugin</artifactId>
-                <configuration>
-                    <connectors>
-                        <connector>
-                            <name>${cos.connector.type}-source-${cos.connector.version}</name>
-                            <title>${project.name} source</title>
-                            <description>Receive data from Amazon Simple Queue Service (SQS).</description>
-                            <adapter>
-                                <prefix>aws</prefix>
-                                <name>${cos.connector.type}-source</name>
-                                <version>${camel-kamelets-catalog.version}</version>
-                            </adapter>
-                            <kafka>
-                                <prefix>kafka</prefix>
-                                <name>cos-kafka-sink</name>
-                                <version>${cos.kamelets.version}</version>
-                            </kafka>
-                            <dataShape>
-                                <produces>
-                                    <formats>
-                                        <format>application/octet-stream</format>
-                                    </formats>
-                                </produces>
-                            </dataShape>
-                        </connector>
-                        <connector>
-                            <name>${cos.connector.type}-sink-${cos.connector.version}</name>
-                            <title>${project.name} sink</title>
-                            <description>Send data to Amazon Simple Queue Service (SQS).</description>
-                            <adapter>
-                                <prefix>aws</prefix>
-                                <name>${cos.connector.type}-sink</name>
-                                <version>${camel-kamelets-catalog.version}</version>
-                            </adapter>
-                            <kafka>
-                                <prefix>kafka</prefix>
-                                <name>cos-kafka-source</name>
-                                <version>${cos.kamelets.version}</version>
-                            </kafka>
-                            <dataShape>
-                                <consumes>
-                                    <formats>
-                                        <format>application/octet-stream</format>
-                                    </formats>
-                                </consumes>
-                            </dataShape>
-                        </connector>
-                    </connectors>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
+        <artifactId>camel-connector-maven-plugin</artifactId>
+        <configuration>
+          <connectors>
+            <connector>
+              <name>${cos.connector.type}-source-${cos.connector.version}</name>
+              <title>${project.name} source</title>
+              <description>Receive data from Amazon Simple Queue Service (SQS).</description>
+              <adapter>
+                <prefix>aws</prefix>
+                <name>${cos.connector.type}-source</name>
+                <version>${camel-kamelets-catalog.version}</version>
+              </adapter>
+              <kafka>
+                <prefix>kafka</prefix>
+                <name>cos-kafka-sink</name>
+                <version>${cos.kamelets.version}</version>
+              </kafka>
+              <dataShape>
+                <produces>
+                  <formats>
+                    <format>application/octet-stream</format>
+                  </formats>
+                </produces>
+              </dataShape>
+            </connector>
+            <connector>
+              <name>${cos.connector.type}-sink-${cos.connector.version}</name>
+              <title>${project.name} sink</title>
+              <description>Send data to Amazon Simple Queue Service (SQS).</description>
+              <adapter>
+                <prefix>aws</prefix>
+                <name>${cos.connector.type}-sink</name>
+                <version>${camel-kamelets-catalog.version}</version>
+              </adapter>
+              <kafka>
+                <prefix>kafka</prefix>
+                <name>cos-kafka-source</name>
+                <version>${cos.kamelets.version}</version>
+              </kafka>
+              <dataShape>
+                <consumes>
+                  <formats>
+                    <format>application/octet-stream</format>
+                  </formats>
+                </consumes>
+              </dataShape>
+            </connector>
+          </connectors>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>
+

--- a/cos-fleet-catalog-connectors/azure/azure-eventhubs-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/azure/azure-eventhubs-0.1/pom.xml
@@ -1,88 +1,89 @@
-<?xml version="1.0"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-
-    <parent>
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>org.bf2</groupId>
+    <artifactId>cos-fleet-catalog-connectors-azure</artifactId>
+    <version>999-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>cos-connector-azure-eventhubs-0.1</artifactId>
+  <name>Azure Event Hubs</name>
+  <description>Azure Event Hubs</description>
+  <packaging>jar</packaging>
+  <properties>
+    <cos.connector.type>azure-eventhubs</cos.connector.type>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.camel.quarkus</groupId>
+      <artifactId>camel-quarkus-azure-eventhubs</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel.quarkus</groupId>
+      <artifactId>camel-quarkus-jackson</artifactId>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
         <groupId>org.bf2</groupId>
-        <artifactId>cos-fleet-catalog-connectors-azure</artifactId>
-        <version>999-SNAPSHOT</version>
-    </parent>
-
-    <modelVersion>4.0.0</modelVersion>
-    <artifactId>cos-connector-azure-eventhubs-0.1</artifactId>
-
-    <name>Azure Event Hubs</name>
-    <description>Azure Event Hubs</description>
-
-    <packaging>jar</packaging>
-
-    <properties>
-        <cos.connector.type>azure-eventhubs</cos.connector.type>
-    </properties>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.bf2</groupId>
-                <artifactId>camel-connector-maven-plugin</artifactId>
-                <configuration>
-                    <bannedDependencies>
-                        <bannedDependency>com.fasterxml.jackson.core:jackson-core</bannedDependency>
-                        <bannedDependency>com.fasterxml.jackson.core:jackson-annotations</bannedDependency>
-                        <bannedDependency>com.fasterxml.jackson.core:jackson-databind</bannedDependency>
-                        <bannedDependency>com.fasterxml.jackson.dataformat:jackson-dataformat-xml</bannedDependency>
-                    </bannedDependencies>
-
-                    <connectors>
-                        <connector>
-                            <name>${cos.connector.type}-source-${cos.connector.version}</name>
-                            <title>${project.name} source</title>
-                            <description>Receive data from Azure Event Hubs.</description>
-                            <adapter>
-                                <prefix>azure</prefix>
-                                <name>cos-${cos.connector.type}-source</name>
-                                <version>${cos.kamelets.version}</version>
-                            </adapter>
-                            <kafka>
-                                <prefix>kafka</prefix>
-                                <name>cos-kafka-sink</name>
-                                <version>${cos.kamelets.version}</version>
-                            </kafka>
-                            <dataShape>
-                                <produces>
-                                    <formats>
-                                        <format>application/octet-stream</format>
-                                    </formats>
-                                </produces>
-                            </dataShape>
-                        </connector>
-                        <connector>
-                            <name>${cos.connector.type}-sink-${cos.connector.version}</name>
-                            <title>${project.name} sink</title>
-                            <description>Send data to Azure Event Hubs.</description>
-                            <adapter>
-                                <prefix>azure</prefix>
-                                <name>cos-${cos.connector.type}-sink</name>
-                                <version>${cos.kamelets.version}</version>
-                            </adapter>
-                            <kafka>
-                                <prefix>kafka</prefix>
-                                <name>cos-kafka-source</name>
-                                <version>${cos.kamelets.version}</version>
-                            </kafka>
-                            <dataShape>
-                                <consumes>
-                                    <formats>
-                                        <format>application/octet-stream</format>
-                                    </formats>
-                                </consumes>
-                            </dataShape>
-                        </connector>
-                    </connectors>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
+        <artifactId>camel-connector-maven-plugin</artifactId>
+        <configuration>
+          <bannedDependencies>
+            <bannedDependency>com.fasterxml.jackson.core:jackson-core</bannedDependency>
+            <bannedDependency>com.fasterxml.jackson.core:jackson-annotations</bannedDependency>
+            <bannedDependency>com.fasterxml.jackson.core:jackson-databind</bannedDependency>
+            <bannedDependency>com.fasterxml.jackson.dataformat:jackson-dataformat-xml</bannedDependency>
+          </bannedDependencies>
+          <connectors>
+            <connector>
+              <name>${cos.connector.type}-source-${cos.connector.version}</name>
+              <title>${project.name} source</title>
+              <description>Receive data from Azure Event Hubs.</description>
+              <adapter>
+                <prefix>azure</prefix>
+                <name>cos-${cos.connector.type}-source</name>
+                <version>${cos.kamelets.version}</version>
+              </adapter>
+              <kafka>
+                <prefix>kafka</prefix>
+                <name>cos-kafka-sink</name>
+                <version>${cos.kamelets.version}</version>
+              </kafka>
+              <dataShape>
+                <produces>
+                  <formats>
+                    <format>application/octet-stream</format>
+                  </formats>
+                </produces>
+              </dataShape>
+            </connector>
+            <connector>
+              <name>${cos.connector.type}-sink-${cos.connector.version}</name>
+              <title>${project.name} sink</title>
+              <description>Send data to Azure Event Hubs.</description>
+              <adapter>
+                <prefix>azure</prefix>
+                <name>cos-${cos.connector.type}-sink</name>
+                <version>${cos.kamelets.version}</version>
+              </adapter>
+              <kafka>
+                <prefix>kafka</prefix>
+                <name>cos-kafka-source</name>
+                <version>${cos.kamelets.version}</version>
+              </kafka>
+              <dataShape>
+                <consumes>
+                  <formats>
+                    <format>application/octet-stream</format>
+                  </formats>
+                </consumes>
+              </dataShape>
+            </connector>
+          </connectors>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>
+

--- a/cos-fleet-catalog-connectors/azure/azure-functions-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/azure/azure-functions-0.1/pom.xml
@@ -1,63 +1,61 @@
-<?xml version="1.0"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-
-    <parent>
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>org.bf2</groupId>
+    <artifactId>cos-fleet-catalog-connectors-azure</artifactId>
+    <version>999-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>cos-connector-azure-functions-0.1</artifactId>
+  <name>Azure Functions</name>
+  <description>Azure Functions</description>
+  <packaging>jar</packaging>
+  <properties>
+    <cos.connector.type>azure-functions</cos.connector.type>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.camel.quarkus</groupId>
+      <artifactId>camel-quarkus-vertx-http</artifactId>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
         <groupId>org.bf2</groupId>
-        <artifactId>cos-fleet-catalog-connectors-azure</artifactId>
-        <version>999-SNAPSHOT</version>
-    </parent>
-
-    <modelVersion>4.0.0</modelVersion>
-    <artifactId>cos-connector-azure-functions-0.1</artifactId>
-
-    <name>Azure Functions</name>
-    <description>Azure Functions</description>
-
-    <packaging>jar</packaging>
-
-    <properties>
-        <cos.connector.type>azure-functions</cos.connector.type>
-    </properties>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.bf2</groupId>
-                <artifactId>camel-connector-maven-plugin</artifactId>
-                <configuration>
-                    <connectors>
-                        <connector>
-                            <name>${cos.connector.type}-sink-${cos.connector.version}</name>
-                            <title>${project.name} sink</title>
-                            <description>Send data to Functions.</description>
-                            <adapter>
-                                <prefix>azure</prefix>
-                                <name>${cos.connector.type}-sink</name>
-                                <version>${camel-kamelets-catalog.version}</version>
-                            </adapter>
-                            <kafka>
-                                <prefix>kafka</prefix>
-                                <name>cos-kafka-source</name>
-                                <version>${cos.kamelets.version}</version>
-                            </kafka>
-                            <dataShape>
-                                <consumes>
-                                    <formats>
-                                        <format>application/octet-stream</format>
-                                    </formats>
-                                </consumes>
-                            </dataShape>
-                        </connector>
-                    </connectors>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-resources-plugin</artifactId>
-            </plugin>
-        </plugins>
-    </build>
-
+        <artifactId>camel-connector-maven-plugin</artifactId>
+        <configuration>
+          <connectors>
+            <connector>
+              <name>${cos.connector.type}-sink-${cos.connector.version}</name>
+              <title>${project.name} sink</title>
+              <description>Send data to Functions.</description>
+              <adapter>
+                <prefix>azure</prefix>
+                <name>${cos.connector.type}-sink</name>
+                <version>${camel-kamelets-catalog.version}</version>
+              </adapter>
+              <kafka>
+                <prefix>kafka</prefix>
+                <name>cos-kafka-source</name>
+                <version>${cos.kamelets.version}</version>
+              </kafka>
+              <dataShape>
+                <consumes>
+                  <formats>
+                    <format>application/octet-stream</format>
+                  </formats>
+                </consumes>
+              </dataShape>
+            </connector>
+          </connectors>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
 </project>
+

--- a/cos-fleet-catalog-connectors/azure/azure-storage-blob-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/azure/azure-storage-blob-0.1/pom.xml
@@ -1,81 +1,83 @@
-<?xml version="1.0"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-
-    <parent>
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>org.bf2</groupId>
+    <artifactId>cos-fleet-catalog-connectors-azure</artifactId>
+    <version>999-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>cos-connector-azure-storage-blob-0.1</artifactId>
+  <name>Azure Blob Storage</name>
+  <description>Azure Blob Storage</description>
+  <packaging>jar</packaging>
+  <properties>
+    <cos.connector.type>azure-storage-blob</cos.connector.type>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.camel.quarkus</groupId>
+      <artifactId>camel-quarkus-azure-storage-blob</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel.quarkus</groupId>
+      <artifactId>camel-quarkus-timer</artifactId>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
         <groupId>org.bf2</groupId>
-        <artifactId>cos-fleet-catalog-connectors-azure</artifactId>
-        <version>999-SNAPSHOT</version>
-    </parent>
-
-    <modelVersion>4.0.0</modelVersion>
-    <artifactId>cos-connector-azure-storage-blob-0.1</artifactId>
-
-    <name>Azure Blob Storage</name>
-    <description>Azure Blob Storage</description>
-
-    <packaging>jar</packaging>
-
-    <properties>
-        <cos.connector.type>azure-storage-blob</cos.connector.type>
-    </properties>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.bf2</groupId>
-                <artifactId>camel-connector-maven-plugin</artifactId>
-                <configuration>
-                    <connectors>
-                        <connector>
-                            <name>${cos.connector.type}-source-${cos.connector.version}</name>
-                            <title>${project.name} source</title>
-                            <description>Receive data from Azure Blob storage.</description>
-                            <adapter>
-                                <prefix>azure</prefix>
-                                <name>cos-${cos.connector.type}-source</name>
-                                <version>${cos.kamelets.version}</version>
-                            </adapter>
-                            <kafka>
-                                <prefix>kafka</prefix>
-                                <name>cos-kafka-sink</name>
-                                <version>${cos.kamelets.version}</version>
-                            </kafka>
-                            <dataShape>
-                                <produces>
-                                    <formats>
-                                        <format>application/octet-stream</format>
-                                    </formats>
-                                </produces>
-                            </dataShape>
-                        </connector>
-                        <connector>
-                            <name>${cos.connector.type}-sink-${cos.connector.version}</name>
-                            <title>${project.name} sink</title>
-                            <description>Send data to Azure Blob storage.</description>
-                            <adapter>
-                                <prefix>azure</prefix>
-                                <name>${cos.connector.type}-sink</name>
-                                <version>${camel-kamelets-catalog.version}</version>
-                            </adapter>
-                            <kafka>
-                                <prefix>kafka</prefix>
-                                <name>cos-kafka-source</name>
-                                <version>${cos.kamelets.version}</version>
-                            </kafka>
-                            <dataShape>
-                                <consumes>
-                                    <formats>
-                                        <format>application/octet-stream</format>
-                                    </formats>
-                                </consumes>
-                            </dataShape>
-                        </connector>
-                    </connectors>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
+        <artifactId>camel-connector-maven-plugin</artifactId>
+        <configuration>
+          <connectors>
+            <connector>
+              <name>${cos.connector.type}-source-${cos.connector.version}</name>
+              <title>${project.name} source</title>
+              <description>Receive data from Azure Blob storage.</description>
+              <adapter>
+                <prefix>azure</prefix>
+                <name>cos-${cos.connector.type}-source</name>
+                <version>${cos.kamelets.version}</version>
+              </adapter>
+              <kafka>
+                <prefix>kafka</prefix>
+                <name>cos-kafka-sink</name>
+                <version>${cos.kamelets.version}</version>
+              </kafka>
+              <dataShape>
+                <produces>
+                  <formats>
+                    <format>application/octet-stream</format>
+                  </formats>
+                </produces>
+              </dataShape>
+            </connector>
+            <connector>
+              <name>${cos.connector.type}-sink-${cos.connector.version}</name>
+              <title>${project.name} sink</title>
+              <description>Send data to Azure Blob storage.</description>
+              <adapter>
+                <prefix>azure</prefix>
+                <name>${cos.connector.type}-sink</name>
+                <version>${camel-kamelets-catalog.version}</version>
+              </adapter>
+              <kafka>
+                <prefix>kafka</prefix>
+                <name>cos-kafka-source</name>
+                <version>${cos.kamelets.version}</version>
+              </kafka>
+              <dataShape>
+                <consumes>
+                  <formats>
+                    <format>application/octet-stream</format>
+                  </formats>
+                </consumes>
+              </dataShape>
+            </connector>
+          </connectors>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>
+

--- a/cos-fleet-catalog-connectors/azure/azure-storage-blob-changefeed-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/azure/azure-storage-blob-changefeed-0.1/pom.xml
@@ -1,65 +1,83 @@
-<?xml version="1.0"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-
-    <parent>
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>org.bf2</groupId>
+    <artifactId>cos-fleet-catalog-connectors-azure</artifactId>
+    <version>999-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>cos-connector-azure-storage-blob-changefeed-0.1</artifactId>
+  <name>Azure Blob Storage change feed</name>
+  <description>Azure Blob Storage change feed</description>
+  <packaging>jar</packaging>
+  <properties>
+    <cos.connector.type>azure-storage-blob-changefeed</cos.connector.type>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>com.azure</groupId>
+      <artifactId>azure-storage-blob-changefeed</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel.quarkus</groupId>
+      <artifactId>camel-quarkus-azure-storage-blob</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel.quarkus</groupId>
+      <artifactId>camel-quarkus-jackson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel.quarkus</groupId>
+      <artifactId>camel-quarkus-jsonpath</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel.quarkus</groupId>
+      <artifactId>camel-quarkus-timer</artifactId>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
         <groupId>org.bf2</groupId>
-        <artifactId>cos-fleet-catalog-connectors-azure</artifactId>
-        <version>999-SNAPSHOT</version>
-    </parent>
-
-    <modelVersion>4.0.0</modelVersion>
-    <artifactId>cos-connector-azure-storage-blob-changefeed-0.1</artifactId>
-
-    <name>Azure Blob Storage change feed</name>
-    <description>Azure Blob Storage change feed</description>
-
-    <packaging>jar</packaging>
-
-    <properties>
-        <cos.connector.type>azure-storage-blob-changefeed</cos.connector.type>
-    </properties>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.bf2</groupId>
-                <artifactId>camel-connector-maven-plugin</artifactId>
-                <configuration>
-                    <exclude>true</exclude>
-                    <connectors>
-                        <connector>
-                            <name>${cos.connector.type}-source-${cos.connector.version}</name>
-                            <title>${project.name} source</title>
-                            <description>Receive data from Azure Blob storage change feed.</description>
-                            <adapter>
-                                <prefix>azure</prefix>
-                                <name>cos-${cos.connector.type}-source</name>
-                                <version>${cos.kamelets.version}</version>
-                            </adapter>
-                            <kafka>
-                                <prefix>kafka</prefix>
-                                <name>cos-kafka-sink</name>
-                                <version>${cos.kamelets.version}</version>
-                            </kafka>
-                            <dataShape>
-                                <consumes>
-                                    <formats>
-                                        <format>application/json</format>
-                                    </formats>
-                                </consumes>
-                                <produces>
-                                    <formats>
-                                        <format>application/json</format>
-                                    </formats>
-                                </produces>
-                            </dataShape>
-                        </connector>
-                    </connectors>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
+        <artifactId>camel-connector-maven-plugin</artifactId>
+        <configuration>
+          <exclude>true</exclude>
+          <connectors>
+            <connector>
+              <name>${cos.connector.type}-source-${cos.connector.version}</name>
+              <title>${project.name} source</title>
+              <description>Receive data from Azure Blob storage change feed.</description>
+              <adapter>
+                <prefix>azure</prefix>
+                <name>cos-${cos.connector.type}-source</name>
+                <version>${cos.kamelets.version}</version>
+              </adapter>
+              <kafka>
+                <prefix>kafka</prefix>
+                <name>cos-kafka-sink</name>
+                <version>${cos.kamelets.version}</version>
+              </kafka>
+              <dataShape>
+                <consumes>
+                  <formats>
+                    <format>application/json</format>
+                  </formats>
+                </consumes>
+                <produces>
+                  <formats>
+                    <format>application/json</format>
+                  </formats>
+                </produces>
+              </dataShape>
+            </connector>
+          </connectors>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>
+

--- a/cos-fleet-catalog-connectors/azure/azure-storage-queue-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/azure/azure-storage-queue-0.1/pom.xml
@@ -1,81 +1,79 @@
-<?xml version="1.0"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-
-    <parent>
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>org.bf2</groupId>
+    <artifactId>cos-fleet-catalog-connectors-azure</artifactId>
+    <version>999-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>cos-connector-azure-storage-queue-0.1</artifactId>
+  <name>Azure Queue Storage</name>
+  <description>Azure Queue Storage</description>
+  <packaging>jar</packaging>
+  <properties>
+    <cos.connector.type>azure-storage-queue</cos.connector.type>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.camel.quarkus</groupId>
+      <artifactId>camel-quarkus-azure-storage-queue</artifactId>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
         <groupId>org.bf2</groupId>
-        <artifactId>cos-fleet-catalog-connectors-azure</artifactId>
-        <version>999-SNAPSHOT</version>
-    </parent>
-
-    <modelVersion>4.0.0</modelVersion>
-    <artifactId>cos-connector-azure-storage-queue-0.1</artifactId>
-
-    <name>Azure Queue Storage</name>
-    <description>Azure Queue Storage</description>
-
-    <packaging>jar</packaging>
-
-    <properties>
-        <cos.connector.type>azure-storage-queue</cos.connector.type>
-    </properties>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.bf2</groupId>
-                <artifactId>camel-connector-maven-plugin</artifactId>
-                <configuration>
-                    <connectors>
-                        <connector>
-                            <name>${cos.connector.type}-source-${cos.connector.version}</name>
-                            <title>${project.name} source</title>
-                            <description>Receive data from Azure Queue Storage.</description>
-                            <adapter>
-                                <prefix>azure</prefix>
-                                <name>${cos.connector.type}-source</name>
-                                <version>${camel-kamelets-catalog.version}</version>
-                            </adapter>
-                            <kafka>
-                                <prefix>kafka</prefix>
-                                <name>cos-kafka-sink</name>
-                                <version>${cos.kamelets.version}</version>
-                            </kafka>
-                            <dataShape>
-                                <produces>
-                                    <formats>
-                                        <format>application/octet-stream</format>
-                                    </formats>
-                                </produces>
-                            </dataShape>
-                        </connector>
-                        <connector>
-                            <name>${cos.connector.type}-sink-${cos.connector.version}</name>
-                            <title>${project.name} sink</title>
-                            <description>Send data to Azure Queue Storage.</description>
-                            <adapter>
-                                <prefix>azure</prefix>
-                                <name>${cos.connector.type}-sink</name>
-                                <version>${camel-kamelets-catalog.version}</version>
-                            </adapter>
-                            <kafka>
-                                <prefix>kafka</prefix>
-                                <name>cos-kafka-source</name>
-                                <version>${cos.kamelets.version}</version>
-                            </kafka>
-                            <dataShape>
-                                <consumes>
-                                    <formats>
-                                        <format>application/octet-stream</format>
-                                    </formats>
-                                </consumes>
-                            </dataShape>
-                        </connector>
-                    </connectors>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
+        <artifactId>camel-connector-maven-plugin</artifactId>
+        <configuration>
+          <connectors>
+            <connector>
+              <name>${cos.connector.type}-source-${cos.connector.version}</name>
+              <title>${project.name} source</title>
+              <description>Receive data from Azure Queue Storage.</description>
+              <adapter>
+                <prefix>azure</prefix>
+                <name>${cos.connector.type}-source</name>
+                <version>${camel-kamelets-catalog.version}</version>
+              </adapter>
+              <kafka>
+                <prefix>kafka</prefix>
+                <name>cos-kafka-sink</name>
+                <version>${cos.kamelets.version}</version>
+              </kafka>
+              <dataShape>
+                <produces>
+                  <formats>
+                    <format>application/octet-stream</format>
+                  </formats>
+                </produces>
+              </dataShape>
+            </connector>
+            <connector>
+              <name>${cos.connector.type}-sink-${cos.connector.version}</name>
+              <title>${project.name} sink</title>
+              <description>Send data to Azure Queue Storage.</description>
+              <adapter>
+                <prefix>azure</prefix>
+                <name>${cos.connector.type}-sink</name>
+                <version>${camel-kamelets-catalog.version}</version>
+              </adapter>
+              <kafka>
+                <prefix>kafka</prefix>
+                <name>cos-kafka-source</name>
+                <version>${cos.kamelets.version}</version>
+              </kafka>
+              <dataShape>
+                <consumes>
+                  <formats>
+                    <format>application/octet-stream</format>
+                  </formats>
+                </consumes>
+              </dataShape>
+            </connector>
+          </connectors>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>
+

--- a/cos-fleet-catalog-connectors/gcp/google-bigquery-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/gcp/google-bigquery-0.1/pom.xml
@@ -1,65 +1,64 @@
-<?xml version="1.0"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-
-    <parent>
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>org.bf2</groupId>
+    <artifactId>cos-fleet-catalog-connectors-gcp</artifactId>
+    <version>999-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>cos-connector-google-bigquery-0.1</artifactId>
+  <name>Google BigQuery</name>
+  <description>Google BigQuery</description>
+  <packaging>jar</packaging>
+  <properties>
+    <cos.connector.type>google-bigquery</cos.connector.type>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.camel.quarkus</groupId>
+      <artifactId>camel-quarkus-google-bigquery</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel.quarkus</groupId>
+      <artifactId>camel-quarkus-jackson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.bf2</groupId>
+      <artifactId>cos-connector-google</artifactId>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
         <groupId>org.bf2</groupId>
-        <artifactId>cos-fleet-catalog-connectors-gcp</artifactId>
-        <version>999-SNAPSHOT</version>
-    </parent>
-
-    <modelVersion>4.0.0</modelVersion>
-    <artifactId>cos-connector-google-bigquery-0.1</artifactId>
-
-    <name>Google BigQuery</name>
-    <description>Google BigQuery</description>
-
-    <packaging>jar</packaging>
-
-    <properties>
-        <cos.connector.type>google-bigquery</cos.connector.type>
-    </properties>
-
-    <dependencies>
-        <dependency>
-            <groupId>org.bf2</groupId>
-            <artifactId>cos-connector-google</artifactId>
-        </dependency>
-    </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.bf2</groupId>
-                <artifactId>camel-connector-maven-plugin</artifactId>
-                <configuration>
-                    <defaults>
-                        <customizers>
-                            <customizer>${project.basedir}/etc/customizers/patch_binary_properties.groovy</customizer>
-                            <customizer>${project.basedir}/etc/customizers/patch_service_account_key.groovy</customizer>
-                        </customizers>
-                    </defaults>
-                    <connectors>
-                        <connector>
-                            <name>${cos.connector.type}-sink-${cos.connector.version}</name>
-                            <title>${project.name} sink</title>
-                            <description>Send data to a Google Big Query table.</description>
-                            <adapter>
-                                <prefix>gcp</prefix>
-                                <name>${cos.connector.type}-sink</name>
-                                <version>${camel-kamelets-catalog.version}</version>
-                            </adapter>
-                            <kafka>
-                                <prefix>kafka</prefix>
-                                <name>cos-kafka-source</name>
-                                <version>${cos.kamelets.version}</version>
-                            </kafka>
-                        </connector>
-                    </connectors>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
+        <artifactId>camel-connector-maven-plugin</artifactId>
+        <configuration>
+          <defaults>
+            <customizers>
+              <customizer>${project.basedir}/etc/customizers/patch_binary_properties.groovy</customizer>
+              <customizer>${project.basedir}/etc/customizers/patch_service_account_key.groovy</customizer>
+            </customizers>
+          </defaults>
+          <connectors>
+            <connector>
+              <name>${cos.connector.type}-sink-${cos.connector.version}</name>
+              <title>${project.name} sink</title>
+              <description>Send data to a Google Big Query table.</description>
+              <adapter>
+                <prefix>gcp</prefix>
+                <name>${cos.connector.type}-sink</name>
+                <version>${camel-kamelets-catalog.version}</version>
+              </adapter>
+              <kafka>
+                <prefix>kafka</prefix>
+                <name>cos-kafka-source</name>
+                <version>${cos.kamelets.version}</version>
+              </kafka>
+            </connector>
+          </connectors>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>
+

--- a/cos-fleet-catalog-connectors/gcp/google-functions-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/gcp/google-functions-0.1/pom.xml
@@ -1,72 +1,71 @@
-<?xml version="1.0"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-
-    <parent>
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>org.bf2</groupId>
+    <artifactId>cos-fleet-catalog-connectors-gcp</artifactId>
+    <version>999-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>cos-connector-google-functions-0.1</artifactId>
+  <name>Google Cloud Functions</name>
+  <description>Google Cloud Functions</description>
+  <packaging>jar</packaging>
+  <properties>
+    <cos.connector.type>google-functions</cos.connector.type>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.camel.quarkus</groupId>
+      <artifactId>camel-quarkus-google-functions</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel.quarkus</groupId>
+      <artifactId>camel-quarkus-jackson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.bf2</groupId>
+      <artifactId>cos-connector-google</artifactId>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
         <groupId>org.bf2</groupId>
-        <artifactId>cos-fleet-catalog-connectors-gcp</artifactId>
-        <version>999-SNAPSHOT</version>
-    </parent>
-
-    <modelVersion>4.0.0</modelVersion>
-    <artifactId>cos-connector-google-functions-0.1</artifactId>
-
-    <name>Google Cloud Functions</name>
-    <description>Google Cloud Functions</description>
-
-    <packaging>jar</packaging>
-
-    <properties>
-        <cos.connector.type>google-functions</cos.connector.type>
-    </properties>
-
-    <dependencies>
-        <dependency>
-            <groupId>org.bf2</groupId>
-            <artifactId>cos-connector-google</artifactId>
-        </dependency>
-    </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.bf2</groupId>
-                <artifactId>camel-connector-maven-plugin</artifactId>
-                <configuration>
-                    <defaults>
-                        <customizers>
-                            <customizer>${project.basedir}/etc/customizers/patch_binary_properties.groovy</customizer>
-                            <customizer>${project.basedir}/etc/customizers/patch_service_account_key.groovy</customizer>
-                        </customizers>
-                    </defaults>
-                    <connectors>
-                        <connector>
-                            <name>${cos.connector.type}-sink-${cos.connector.version}</name>
-                            <title>${project.name} sink</title>
-                            <description>Send data to Google Functions.</description>
-                            <adapter>
-                                <prefix>gcp</prefix>
-                                <name>cos-${cos.connector.type}-sink</name>
-                                <version>${cos.kamelets.version}</version>
-                            </adapter>
-                            <kafka>
-                                <prefix>kafka</prefix>
-                                <name>cos-kafka-source</name>
-                                <version>${cos.kamelets.version}</version>
-                            </kafka>
-                            <dataShape>
-                                <consumes>
-                                    <formats>
-                                        <format>application/octet-stream</format>
-                                    </formats>
-                                </consumes>
-                            </dataShape>
-                        </connector>
-                    </connectors>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
+        <artifactId>camel-connector-maven-plugin</artifactId>
+        <configuration>
+          <defaults>
+            <customizers>
+              <customizer>${project.basedir}/etc/customizers/patch_binary_properties.groovy</customizer>
+              <customizer>${project.basedir}/etc/customizers/patch_service_account_key.groovy</customizer>
+            </customizers>
+          </defaults>
+          <connectors>
+            <connector>
+              <name>${cos.connector.type}-sink-${cos.connector.version}</name>
+              <title>${project.name} sink</title>
+              <description>Send data to Google Functions.</description>
+              <adapter>
+                <prefix>gcp</prefix>
+                <name>cos-${cos.connector.type}-sink</name>
+                <version>${cos.kamelets.version}</version>
+              </adapter>
+              <kafka>
+                <prefix>kafka</prefix>
+                <name>cos-kafka-source</name>
+                <version>${cos.kamelets.version}</version>
+              </kafka>
+              <dataShape>
+                <consumes>
+                  <formats>
+                    <format>application/octet-stream</format>
+                  </formats>
+                </consumes>
+              </dataShape>
+            </connector>
+          </connectors>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>
+

--- a/cos-fleet-catalog-connectors/gcp/google-pubsub-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/gcp/google-pubsub-0.1/pom.xml
@@ -1,94 +1,93 @@
-<?xml version="1.0"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-
-    <parent>
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>org.bf2</groupId>
+    <artifactId>cos-fleet-catalog-connectors-gcp</artifactId>
+    <version>999-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>cos-connector-google-pubsub-0.1</artifactId>
+  <name>Google Cloud Pub/Sub</name>
+  <description>Google Cloud Pub/Sub</description>
+  <packaging>jar</packaging>
+  <properties>
+    <cos.connector.type>google-pubsub</cos.connector.type>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.camel.quarkus</groupId>
+      <artifactId>camel-quarkus-google-pubsub</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel.quarkus</groupId>
+      <artifactId>camel-quarkus-jackson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.bf2</groupId>
+      <artifactId>cos-connector-google</artifactId>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
         <groupId>org.bf2</groupId>
-        <artifactId>cos-fleet-catalog-connectors-gcp</artifactId>
-        <version>999-SNAPSHOT</version>
-    </parent>
-
-    <modelVersion>4.0.0</modelVersion>
-    <artifactId>cos-connector-google-pubsub-0.1</artifactId>
-
-    <name>Google Cloud Pub/Sub</name>
-    <description>Google Cloud Pub/Sub</description>
-
-    <packaging>jar</packaging>
-
-    <properties>
-        <cos.connector.type>google-pubsub</cos.connector.type>
-    </properties>
-
-    <dependencies>
-        <dependency>
-            <groupId>org.bf2</groupId>
-            <artifactId>cos-connector-google</artifactId>
-        </dependency>
-    </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.bf2</groupId>
-                <artifactId>camel-connector-maven-plugin</artifactId>
-                <configuration>
-                    <defaults>
-                        <customizers>
-                            <customizer>${project.basedir}/etc/customizers/patch_binary_properties.groovy</customizer>
-                            <customizer>${project.basedir}/etc/customizers/patch_service_account_key.groovy</customizer>
-                        </customizers>
-                    </defaults>
-                    <connectors>
-                        <connector>
-                            <name>${cos.connector.type}-source-${cos.connector.version}</name>
-                            <title>${project.name} source</title>
-                            <description>Receive data from Google Cloud Pub/Sub.</description>
-                            <adapter>
-                                <prefix>gcp</prefix>
-                                <name>${cos.connector.type}-source</name>
-                                <version>${camel-kamelets-catalog.version}</version>
-                            </adapter>
-                            <kafka>
-                                <prefix>kafka</prefix>
-                                <name>cos-kafka-sink</name>
-                                <version>${cos.kamelets.version}</version>
-                            </kafka>
-                            <dataShape>
-                                <produces>
-                                    <formats>
-                                        <format>application/octet-stream</format>
-                                    </formats>
-                                </produces>
-                            </dataShape>
-                        </connector>
-                        <connector>
-                            <name>${cos.connector.type}-sink-${cos.connector.version}</name>
-                            <title>${project.name} sink</title>
-                            <description>Send data to Google Cloud Pub/Sub.</description>
-                            <adapter>
-                                <prefix>gcp</prefix>
-                                <name>${cos.connector.type}-sink</name>
-                                <version>${camel-kamelets-catalog.version}</version>
-                            </adapter>
-                            <kafka>
-                                <prefix>kafka</prefix>
-                                <name>cos-kafka-source</name>
-                                <version>${cos.kamelets.version}</version>
-                            </kafka>
-                            <dataShape>
-                                <consumes>
-                                    <formats>
-                                        <format>application/octet-stream</format>
-                                    </formats>
-                                </consumes>
-                            </dataShape>
-                        </connector>
-                    </connectors>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
+        <artifactId>camel-connector-maven-plugin</artifactId>
+        <configuration>
+          <defaults>
+            <customizers>
+              <customizer>${project.basedir}/etc/customizers/patch_binary_properties.groovy</customizer>
+              <customizer>${project.basedir}/etc/customizers/patch_service_account_key.groovy</customizer>
+            </customizers>
+          </defaults>
+          <connectors>
+            <connector>
+              <name>${cos.connector.type}-source-${cos.connector.version}</name>
+              <title>${project.name} source</title>
+              <description>Receive data from Google Cloud Pub/Sub.</description>
+              <adapter>
+                <prefix>gcp</prefix>
+                <name>${cos.connector.type}-source</name>
+                <version>${camel-kamelets-catalog.version}</version>
+              </adapter>
+              <kafka>
+                <prefix>kafka</prefix>
+                <name>cos-kafka-sink</name>
+                <version>${cos.kamelets.version}</version>
+              </kafka>
+              <dataShape>
+                <produces>
+                  <formats>
+                    <format>application/octet-stream</format>
+                  </formats>
+                </produces>
+              </dataShape>
+            </connector>
+            <connector>
+              <name>${cos.connector.type}-sink-${cos.connector.version}</name>
+              <title>${project.name} sink</title>
+              <description>Send data to Google Cloud Pub/Sub.</description>
+              <adapter>
+                <prefix>gcp</prefix>
+                <name>${cos.connector.type}-sink</name>
+                <version>${camel-kamelets-catalog.version}</version>
+              </adapter>
+              <kafka>
+                <prefix>kafka</prefix>
+                <name>cos-kafka-source</name>
+                <version>${cos.kamelets.version}</version>
+              </kafka>
+              <dataShape>
+                <consumes>
+                  <formats>
+                    <format>application/octet-stream</format>
+                  </formats>
+                </consumes>
+              </dataShape>
+            </connector>
+          </connectors>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>
+

--- a/cos-fleet-catalog-connectors/gcp/google-storage-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/gcp/google-storage-0.1/pom.xml
@@ -1,94 +1,93 @@
-<?xml version="1.0"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-
-    <parent>
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>org.bf2</groupId>
+    <artifactId>cos-fleet-catalog-connectors-gcp</artifactId>
+    <version>999-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>cos-connector-google-storage-0.1</artifactId>
+  <name>Google Cloud Storage</name>
+  <description>Google Cloud Storage</description>
+  <packaging>jar</packaging>
+  <properties>
+    <cos.connector.type>google-storage</cos.connector.type>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.camel.quarkus</groupId>
+      <artifactId>camel-quarkus-google-storage</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel.quarkus</groupId>
+      <artifactId>camel-quarkus-jackson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.bf2</groupId>
+      <artifactId>cos-connector-google</artifactId>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
         <groupId>org.bf2</groupId>
-        <artifactId>cos-fleet-catalog-connectors-gcp</artifactId>
-        <version>999-SNAPSHOT</version>
-    </parent>
-
-    <modelVersion>4.0.0</modelVersion>
-    <artifactId>cos-connector-google-storage-0.1</artifactId>
-
-    <name>Google Cloud Storage</name>
-    <description>Google Cloud Storage</description>
-
-    <packaging>jar</packaging>
-
-    <properties>
-        <cos.connector.type>google-storage</cos.connector.type>
-    </properties>
-
-    <dependencies>
-        <dependency>
-            <groupId>org.bf2</groupId>
-            <artifactId>cos-connector-google</artifactId>
-        </dependency>
-    </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.bf2</groupId>
-                <artifactId>camel-connector-maven-plugin</artifactId>
-                <configuration>
-                    <defaults>
-                        <customizers>
-                            <customizer>${project.basedir}/etc/customizers/patch_binary_properties.groovy</customizer>
-                            <customizer>${project.basedir}/etc/customizers/patch_service_account_key.groovy</customizer>
-                        </customizers>
-                    </defaults>
-                    <connectors>
-                        <connector>
-                            <name>${cos.connector.type}-source-${cos.connector.version}</name>
-                            <title>${project.name} source</title>
-                            <description>Send messages to Google Pubsub.</description>
-                            <adapter>
-                                <prefix>gcp</prefix>
-                                <name>${cos.connector.type}-source</name>
-                                <version>${camel-kamelets-catalog.version}</version>
-                            </adapter>
-                            <kafka>
-                                <prefix>kafka</prefix>
-                                <name>cos-kafka-sink</name>
-                                <version>${cos.kamelets.version}</version>
-                            </kafka>
-                            <dataShape>
-                                <produces>
-                                    <formats>
-                                        <format>application/octet-stream</format>
-                                    </formats>
-                                </produces>
-                            </dataShape>
-                        </connector>
-                        <connector>
-                            <name>${cos.connector.type}-sink-${cos.connector.version}</name>
-                            <title>${project.name} sink</title>
-                            <description>Upload data to Google Cloud Storage.</description>
-                            <adapter>
-                                <prefix>gcp</prefix>
-                                <name>${cos.connector.type}-sink</name>
-                                <version>${camel-kamelets-catalog.version}</version>
-                            </adapter>
-                            <kafka>
-                                <prefix>kafka</prefix>
-                                <name>cos-kafka-source</name>
-                                <version>${cos.kamelets.version}</version>
-                            </kafka>
-                            <dataShape>
-                                <consumes>
-                                    <formats>
-                                        <format>application/octet-stream</format>
-                                    </formats>
-                                </consumes>
-                            </dataShape>
-                        </connector>
-                    </connectors>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
+        <artifactId>camel-connector-maven-plugin</artifactId>
+        <configuration>
+          <defaults>
+            <customizers>
+              <customizer>${project.basedir}/etc/customizers/patch_binary_properties.groovy</customizer>
+              <customizer>${project.basedir}/etc/customizers/patch_service_account_key.groovy</customizer>
+            </customizers>
+          </defaults>
+          <connectors>
+            <connector>
+              <name>${cos.connector.type}-source-${cos.connector.version}</name>
+              <title>${project.name} source</title>
+              <description>Send messages to Google Pubsub.</description>
+              <adapter>
+                <prefix>gcp</prefix>
+                <name>${cos.connector.type}-source</name>
+                <version>${camel-kamelets-catalog.version}</version>
+              </adapter>
+              <kafka>
+                <prefix>kafka</prefix>
+                <name>cos-kafka-sink</name>
+                <version>${cos.kamelets.version}</version>
+              </kafka>
+              <dataShape>
+                <produces>
+                  <formats>
+                    <format>application/octet-stream</format>
+                  </formats>
+                </produces>
+              </dataShape>
+            </connector>
+            <connector>
+              <name>${cos.connector.type}-sink-${cos.connector.version}</name>
+              <title>${project.name} sink</title>
+              <description>Upload data to Google Cloud Storage.</description>
+              <adapter>
+                <prefix>gcp</prefix>
+                <name>${cos.connector.type}-sink</name>
+                <version>${camel-kamelets-catalog.version}</version>
+              </adapter>
+              <kafka>
+                <prefix>kafka</prefix>
+                <name>cos-kafka-source</name>
+                <version>${cos.kamelets.version}</version>
+              </kafka>
+              <dataShape>
+                <consumes>
+                  <formats>
+                    <format>application/octet-stream</format>
+                  </formats>
+                </consumes>
+              </dataShape>
+            </connector>
+          </connectors>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>
+

--- a/cos-fleet-catalog-connectors/itops/ansible-tower-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/itops/ansible-tower-0.1/pom.xml
@@ -1,60 +1,55 @@
-<?xml version="1.0"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-
-    <parent>
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>org.bf2</groupId>
+    <artifactId>cos-fleet-catalog-connectors-itops</artifactId>
+    <version>999-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>cos-connector-ansible-tower-0.1</artifactId>
+  <name>Ansible Tower</name>
+  <description>Ansible Tower</description>
+  <packaging>jar</packaging>
+  <properties>
+    <cos.connector.type>ansible-tower</cos.connector.type>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.camel.quarkus</groupId>
+      <artifactId>camel-quarkus-vertx-http</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.bf2</groupId>
+      <artifactId>cos-connector-ansible-tower</artifactId>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
         <groupId>org.bf2</groupId>
-        <artifactId>cos-fleet-catalog-connectors-itops</artifactId>
-        <version>999-SNAPSHOT</version>
-    </parent>
-
-    <modelVersion>4.0.0</modelVersion>
-    <artifactId>cos-connector-ansible-tower-0.1</artifactId>
-
-    <name>Ansible Tower</name>
-    <description>Ansible Tower</description>
-
-    <packaging>jar</packaging>
-
-    <properties>
-        <cos.connector.type>ansible-tower</cos.connector.type>
-    </properties>
-
-    <dependencies>
-        <dependency>
-            <groupId>org.bf2</groupId>
-            <artifactId>cos-connector-ansible-tower</artifactId>
-        </dependency>
-    </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.bf2</groupId>
-                <artifactId>camel-connector-maven-plugin</artifactId>
-                <configuration>
-                    <exclude>true</exclude>
-                    <connectors>
-                        <connector>
-                            <name>${cos.connector.type}-job-template-launch-sink-${cos.connector.version}</name>
-                            <title>${project.name} sink</title>
-                            <description>${project.description} sink</description>
-                            <adapter>
-                                <prefix>ansible</prefix>
-                                <name>ansible-job-template-launch-sink</name>
-                                <version>${cos.kamelets.version}</version>
-                            </adapter>
-                            <kafka>
-                                <prefix>kafka</prefix>
-                                <name>cos-kafka-source</name>
-                                <version>${cos.kamelets.version}</version>
-                            </kafka>
-                        </connector>
-                    </connectors>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
+        <artifactId>camel-connector-maven-plugin</artifactId>
+        <configuration>
+          <exclude>true</exclude>
+          <connectors>
+            <connector>
+              <name>${cos.connector.type}-job-template-launch-sink-${cos.connector.version}</name>
+              <title>${project.name} sink</title>
+              <description>${project.description} sink</description>
+              <adapter>
+                <prefix>ansible</prefix>
+                <name>ansible-job-template-launch-sink</name>
+                <version>${cos.kamelets.version}</version>
+              </adapter>
+              <kafka>
+                <prefix>kafka</prefix>
+                <name>cos-kafka-source</name>
+                <version>${cos.kamelets.version}</version>
+              </kafka>
+            </connector>
+          </connectors>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>
+

--- a/cos-fleet-catalog-connectors/itops/splunk-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/itops/splunk-0.1/pom.xml
@@ -1,58 +1,56 @@
-<?xml version="1.0"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-
-    <parent>
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>org.bf2</groupId>
+    <artifactId>cos-fleet-catalog-connectors-itops</artifactId>
+    <version>999-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>cos-connector-splunk-0.1</artifactId>
+  <name>Splunk</name>
+  <description>Splunk</description>
+  <packaging>jar</packaging>
+  <properties>
+    <cos.connector.type>splunk</cos.connector.type>
+    <quarkus.container-image.name>${cos.connector.container.prefix}-${cos.connector.type}</quarkus.container-image.name>
+    <quarkus.container-image.tag>${cos.connector.container.tag}</quarkus.container-image.tag>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.camel.quarkus</groupId>
+      <artifactId>camel-quarkus-splunk</artifactId>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
         <groupId>org.bf2</groupId>
-        <artifactId>cos-fleet-catalog-connectors-itops</artifactId>
-        <version>999-SNAPSHOT</version>
-    </parent>
-
-    <modelVersion>4.0.0</modelVersion>
-    <artifactId>cos-connector-splunk-0.1</artifactId>
-
-    <name>Splunk</name>
-    <description>Splunk</description>
-
-    <packaging>jar</packaging>
-
-    <properties>
-        <cos.connector.type>splunk</cos.connector.type>
-        <quarkus.container-image.name>${cos.connector.container.prefix}-${cos.connector.type}</quarkus.container-image.name>
-        <quarkus.container-image.tag>${cos.connector.container.tag}</quarkus.container-image.tag>
-    </properties>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.bf2</groupId>
-                <artifactId>camel-connector-maven-plugin</artifactId>
-                <configuration>
-                    <connectors>
-                        <connector>
-                            <name>splunk-${cos.connector.version}</name>
-                            <title>${project.name} sink</title>
-                            <description>Send data to Splunk.</description>
-                            <adapter>
-                                <prefix>splunk</prefix>
-                                <name>${cos.connector.type}-sink</name>
-                                <version>${camel-kamelets-catalog.version}</version>
-                            </adapter>
-                            <kafka>
-                                <prefix>kafka</prefix>
-                                <name>cos-kafka-source</name>
-                                <version>${cos.kamelets.version}</version>
-                            </kafka>
-                        </connector>
-                    </connectors>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-resources-plugin</artifactId>
-            </plugin>
-        </plugins>
-    </build>
-
+        <artifactId>camel-connector-maven-plugin</artifactId>
+        <configuration>
+          <connectors>
+            <connector>
+              <name>splunk-${cos.connector.version}</name>
+              <title>${project.name} sink</title>
+              <description>Send data to Splunk.</description>
+              <adapter>
+                <prefix>splunk</prefix>
+                <name>${cos.connector.type}-sink</name>
+                <version>${camel-kamelets-catalog.version}</version>
+              </adapter>
+              <kafka>
+                <prefix>kafka</prefix>
+                <name>cos-kafka-source</name>
+                <version>${cos.kamelets.version}</version>
+              </kafka>
+            </connector>
+          </connectors>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
 </project>
+

--- a/cos-fleet-catalog-connectors/messaging/http-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/messaging/http-0.1/pom.xml
@@ -1,66 +1,61 @@
-<?xml version="1.0"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-
-    <parent>
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>org.bf2</groupId>
+    <artifactId>cos-fleet-catalog-connectors-messaging</artifactId>
+    <version>999-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>cos-connector-http-0.1</artifactId>
+  <name>HTTP</name>
+  <description>HTTP</description>
+  <packaging>jar</packaging>
+  <properties>
+    <cos.connector.type>http</cos.connector.type>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.camel.quarkus</groupId>
+      <artifactId>camel-quarkus-http</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.bf2</groupId>
+      <artifactId>cos-connector-http</artifactId>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
         <groupId>org.bf2</groupId>
-        <artifactId>cos-fleet-catalog-connectors-messaging</artifactId>
-        <version>999-SNAPSHOT</version>
-    </parent>
-
-    <modelVersion>4.0.0</modelVersion>
-    <artifactId>cos-connector-http-0.1</artifactId>
-
-    <name>HTTP</name>
-    <description>HTTP</description>
-
-    <packaging>jar</packaging>
-
-    <properties>
-        <cos.connector.type>http</cos.connector.type>
-    </properties>
-
-    <dependencies>
-        <dependency>
-            <groupId>org.bf2</groupId>
-            <artifactId>cos-connector-http</artifactId>
-        </dependency>
-    </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.bf2</groupId>
-                <artifactId>camel-connector-maven-plugin</artifactId>
-                <configuration>
-                    <connectors>
-                        <connector>
-                            <name>${cos.connector.type}-sink-${cos.connector.version}</name>
-                            <title>${project.name} sink</title>
-                            <description>Send data to a HTTP endpoint.</description>
-                            <adapter>
-                                <prefix>http</prefix>
-                                <name>cos-${cos.connector.type}-sink</name>
-                                <version>${cos.kamelets.version}</version>
-                            </adapter>
-                            <kafka>
-                                <prefix>kafka</prefix>
-                                <name>cos-kafka-source</name>
-                                <version>${cos.kamelets.version}</version>
-                            </kafka>
-                            <dataShape>
-                                <consumes>
-                                    <formats>
-                                        <format>application/octet-stream</format>
-                                    </formats>
-                                </consumes>
-                            </dataShape>
-                        </connector>
-                    </connectors>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
+        <artifactId>camel-connector-maven-plugin</artifactId>
+        <configuration>
+          <connectors>
+            <connector>
+              <name>${cos.connector.type}-sink-${cos.connector.version}</name>
+              <title>${project.name} sink</title>
+              <description>Send data to a HTTP endpoint.</description>
+              <adapter>
+                <prefix>http</prefix>
+                <name>cos-${cos.connector.type}-sink</name>
+                <version>${cos.kamelets.version}</version>
+              </adapter>
+              <kafka>
+                <prefix>kafka</prefix>
+                <name>cos-kafka-source</name>
+                <version>${cos.kamelets.version}</version>
+              </kafka>
+              <dataShape>
+                <consumes>
+                  <formats>
+                    <format>application/octet-stream</format>
+                  </formats>
+                </consumes>
+              </dataShape>
+            </connector>
+          </connectors>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>
+

--- a/cos-fleet-catalog-connectors/messaging/jms-amqp-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/messaging/jms-amqp-0.1/pom.xml
@@ -1,81 +1,83 @@
-<?xml version="1.0"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-
-    <parent>
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>org.bf2</groupId>
+    <artifactId>cos-fleet-catalog-connectors-messaging</artifactId>
+    <version>999-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>cos-connector-jms-amqp-0.1</artifactId>
+  <name>JMS AMQP 1.0</name>
+  <description>JMS AMQP 1.0</description>
+  <packaging>jar</packaging>
+  <properties>
+    <cos.connector.type>jms-amqp-10</cos.connector.type>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.camel.quarkus</groupId>
+      <artifactId>camel-quarkus-jms</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.qpid</groupId>
+      <artifactId>qpid-jms-client</artifactId>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
         <groupId>org.bf2</groupId>
-        <artifactId>cos-fleet-catalog-connectors-messaging</artifactId>
-        <version>999-SNAPSHOT</version>
-    </parent>
-
-    <modelVersion>4.0.0</modelVersion>
-    <artifactId>cos-connector-jms-amqp-0.1</artifactId>
-
-    <name>JMS AMQP 1.0</name>
-    <description>JMS AMQP 1.0</description>
-
-    <packaging>jar</packaging>
-
-    <properties>
-        <cos.connector.type>jms-amqp-10</cos.connector.type>
-    </properties>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.bf2</groupId>
-                <artifactId>camel-connector-maven-plugin</artifactId>
-                <configuration>
-                    <connectors>
-                        <connector>
-                            <name>${cos.connector.type}-source-${cos.connector.version}</name>
-                            <title>${project.name} source</title>
-                            <description>Receive data from any AMQP 1.0 compliant message broker by using the Apache Qpid JMS client.</description>
-                            <adapter>
-                                <prefix>jms-amqp</prefix>
-                                <name>${cos.connector.type}-source</name>
-                                <version>${camel-kamelets-catalog.version}</version>
-                            </adapter>
-                            <kafka>
-                                <prefix>kafka</prefix>
-                                <name>cos-kafka-sink</name>
-                                <version>${cos.kamelets.version}</version>
-                            </kafka>
-                            <dataShape>
-                                <produces>
-                                    <formats>
-                                        <format>application/octet-stream</format>
-                                    </formats>
-                                </produces>
-                            </dataShape>
-                        </connector>
-                        <connector>
-                            <name>${cos.connector.type}-sink-${cos.connector.version}</name>
-                            <title>${project.name} sink</title>
-                            <description>Send data to any AMQP 1.0 compliant message broker by using the Apache Qpid JMS client.</description>
-                            <adapter>
-                                <prefix>jms-amqp</prefix>
-                                <name>${cos.connector.type}-sink</name>
-                                <version>${camel-kamelets-catalog.version}</version>
-                            </adapter>
-                            <kafka>
-                                <prefix>kafka</prefix>
-                                <name>cos-kafka-source</name>
-                                <version>${cos.kamelets.version}</version>
-                            </kafka>
-                            <dataShape>
-                                <consumes>
-                                    <formats>
-                                        <format>application/octet-stream</format>
-                                    </formats>
-                                </consumes>
-                            </dataShape>
-                        </connector>
-                    </connectors>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
+        <artifactId>camel-connector-maven-plugin</artifactId>
+        <configuration>
+          <connectors>
+            <connector>
+              <name>${cos.connector.type}-source-${cos.connector.version}</name>
+              <title>${project.name} source</title>
+              <description>Receive data from any AMQP 1.0 compliant message broker by using the Apache Qpid JMS client.</description>
+              <adapter>
+                <prefix>jms-amqp</prefix>
+                <name>${cos.connector.type}-source</name>
+                <version>${camel-kamelets-catalog.version}</version>
+              </adapter>
+              <kafka>
+                <prefix>kafka</prefix>
+                <name>cos-kafka-sink</name>
+                <version>${cos.kamelets.version}</version>
+              </kafka>
+              <dataShape>
+                <produces>
+                  <formats>
+                    <format>application/octet-stream</format>
+                  </formats>
+                </produces>
+              </dataShape>
+            </connector>
+            <connector>
+              <name>${cos.connector.type}-sink-${cos.connector.version}</name>
+              <title>${project.name} sink</title>
+              <description>Send data to any AMQP 1.0 compliant message broker by using the Apache Qpid JMS client.</description>
+              <adapter>
+                <prefix>jms-amqp</prefix>
+                <name>${cos.connector.type}-sink</name>
+                <version>${camel-kamelets-catalog.version}</version>
+              </adapter>
+              <kafka>
+                <prefix>kafka</prefix>
+                <name>cos-kafka-source</name>
+                <version>${cos.kamelets.version}</version>
+              </kafka>
+              <dataShape>
+                <consumes>
+                  <formats>
+                    <format>application/octet-stream</format>
+                  </formats>
+                </consumes>
+              </dataShape>
+            </connector>
+          </connectors>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>
+

--- a/cos-fleet-catalog-connectors/messaging/jms-artemis-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/messaging/jms-artemis-0.1/pom.xml
@@ -1,81 +1,83 @@
-<?xml version="1.0"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-
-    <parent>
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>org.bf2</groupId>
+    <artifactId>cos-fleet-catalog-connectors-messaging</artifactId>
+    <version>999-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>cos-connector-jms-artemis-0.1</artifactId>
+  <name>JMS Apache Artemis</name>
+  <description>JMS Apache Artemis</description>
+  <packaging>jar</packaging>
+  <properties>
+    <cos.connector.type>jms-apache-artemis</cos.connector.type>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.activemq</groupId>
+      <artifactId>artemis-jms-client-all</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel.quarkus</groupId>
+      <artifactId>camel-quarkus-jms</artifactId>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
         <groupId>org.bf2</groupId>
-        <artifactId>cos-fleet-catalog-connectors-messaging</artifactId>
-        <version>999-SNAPSHOT</version>
-    </parent>
-
-    <modelVersion>4.0.0</modelVersion>
-    <artifactId>cos-connector-jms-artemis-0.1</artifactId>
-
-    <name>JMS Apache Artemis</name>
-    <description>JMS Apache Artemis</description>
-
-    <packaging>jar</packaging>
-
-    <properties>
-        <cos.connector.type>jms-apache-artemis</cos.connector.type>
-    </properties>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.bf2</groupId>
-                <artifactId>camel-connector-maven-plugin</artifactId>
-                <configuration>
-                    <connectors>
-                        <connector>
-                            <name>${cos.connector.type}-source-${cos.connector.version}</name>
-                            <title>${project.name} source</title>
-                            <description>Receive data from an Apache Artemis message broker by using JMS.</description>
-                            <adapter>
-                                <prefix>jms-artemis</prefix>
-                                <name>${cos.connector.type}-source</name>
-                                <version>${camel-kamelets-catalog.version}</version>
-                            </adapter>
-                            <kafka>
-                                <prefix>kafka</prefix>
-                                <name>cos-kafka-sink</name>
-                                <version>${cos.kamelets.version}</version>
-                            </kafka>
-                            <dataShape>
-                                <produces>
-                                    <formats>
-                                        <format>application/octet-stream</format>
-                                    </formats>
-                                </produces>
-                            </dataShape>
-                        </connector>
-                        <connector>
-                            <name>${cos.connector.type}-sink-${cos.connector.version}</name>
-                            <title>${project.name} sink</title>
-                            <description>Send data to an Apache Artemis message broker by using JMS.</description>
-                            <adapter>
-                                <prefix>jms-artemis</prefix>
-                                <name>${cos.connector.type}-sink</name>
-                                <version>${camel-kamelets-catalog.version}</version>
-                            </adapter>
-                            <kafka>
-                                <prefix>kafka</prefix>
-                                <name>cos-kafka-source</name>
-                                <version>${cos.kamelets.version}</version>
-                            </kafka>
-                            <dataShape>
-                                <consumes>
-                                    <formats>
-                                        <format>application/octet-stream</format>
-                                    </formats>
-                                </consumes>
-                            </dataShape>
-                        </connector>
-                    </connectors>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
+        <artifactId>camel-connector-maven-plugin</artifactId>
+        <configuration>
+          <connectors>
+            <connector>
+              <name>${cos.connector.type}-source-${cos.connector.version}</name>
+              <title>${project.name} source</title>
+              <description>Receive data from an Apache Artemis message broker by using JMS.</description>
+              <adapter>
+                <prefix>jms-artemis</prefix>
+                <name>${cos.connector.type}-source</name>
+                <version>${camel-kamelets-catalog.version}</version>
+              </adapter>
+              <kafka>
+                <prefix>kafka</prefix>
+                <name>cos-kafka-sink</name>
+                <version>${cos.kamelets.version}</version>
+              </kafka>
+              <dataShape>
+                <produces>
+                  <formats>
+                    <format>application/octet-stream</format>
+                  </formats>
+                </produces>
+              </dataShape>
+            </connector>
+            <connector>
+              <name>${cos.connector.type}-sink-${cos.connector.version}</name>
+              <title>${project.name} sink</title>
+              <description>Send data to an Apache Artemis message broker by using JMS.</description>
+              <adapter>
+                <prefix>jms-artemis</prefix>
+                <name>${cos.connector.type}-sink</name>
+                <version>${camel-kamelets-catalog.version}</version>
+              </adapter>
+              <kafka>
+                <prefix>kafka</prefix>
+                <name>cos-kafka-source</name>
+                <version>${cos.kamelets.version}</version>
+              </kafka>
+              <dataShape>
+                <consumes>
+                  <formats>
+                    <format>application/octet-stream</format>
+                  </formats>
+                </consumes>
+              </dataShape>
+            </connector>
+          </connectors>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>
+

--- a/cos-fleet-catalog-connectors/messaging/openapi-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/messaging/openapi-0.1/pom.xml
@@ -1,60 +1,59 @@
-<?xml version="1.0"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-
-    <parent>
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>org.bf2</groupId>
+    <artifactId>cos-fleet-catalog-connectors-messaging</artifactId>
+    <version>999-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>cos-connector-openapi-0.1</artifactId>
+  <name>OpenAPI</name>
+  <description>OpenAPI</description>
+  <packaging>jar</packaging>
+  <properties>
+    <cos.connector.type>rest-openapi</cos.connector.type>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.camel.quarkus</groupId>
+      <artifactId>camel-quarkus-rest-openapi</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel.quarkus</groupId>
+      <artifactId>camel-quarkus-vertx-http</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.bf2</groupId>
+      <artifactId>cos-connector-openapi</artifactId>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
         <groupId>org.bf2</groupId>
-        <artifactId>cos-fleet-catalog-connectors-messaging</artifactId>
-        <version>999-SNAPSHOT</version>
-    </parent>
-
-    <modelVersion>4.0.0</modelVersion>
-    <artifactId>cos-connector-openapi-0.1</artifactId>
-
-    <name>OpenAPI</name>
-    <description>OpenAPI</description>
-
-    <packaging>jar</packaging>
-
-    <properties>
-        <cos.connector.type>rest-openapi</cos.connector.type>
-    </properties>
-
-    <dependencies>
-        <dependency>
-            <groupId>org.bf2</groupId>
-            <artifactId>cos-connector-openapi</artifactId>
-        </dependency>
-    </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.bf2</groupId>
-                <artifactId>camel-connector-maven-plugin</artifactId>
-                <configuration>
-                    <exclude>true</exclude>
-                    <connectors>
-                        <connector>
-                            <name>${cos.connector.type}-sink-${cos.connector.version}</name>
-                            <title>${project.name} sink</title>
-                            <description>Load an OpenAPI specification from a specified URI and call an operation on the HTTP service. </description>
-                            <adapter>
-                                <prefix>rest-openapi</prefix>
-                                <name>cos-${cos.connector.type}-sink</name>
-                                <version>${cos.kamelets.version}</version>
-                            </adapter>
-                            <kafka>
-                                <prefix>kafka</prefix>
-                                <name>cos-kafka-source</name>
-                                <version>${cos.kamelets.version}</version>
-                            </kafka>
-                        </connector>
-                    </connectors>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
+        <artifactId>camel-connector-maven-plugin</artifactId>
+        <configuration>
+          <exclude>true</exclude>
+          <connectors>
+            <connector>
+              <name>${cos.connector.type}-sink-${cos.connector.version}</name>
+              <title>${project.name} sink</title>
+              <description>Load an OpenAPI specification from a specified URI and call an operation on the HTTP service.</description>
+              <adapter>
+                <prefix>rest-openapi</prefix>
+                <name>cos-${cos.connector.type}-sink</name>
+                <version>${cos.kamelets.version}</version>
+              </adapter>
+              <kafka>
+                <prefix>kafka</prefix>
+                <name>cos-kafka-source</name>
+                <version>${cos.kamelets.version}</version>
+              </kafka>
+            </connector>
+          </connectors>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>
+

--- a/cos-fleet-catalog-connectors/misc/data-generator-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/misc/data-generator-0.1/pom.xml
@@ -1,59 +1,57 @@
-<?xml version="1.0"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-
-    <parent>
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>org.bf2</groupId>
+    <artifactId>cos-fleet-catalog-connectors-misc</artifactId>
+    <version>999-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>cos-connector-data-generator-0.1</artifactId>
+  <name>Data Generator</name>
+  <description>Data Generator</description>
+  <packaging>jar</packaging>
+  <properties>
+    <cos.connector.type>data-generator</cos.connector.type>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.camel.quarkus</groupId>
+      <artifactId>camel-quarkus-timer</artifactId>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
         <groupId>org.bf2</groupId>
-        <artifactId>cos-fleet-catalog-connectors-misc</artifactId>
-        <version>999-SNAPSHOT</version>
-    </parent>
-
-    <modelVersion>4.0.0</modelVersion>
-    <artifactId>cos-connector-data-generator-0.1</artifactId>
-
-    <name>Data Generator</name>
-    <description>Data Generator</description>
-
-    <packaging>jar</packaging>
-
-    <properties>
-        <cos.connector.type>data-generator</cos.connector.type>
-    </properties>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.bf2</groupId>
-                <artifactId>camel-connector-maven-plugin</artifactId>
-                <configuration>
-                    <connectors>
-                        <connector>
-                            <name>${cos.connector.type}-source-${cos.connector.version}</name>
-                            <title>${project.name} source</title>
-                            <description>A data generator (for development and testing purposes).</description>
-                            <adapter>
-                                <prefix>timer</prefix>
-                                <name>timer-source</name>
-                                <version>${camel-kamelets-catalog.version}</version>
-                            </adapter>
-                            <kafka>
-                                <prefix>kafka</prefix>
-                                <name>cos-kafka-sink</name>
-                                <version>${cos.kamelets.version}</version>
-                            </kafka>
-                            <dataShape>
-                                <produces>
-                                    <formats>
-                                        <format>application/octet-stream</format>
-                                    </formats>
-                                </produces>
-                            </dataShape>
-                        </connector>
-                    </connectors>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
+        <artifactId>camel-connector-maven-plugin</artifactId>
+        <configuration>
+          <connectors>
+            <connector>
+              <name>${cos.connector.type}-source-${cos.connector.version}</name>
+              <title>${project.name} source</title>
+              <description>A data generator (for development and testing purposes).</description>
+              <adapter>
+                <prefix>timer</prefix>
+                <name>timer-source</name>
+                <version>${camel-kamelets-catalog.version}</version>
+              </adapter>
+              <kafka>
+                <prefix>kafka</prefix>
+                <name>cos-kafka-sink</name>
+                <version>${cos.kamelets.version}</version>
+              </kafka>
+              <dataShape>
+                <produces>
+                  <formats>
+                    <format>application/octet-stream</format>
+                  </formats>
+                </produces>
+              </dataShape>
+            </connector>
+          </connectors>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>
+

--- a/cos-fleet-catalog-connectors/nosql/cassandra-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/nosql/cassandra-0.1/pom.xml
@@ -1,75 +1,77 @@
-<?xml version="1.0"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-
-    <parent>
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>org.bf2</groupId>
+    <artifactId>cos-fleet-catalog-connectors-nosql</artifactId>
+    <version>999-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>cos-connector-cassandra-0.1</artifactId>
+  <name>Apache Cassandra</name>
+  <description>Apache Cassandra</description>
+  <packaging>jar</packaging>
+  <properties>
+    <cos.connector.type>cassandra</cos.connector.type>
+    <quarkus.cassandra.health.enabled>false</quarkus.cassandra.health.enabled>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.camel.quarkus</groupId>
+      <artifactId>camel-quarkus-cassandraql</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel.quarkus</groupId>
+      <artifactId>camel-quarkus-jackson</artifactId>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
         <groupId>org.bf2</groupId>
-        <artifactId>cos-fleet-catalog-connectors-nosql</artifactId>
-        <version>999-SNAPSHOT</version>
-    </parent>
-
-    <modelVersion>4.0.0</modelVersion>
-    <artifactId>cos-connector-cassandra-0.1</artifactId>
-
-    <name>Apache Cassandra</name>
-    <description>Apache Cassandra</description>
-
-    <packaging>jar</packaging>
-
-    <properties>
-        <cos.connector.type>cassandra</cos.connector.type>
-        <quarkus.cassandra.health.enabled>false</quarkus.cassandra.health.enabled>
-    </properties>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.bf2</groupId>
-                <artifactId>camel-connector-maven-plugin</artifactId>
-                <configuration>
-                    <connectors>
-                        <connector>
-                            <name>${cos.connector.type}-source-${cos.connector.version}</name>
-                            <title>${project.name} source</title>
-                            <description>Retrieve data by sending a query to an Apache Cassandra cluster table.</description>
-                            <adapter>
-                                <prefix>cassandra</prefix>
-                                <name>${cos.connector.type}-source</name>
-                                <version>${camel-kamelets-catalog.version}</version>
-                            </adapter>
-                            <kafka>
-                                <prefix>kafka</prefix>
-                                <name>cos-kafka-sink</name>
-                                <version>${cos.kamelets.version}</version>
-                            </kafka>
-                            <dataShape>
-                                <produces>
-                                    <formats>
-                                        <format>application/octet-stream</format>
-                                    </formats>
-                                </produces>
-                            </dataShape>
-                        </connector>
-                        <connector>
-                            <name>${cos.connector.type}-sink-${cos.connector.version}</name>
-                            <title>${project.name} sink</title>
-                            <description>Send data to an Apache Cassandra cluster.</description>
-                            <adapter>
-                                <prefix>cassandra</prefix>
-                                <name>${cos.connector.type}-sink</name>
-                                <version>${camel-kamelets-catalog.version}</version>
-                            </adapter>
-                            <kafka>
-                                <prefix>kafka</prefix>
-                                <name>cos-kafka-source</name>
-                                <version>${cos.kamelets.version}</version>
-                            </kafka>
-                        </connector>
-                    </connectors>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
+        <artifactId>camel-connector-maven-plugin</artifactId>
+        <configuration>
+          <connectors>
+            <connector>
+              <name>${cos.connector.type}-source-${cos.connector.version}</name>
+              <title>${project.name} source</title>
+              <description>Retrieve data by sending a query to an Apache Cassandra cluster table.</description>
+              <adapter>
+                <prefix>cassandra</prefix>
+                <name>${cos.connector.type}-source</name>
+                <version>${camel-kamelets-catalog.version}</version>
+              </adapter>
+              <kafka>
+                <prefix>kafka</prefix>
+                <name>cos-kafka-sink</name>
+                <version>${cos.kamelets.version}</version>
+              </kafka>
+              <dataShape>
+                <produces>
+                  <formats>
+                    <format>application/octet-stream</format>
+                  </formats>
+                </produces>
+              </dataShape>
+            </connector>
+            <connector>
+              <name>${cos.connector.type}-sink-${cos.connector.version}</name>
+              <title>${project.name} sink</title>
+              <description>Send data to an Apache Cassandra cluster.</description>
+              <adapter>
+                <prefix>cassandra</prefix>
+                <name>${cos.connector.type}-sink</name>
+                <version>${camel-kamelets-catalog.version}</version>
+              </adapter>
+              <kafka>
+                <prefix>kafka</prefix>
+                <name>cos-kafka-source</name>
+                <version>${cos.kamelets.version}</version>
+              </kafka>
+            </connector>
+          </connectors>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>
+

--- a/cos-fleet-catalog-connectors/nosql/elasticsearch-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/nosql/elasticsearch-0.1/pom.xml
@@ -1,53 +1,63 @@
-<?xml version="1.0"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-
-    <parent>
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>org.bf2</groupId>
+    <artifactId>cos-fleet-catalog-connectors-nosql</artifactId>
+    <version>999-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>cos-connector-elasticsearch-0.1</artifactId>
+  <name>Elasticsearch</name>
+  <description>Elasticsearch</description>
+  <packaging>jar</packaging>
+  <properties>
+    <cos.connector.type>elasticsearch</cos.connector.type>
+    <quarkus.elasticsearch.health.enabled>false</quarkus.elasticsearch.health.enabled>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.camel.quarkus</groupId>
+      <artifactId>camel-quarkus-bean</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel.quarkus</groupId>
+      <artifactId>camel-quarkus-elasticsearch-rest</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel.quarkus</groupId>
+      <artifactId>camel-quarkus-gson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel.quarkus</groupId>
+      <artifactId>camel-quarkus-jackson</artifactId>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
         <groupId>org.bf2</groupId>
-        <artifactId>cos-fleet-catalog-connectors-nosql</artifactId>
-        <version>999-SNAPSHOT</version>
-    </parent>
-
-    <modelVersion>4.0.0</modelVersion>
-    <artifactId>cos-connector-elasticsearch-0.1</artifactId>
-
-    <name>Elasticsearch</name>
-    <description>Elasticsearch</description>
-
-    <packaging>jar</packaging>
-
-    <properties>
-        <cos.connector.type>elasticsearch</cos.connector.type>
-        <quarkus.elasticsearch.health.enabled>false</quarkus.elasticsearch.health.enabled>
-    </properties>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.bf2</groupId>
-                <artifactId>camel-connector-maven-plugin</artifactId>
-                <configuration>
-                    <connectors>
-                        <connector>
-                            <name>${cos.connector.type}-sink-${cos.connector.version}</name>
-                            <title>${project.name} sink</title>
-                            <description>Store JSON-formatted data into ElasticSearch.</description>
-                            <adapter>
-                                <prefix>elasticsearch</prefix>
-                                <name>${cos.connector.type}-index-sink</name>
-                                <version>${camel-kamelets-catalog.version}</version>
-                            </adapter>
-                            <kafka>
-                                <prefix>kafka</prefix>
-                                <name>cos-kafka-source</name>
-                                <version>${cos.kamelets.version}</version>
-                            </kafka>
-                        </connector>
-                    </connectors>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
+        <artifactId>camel-connector-maven-plugin</artifactId>
+        <configuration>
+          <connectors>
+            <connector>
+              <name>${cos.connector.type}-sink-${cos.connector.version}</name>
+              <title>${project.name} sink</title>
+              <description>Store JSON-formatted data into ElasticSearch.</description>
+              <adapter>
+                <prefix>elasticsearch</prefix>
+                <name>${cos.connector.type}-index-sink</name>
+                <version>${camel-kamelets-catalog.version}</version>
+              </adapter>
+              <kafka>
+                <prefix>kafka</prefix>
+                <name>cos-kafka-source</name>
+                <version>${cos.kamelets.version}</version>
+              </kafka>
+            </connector>
+          </connectors>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>
+

--- a/cos-fleet-catalog-connectors/nosql/mongodb-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/nosql/mongodb-0.1/pom.xml
@@ -1,81 +1,80 @@
-<?xml version="1.0"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-
-    <parent>
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>org.bf2</groupId>
+    <artifactId>cos-fleet-catalog-connectors-nosql</artifactId>
+    <version>999-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>cos-connector-mongodb-0.1</artifactId>
+  <name>MongoDB</name>
+  <description>MongoDB</description>
+  <packaging>jar</packaging>
+  <properties>
+    <cos.connector.type>mongodb</cos.connector.type>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.camel.quarkus</groupId>
+      <artifactId>camel-quarkus-jackson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel.quarkus</groupId>
+      <artifactId>camel-quarkus-mongodb</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.bf2</groupId>
+      <artifactId>cos-connector-mongodb</artifactId>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
         <groupId>org.bf2</groupId>
-        <artifactId>cos-fleet-catalog-connectors-nosql</artifactId>
-        <version>999-SNAPSHOT</version>
-    </parent>
-
-    <modelVersion>4.0.0</modelVersion>
-    <artifactId>cos-connector-mongodb-0.1</artifactId>
-
-    <name>MongoDB</name>
-    <description>MongoDB</description>
-
-    <packaging>jar</packaging>
-
-    <properties>
-        <cos.connector.type>mongodb</cos.connector.type>
-    </properties>
-
-    <dependencies>
-        <dependency>
-            <groupId>org.bf2</groupId>
-            <artifactId>cos-connector-mongodb</artifactId>
-        </dependency>
-    </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.bf2</groupId>
-                <artifactId>camel-connector-maven-plugin</artifactId>
-                <configuration>
-                    <connectors>
-                        <connector>
-                            <name>${cos.connector.type}-source-${cos.connector.version}</name>
-                            <title>${project.name} source</title>
-                            <description>Retrieve data from MongoDB.</description>
-                            <adapter>
-                                <prefix>mongodb</prefix>
-                                <name>cos-${cos.connector.type}-source</name>
-                                <version>${cos.kamelets.version}</version>
-                            </adapter>
-                            <kafka>
-                                <prefix>kafka</prefix>
-                                <name>cos-kafka-sink</name>
-                                <version>${cos.kamelets.version}</version>
-                            </kafka>
-                            <dataShape>
-                                <produces>
-                                    <formats>
-                                        <format>application/json</format>
-                                    </formats>
-                                </produces>
-                            </dataShape>
-                        </connector>
-                        <connector>
-                            <name>${cos.connector.type}-sink-${cos.connector.version}</name>
-                            <title>${project.name} sink</title>
-                            <description>Send data to MongoDB.</description>
-                            <adapter>
-                                <prefix>mongodb</prefix>
-                                <name>cos-${cos.connector.type}-sink</name>
-                                <version>${cos.kamelets.version}</version>
-                            </adapter>
-                            <kafka>
-                                <prefix>kafka</prefix>
-                                <name>cos-kafka-source</name>
-                                <version>${cos.kamelets.version}</version>
-                            </kafka>
-                        </connector>
-                    </connectors>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
+        <artifactId>camel-connector-maven-plugin</artifactId>
+        <configuration>
+          <connectors>
+            <connector>
+              <name>${cos.connector.type}-source-${cos.connector.version}</name>
+              <title>${project.name} source</title>
+              <description>Retrieve data from MongoDB.</description>
+              <adapter>
+                <prefix>mongodb</prefix>
+                <name>cos-${cos.connector.type}-source</name>
+                <version>${cos.kamelets.version}</version>
+              </adapter>
+              <kafka>
+                <prefix>kafka</prefix>
+                <name>cos-kafka-sink</name>
+                <version>${cos.kamelets.version}</version>
+              </kafka>
+              <dataShape>
+                <produces>
+                  <formats>
+                    <format>application/json</format>
+                  </formats>
+                </produces>
+              </dataShape>
+            </connector>
+            <connector>
+              <name>${cos.connector.type}-sink-${cos.connector.version}</name>
+              <title>${project.name} sink</title>
+              <description>Send data to MongoDB.</description>
+              <adapter>
+                <prefix>mongodb</prefix>
+                <name>cos-${cos.connector.type}-sink</name>
+                <version>${cos.kamelets.version}</version>
+              </adapter>
+              <kafka>
+                <prefix>kafka</prefix>
+                <name>cos-kafka-source</name>
+                <version>${cos.kamelets.version}</version>
+              </kafka>
+            </connector>
+          </connectors>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>
+

--- a/cos-fleet-catalog-connectors/pom.xml
+++ b/cos-fleet-catalog-connectors/pom.xml
@@ -84,6 +84,10 @@
         <!-- camel -->
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
             <artifactId>camel-quarkus-direct</artifactId>
         </dependency>
         <dependency>
@@ -133,7 +137,14 @@
                     <artifactId>camel-connector-maven-plugin</artifactId>
                     <executions>
                         <execution>
-                            <id>generate</id>
+                            <id>generate-pom</id>
+                            <phase>process-resources</phase>
+                            <goals>
+                                <goal>enrich-pom</goal>
+                            </goals>
+                        </execution>
+                        <execution>
+                            <id>generate-catalo</id>
                             <phase>process-resources</phase>
                             <goals>
                                 <goal>generate-catalog</goal>

--- a/cos-fleet-catalog-connectors/saas/jira-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/saas/jira-0.1/pom.xml
@@ -1,82 +1,88 @@
-<?xml version="1.0"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-
-    <parent>
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>org.bf2</groupId>
+    <artifactId>cos-fleet-catalog-connectors-saas</artifactId>
+    <version>999-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>cos-connector-jira-0.1</artifactId>
+  <name>Jira</name>
+  <description>Jira</description>
+  <packaging>jar</packaging>
+  <properties>
+    <cos.connector.type>jira</cos.connector.type>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-joda</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel.quarkus</groupId>
+      <artifactId>camel-quarkus-jackson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel.quarkus</groupId>
+      <artifactId>camel-quarkus-jira</artifactId>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
         <groupId>org.bf2</groupId>
-        <artifactId>cos-fleet-catalog-connectors-saas</artifactId>
-        <version>999-SNAPSHOT</version>
-    </parent>
-
-    <modelVersion>4.0.0</modelVersion>
-    <artifactId>cos-connector-jira-0.1</artifactId>
-
-    <name>Jira</name>
-    <description>Jira</description>
-
-    <packaging>jar</packaging>
-
-    <properties>
-        <cos.connector.type>jira</cos.connector.type>
-    </properties>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.bf2</groupId>
-                <artifactId>camel-connector-maven-plugin</artifactId>
-                <configuration>
-                    <connectors>
-                        <connector>
-                            <name>${cos.connector.type}-source-${cos.connector.version}</name>
-                            <title>${project.name} source</title>
-                            <description>Receive notifications about new issues from Jira.</description>
-                            <adapter>
-                                <prefix>jira</prefix>
-                                <name>${cos.connector.type}-source</name>
-                                <version>${camel-kamelets-catalog.version}</version>
-                            </adapter>
-                            <kafka>
-                                <prefix>kafka</prefix>
-                                <name>cos-kafka-sink</name>
-                                <version>${cos.kamelets.version}</version>
-                            </kafka>
-                        </connector>
-                        <connector>
-                            <name>${cos.connector.type}-add-comment-sink-${cos.connector.version}</name>
-                            <title>${project.name} Add Comment sink</title>
-                            <description>Add a new comment to an existing issue in Jira.</description>
-                            <adapter>
-                                <prefix>jira</prefix>
-                                <name>${cos.connector.type}-add-comment-sink</name>
-                                <version>${camel-kamelets-catalog.version}</version>
-                            </adapter>
-                            <kafka>
-                                <prefix>kafka</prefix>
-                                <name>cos-kafka-source</name>
-                                <version>${cos.kamelets.version}</version>
-                            </kafka>
-                        </connector>
-                        <connector>
-                            <name>${cos.connector.type}-add-issue-sink-${cos.connector.version}</name>
-                            <title>${project.name} Add Issue sink</title>
-                            <description>Add a new issue to Jira.</description>
-                            <adapter>
-                                <prefix>jira</prefix>
-                                <name>${cos.connector.type}-add-issue-sink</name>
-                                <version>${camel-kamelets-catalog.version}</version>
-                            </adapter>
-                            <kafka>
-                                <prefix>kafka</prefix>
-                                <name>cos-kafka-source</name>
-                                <version>${cos.kamelets.version}</version>
-                            </kafka>
-                        </connector>
-                    </connectors>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
+        <artifactId>camel-connector-maven-plugin</artifactId>
+        <configuration>
+          <connectors>
+            <connector>
+              <name>${cos.connector.type}-source-${cos.connector.version}</name>
+              <title>${project.name} source</title>
+              <description>Receive notifications about new issues from Jira.</description>
+              <adapter>
+                <prefix>jira</prefix>
+                <name>${cos.connector.type}-source</name>
+                <version>${camel-kamelets-catalog.version}</version>
+              </adapter>
+              <kafka>
+                <prefix>kafka</prefix>
+                <name>cos-kafka-sink</name>
+                <version>${cos.kamelets.version}</version>
+              </kafka>
+            </connector>
+            <connector>
+              <name>${cos.connector.type}-add-comment-sink-${cos.connector.version}</name>
+              <title>${project.name} Add Comment sink</title>
+              <description>Add a new comment to an existing issue in Jira.</description>
+              <adapter>
+                <prefix>jira</prefix>
+                <name>${cos.connector.type}-add-comment-sink</name>
+                <version>${camel-kamelets-catalog.version}</version>
+              </adapter>
+              <kafka>
+                <prefix>kafka</prefix>
+                <name>cos-kafka-source</name>
+                <version>${cos.kamelets.version}</version>
+              </kafka>
+            </connector>
+            <connector>
+              <name>${cos.connector.type}-add-issue-sink-${cos.connector.version}</name>
+              <title>${project.name} Add Issue sink</title>
+              <description>Add a new issue to Jira.</description>
+              <adapter>
+                <prefix>jira</prefix>
+                <name>${cos.connector.type}-add-issue-sink</name>
+                <version>${camel-kamelets-catalog.version}</version>
+              </adapter>
+              <kafka>
+                <prefix>kafka</prefix>
+                <name>cos-kafka-source</name>
+                <version>${cos.kamelets.version}</version>
+              </kafka>
+            </connector>
+          </connectors>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>
+

--- a/cos-fleet-catalog-connectors/saas/salesforce-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/saas/salesforce-0.1/pom.xml
@@ -1,120 +1,118 @@
-<?xml version="1.0"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-
-    <parent>
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>org.bf2</groupId>
+    <artifactId>cos-fleet-catalog-connectors-saas</artifactId>
+    <version>999-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>cos-connector-salesforce-0.1</artifactId>
+  <name>Salesforce</name>
+  <description>Salesforce</description>
+  <packaging>jar</packaging>
+  <properties>
+    <cos.connector.type>salesforce</cos.connector.type>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.camel.quarkus</groupId>
+      <artifactId>camel-quarkus-jackson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel.quarkus</groupId>
+      <artifactId>camel-quarkus-jsonpath</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel.quarkus</groupId>
+      <artifactId>camel-quarkus-salesforce</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.bf2</groupId>
+      <artifactId>cos-connector-salesforce</artifactId>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
         <groupId>org.bf2</groupId>
-        <artifactId>cos-fleet-catalog-connectors-saas</artifactId>
-        <version>999-SNAPSHOT</version>
-    </parent>
-
-    <modelVersion>4.0.0</modelVersion>
-    <artifactId>cos-connector-salesforce-0.1</artifactId>
-
-    <name>Salesforce</name>
-    <description>Salesforce</description>
-
-    <packaging>jar</packaging>
-
-    <properties>
-        <cos.connector.type>salesforce</cos.connector.type>
-    </properties>
-
-    <dependencies>
-        <dependency>
-            <groupId>org.bf2</groupId>
-            <artifactId>cos-connector-salesforce</artifactId>
-        </dependency>
-    </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.bf2</groupId>
-                <artifactId>camel-connector-maven-plugin</artifactId>
-                <configuration>
-                    <connectors>
-
-                        <!-- Salesforce Streaming Source -->
-                        <connector>
-                            <name>${cos.connector.type}-streaming-source-${cos.connector.version}</name>
-                            <title>${project.name} Streaming source</title>
-                            <description>Receive updates from Salesforce.</description>
-                            <adapter>
-                                <prefix>salesforce</prefix>
-                                <name>cos-${cos.connector.type}-streaming-source</name>
-                                <version>${cos.kamelets.version}</version>
-                            </adapter>
-                            <kafka>
-                                <prefix>kafka</prefix>
-                                <name>cos-kafka-sink</name>
-                                <version>${cos.kamelets.version}</version>
-                            </kafka>
-                            <dataShape>
-                                <produces>
-                                    <formats>
-                                        <format>application/json</format>
-                                    </formats>
-                                </produces>
-                            </dataShape>
-                        </connector>
-
-                        <!-- Salesforce Create -->
-                        <connector>
-                            <name>${cos.connector.type}-create-sink-${cos.connector.version}</name>
-                            <title>${project.name} Create sink</title>
-                            <description>Create an object in Salesforce.</description>
-                            <adapter>
-                                <prefix>salesforce</prefix>
-                                <name>${cos.connector.type}-create-sink</name>
-                                <version>${camel-kamelets-catalog.version}</version>
-                            </adapter>
-                            <kafka>
-                                <prefix>kafka</prefix>
-                                <name>cos-kafka-source</name>
-                                <version>${cos.kamelets.version}</version>
-                            </kafka>
-                        </connector>
-
-                        <!-- Salesforce Delete -->
-                        <connector>
-                            <name>${cos.connector.type}-delete-sink-${cos.connector.version}</name>
-                            <title>${project.name} Delete sink</title>
-                            <description>Delete an object in Salesforce.</description>
-                            <adapter>
-                                <prefix>salesforce</prefix>
-                                <name>${cos.connector.type}-delete-sink</name>
-                                <version>${camel-kamelets-catalog.version}</version>
-                            </adapter>
-                            <kafka>
-                                <prefix>kafka</prefix>
-                                <name>cos-kafka-source</name>
-                                <version>${cos.kamelets.version}</version>
-                            </kafka>
-                        </connector>
-
-                        <!-- Salesforce Update -->
-                        <connector>
-                            <name>${cos.connector.type}-update-sink-${cos.connector.version}</name>
-                            <title>${project.name} Update sink</title>
-                            <description>Update an object in Salesforce.</description>
-                            <adapter>
-                                <prefix>salesforce</prefix>
-                                <name>${cos.connector.type}-update-sink</name>
-                                <version>${camel-kamelets-catalog.version}</version>
-                            </adapter>
-                            <kafka>
-                                <prefix>kafka</prefix>
-                                <name>cos-kafka-source</name>
-                                <version>${cos.kamelets.version}</version>
-                            </kafka>
-                        </connector>
-
-                    </connectors>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
+        <artifactId>camel-connector-maven-plugin</artifactId>
+        <configuration>
+          <connectors>
+            <!-- Salesforce Streaming Source -->
+            <connector>
+              <name>${cos.connector.type}-streaming-source-${cos.connector.version}</name>
+              <title>${project.name} Streaming source</title>
+              <description>Receive updates from Salesforce.</description>
+              <adapter>
+                <prefix>salesforce</prefix>
+                <name>cos-${cos.connector.type}-streaming-source</name>
+                <version>${cos.kamelets.version}</version>
+              </adapter>
+              <kafka>
+                <prefix>kafka</prefix>
+                <name>cos-kafka-sink</name>
+                <version>${cos.kamelets.version}</version>
+              </kafka>
+              <dataShape>
+                <produces>
+                  <formats>
+                    <format>application/json</format>
+                  </formats>
+                </produces>
+              </dataShape>
+            </connector>
+            <!-- Salesforce Create -->
+            <connector>
+              <name>${cos.connector.type}-create-sink-${cos.connector.version}</name>
+              <title>${project.name} Create sink</title>
+              <description>Create an object in Salesforce.</description>
+              <adapter>
+                <prefix>salesforce</prefix>
+                <name>${cos.connector.type}-create-sink</name>
+                <version>${camel-kamelets-catalog.version}</version>
+              </adapter>
+              <kafka>
+                <prefix>kafka</prefix>
+                <name>cos-kafka-source</name>
+                <version>${cos.kamelets.version}</version>
+              </kafka>
+            </connector>
+            <!-- Salesforce Delete -->
+            <connector>
+              <name>${cos.connector.type}-delete-sink-${cos.connector.version}</name>
+              <title>${project.name} Delete sink</title>
+              <description>Delete an object in Salesforce.</description>
+              <adapter>
+                <prefix>salesforce</prefix>
+                <name>${cos.connector.type}-delete-sink</name>
+                <version>${camel-kamelets-catalog.version}</version>
+              </adapter>
+              <kafka>
+                <prefix>kafka</prefix>
+                <name>cos-kafka-source</name>
+                <version>${cos.kamelets.version}</version>
+              </kafka>
+            </connector>
+            <!-- Salesforce Update -->
+            <connector>
+              <name>${cos.connector.type}-update-sink-${cos.connector.version}</name>
+              <title>${project.name} Update sink</title>
+              <description>Update an object in Salesforce.</description>
+              <adapter>
+                <prefix>salesforce</prefix>
+                <name>${cos.connector.type}-update-sink</name>
+                <version>${camel-kamelets-catalog.version}</version>
+              </adapter>
+              <kafka>
+                <prefix>kafka</prefix>
+                <name>cos-kafka-source</name>
+                <version>${cos.kamelets.version}</version>
+              </kafka>
+            </connector>
+          </connectors>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>
+

--- a/cos-fleet-catalog-connectors/social/slack-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/social/slack-0.1/pom.xml
@@ -1,92 +1,95 @@
-<?xml version="1.0"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-
-    <parent>
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>org.bf2</groupId>
+    <artifactId>cos-fleet-catalog-connectors-social</artifactId>
+    <version>999-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>cos-connector-slack-0.1</artifactId>
+  <name>Slack</name>
+  <description>Slack</description>
+  <packaging>jar</packaging>
+  <properties>
+    <cos.connector.type>slack</cos.connector.type>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.camel.quarkus</groupId>
+      <artifactId>camel-quarkus-gson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel.quarkus</groupId>
+      <artifactId>camel-quarkus-jackson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel.quarkus</groupId>
+      <artifactId>camel-quarkus-slack</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.bf2</groupId>
+      <artifactId>cos-connector-slack</artifactId>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
         <groupId>org.bf2</groupId>
-        <artifactId>cos-fleet-catalog-connectors-social</artifactId>
-        <version>999-SNAPSHOT</version>
-    </parent>
-
-    <modelVersion>4.0.0</modelVersion>
-    <artifactId>cos-connector-slack-0.1</artifactId>
-
-    <name>Slack</name>
-    <description>Slack</description>
-
-    <packaging>jar</packaging>
-
-    <properties>
-        <cos.connector.type>slack</cos.connector.type>
-    </properties>
-
-    <dependencies>
-        <dependency>
-            <groupId>org.bf2</groupId>
-            <artifactId>cos-connector-slack</artifactId>
-        </dependency>
-    </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.bf2</groupId>
-                <artifactId>camel-connector-maven-plugin</artifactId>
-                <configuration>
-                    <connectors>
-                        <connector>
-                            <name>${cos.connector.type}-source-${cos.connector.version}</name>
-                            <title>${project.name} source</title>
-                            <description>Receive messages from a Slack channel.</description>
-                            <adapter>
-                                <prefix>slack</prefix>
-                                <name>cos-${cos.connector.type}-source</name>
-                                <version>${cos.kamelets.version}</version>
-                            </adapter>
-                            <kafka>
-                                <prefix>kafka</prefix>
-                                <name>cos-kafka-sink</name>
-                                <version>${cos.kamelets.version}</version>
-                            </kafka>
-                            <dataShape>
-                                <!--
+        <artifactId>camel-connector-maven-plugin</artifactId>
+        <configuration>
+          <connectors>
+            <connector>
+              <name>${cos.connector.type}-source-${cos.connector.version}</name>
+              <title>${project.name} source</title>
+              <description>Receive messages from a Slack channel.</description>
+              <adapter>
+                <prefix>slack</prefix>
+                <name>cos-${cos.connector.type}-source</name>
+                <version>${cos.kamelets.version}</version>
+              </adapter>
+              <kafka>
+                <prefix>kafka</prefix>
+                <name>cos-kafka-sink</name>
+                <version>${cos.kamelets.version}</version>
+              </kafka>
+              <dataShape>
+                <!--
                                 <consumes>
                                     <contentClass>com.slack.api.model.Message</contentClass>
                                 </consumes>
                                 -->
-                                <produces>
-                                    <formats>
-                                        <format>application/json</format>
-                                    </formats>
-                                </produces>
-                            </dataShape>
-                        </connector>
-                        <connector>
-                            <name>${cos.connector.type}-sink-${cos.connector.version}</name>
-                            <title>${project.name} sink</title>
-                            <description>Send messages to a Slack channel.</description>
-                            <adapter>
-                                <prefix>slack</prefix>
-                                <name>${cos.connector.type}-sink</name>
-                                <version>${camel-kamelets-catalog.version}</version>
-                            </adapter>
-                            <kafka>
-                                <prefix>kafka</prefix>
-                                <name>cos-kafka-source</name>
-                                <version>${cos.kamelets.version}</version>
-                            </kafka>
-                            <dataShape>
-                                <consumes>
-                                    <formats>
-                                        <format>application/octet-stream</format>
-                                    </formats>
-                                </consumes>
-                            </dataShape>
-                        </connector>
-                    </connectors>
-                </configuration>
-                <!--
+                <produces>
+                  <formats>
+                    <format>application/json</format>
+                  </formats>
+                </produces>
+              </dataShape>
+            </connector>
+            <connector>
+              <name>${cos.connector.type}-sink-${cos.connector.version}</name>
+              <title>${project.name} sink</title>
+              <description>Send messages to a Slack channel.</description>
+              <adapter>
+                <prefix>slack</prefix>
+                <name>${cos.connector.type}-sink</name>
+                <version>${camel-kamelets-catalog.version}</version>
+              </adapter>
+              <kafka>
+                <prefix>kafka</prefix>
+                <name>cos-kafka-source</name>
+                <version>${cos.kamelets.version}</version>
+              </kafka>
+              <dataShape>
+                <consumes>
+                  <formats>
+                    <format>application/octet-stream</format>
+                  </formats>
+                </consumes>
+              </dataShape>
+            </connector>
+          </connectors>
+        </configuration>
+        <!--
                 <dependencies>
                     <dependency>
                         <groupId>com.slack.api</groupId>
@@ -95,8 +98,8 @@
                     </dependency>
                 </dependencies>
                 -->
-            </plugin>
-        </plugins>
-    </build>
-
+      </plugin>
+    </plugins>
+  </build>
 </project>
+

--- a/cos-fleet-catalog-connectors/social/telegram-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/social/telegram-0.1/pom.xml
@@ -1,74 +1,76 @@
-<?xml version="1.0"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-
-    <parent>
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>org.bf2</groupId>
+    <artifactId>cos-fleet-catalog-connectors-social</artifactId>
+    <version>999-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>cos-connector-telegram-0.1</artifactId>
+  <name>Telegram</name>
+  <description>Telegram</description>
+  <packaging>jar</packaging>
+  <properties>
+    <cos.connector.type>telegram</cos.connector.type>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.camel.quarkus</groupId>
+      <artifactId>camel-quarkus-jackson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel.quarkus</groupId>
+      <artifactId>camel-quarkus-telegram</artifactId>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
         <groupId>org.bf2</groupId>
-        <artifactId>cos-fleet-catalog-connectors-social</artifactId>
-        <version>999-SNAPSHOT</version>
-    </parent>
-
-    <modelVersion>4.0.0</modelVersion>
-    <artifactId>cos-connector-telegram-0.1</artifactId>
-
-    <name>Telegram</name>
-    <description>Telegram</description>
-
-    <packaging>jar</packaging>
-
-    <properties>
-        <cos.connector.type>telegram</cos.connector.type>
-    </properties>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.bf2</groupId>
-                <artifactId>camel-connector-maven-plugin</artifactId>
-                <configuration>
-                    <connectors>
-                        <connector>
-                            <name>${cos.connector.type}-source-${cos.connector.version}</name>
-                            <title>${project.name} source</title>
-                            <description>Receive all messages that people send to your Telegram bot.</description>
-                            <adapter>
-                                <prefix>telegram</prefix>
-                                <name>${cos.connector.type}-source</name>
-                                <version>${camel-kamelets-catalog.version}</version>
-                            </adapter>
-                            <kafka>
-                                <prefix>kafka</prefix>
-                                <name>cos-kafka-sink</name>
-                                <version>${cos.kamelets.version}</version>
-                            </kafka>
-                        </connector>
-                        <connector>
-                            <name>${cos.connector.type}-sink-${cos.connector.version}</name>
-                            <title>${project.name} sink</title>
-                            <description>Send a message to a Telegram chat using your Telegram bot as sender. To create a bot, use your Telegram app to contact the @botfather account.</description>
-                            <adapter>
-                                <prefix>telegram</prefix>
-                                <name>${cos.connector.type}-sink</name>
-                                <version>${camel-kamelets-catalog.version}</version>
-                            </adapter>
-                            <kafka>
-                                <prefix>kafka</prefix>
-                                <name>cos-kafka-source</name>
-                                <version>${cos.kamelets.version}</version>
-                            </kafka>
-                            <dataShape>
-                                <consumes>
-                                    <formats>
-                                        <format>application/octet-stream</format>
-                                    </formats>
-                                </consumes>
-                            </dataShape>
-                        </connector>
-                    </connectors>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
+        <artifactId>camel-connector-maven-plugin</artifactId>
+        <configuration>
+          <connectors>
+            <connector>
+              <name>${cos.connector.type}-source-${cos.connector.version}</name>
+              <title>${project.name} source</title>
+              <description>Receive all messages that people send to your Telegram bot.</description>
+              <adapter>
+                <prefix>telegram</prefix>
+                <name>${cos.connector.type}-source</name>
+                <version>${camel-kamelets-catalog.version}</version>
+              </adapter>
+              <kafka>
+                <prefix>kafka</prefix>
+                <name>cos-kafka-sink</name>
+                <version>${cos.kamelets.version}</version>
+              </kafka>
+            </connector>
+            <connector>
+              <name>${cos.connector.type}-sink-${cos.connector.version}</name>
+              <title>${project.name} sink</title>
+              <description>Send a message to a Telegram chat using your Telegram bot as sender. To create a bot, use your Telegram app to contact the @botfather account.</description>
+              <adapter>
+                <prefix>telegram</prefix>
+                <name>${cos.connector.type}-sink</name>
+                <version>${camel-kamelets-catalog.version}</version>
+              </adapter>
+              <kafka>
+                <prefix>kafka</prefix>
+                <name>cos-kafka-source</name>
+                <version>${cos.kamelets.version}</version>
+              </kafka>
+              <dataShape>
+                <consumes>
+                  <formats>
+                    <format>application/octet-stream</format>
+                  </formats>
+                </consumes>
+              </dataShape>
+            </connector>
+          </connectors>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>
+

--- a/cos-fleet-catalog-connectors/sql/aws-redshift-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/sql/aws-redshift-0.1/pom.xml
@@ -1,67 +1,77 @@
-<?xml version="1.0"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-
-    <parent>
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>org.bf2</groupId>
+    <artifactId>cos-fleet-catalog-connectors-sql</artifactId>
+    <version>999-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>cos-connector-aws-redshift-0.1</artifactId>
+  <name>Amazon Redshift</name>
+  <description>Amazon Redshift</description>
+  <packaging>jar</packaging>
+  <properties>
+    <cos.connector.type>aws-redshift</cos.connector.type>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>com.amazon.redshift</groupId>
+      <artifactId>redshift-jdbc42</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel.quarkus</groupId>
+      <artifactId>camel-quarkus-jackson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel.quarkus</groupId>
+      <artifactId>camel-quarkus-sql</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-dbcp2</artifactId>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
         <groupId>org.bf2</groupId>
-        <artifactId>cos-fleet-catalog-connectors-sql</artifactId>
-        <version>999-SNAPSHOT</version>
-    </parent>
-
-    <modelVersion>4.0.0</modelVersion>
-    <artifactId>cos-connector-aws-redshift-0.1</artifactId>
-
-    <name>Amazon Redshift</name>
-    <description>Amazon Redshift</description>
-
-    <packaging>jar</packaging>
-
-    <properties>
-        <cos.connector.type>aws-redshift</cos.connector.type>
-    </properties>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.bf2</groupId>
-                <artifactId>camel-connector-maven-plugin</artifactId>
-                <configuration>
-                    <connectors>
-                        <connector>
-                            <name>${cos.connector.type}-source-${cos.connector.version}</name>
-                            <title>${project.name} source</title>
-                            <description>Query data from an Amazon Redshift Database.</description>
-                            <adapter>
-                                <prefix>sql</prefix>
-                                <name>${cos.connector.type}-source</name>
-                                <version>${camel-kamelets-catalog.version}</version>
-                            </adapter>
-                            <kafka>
-                                <prefix>kafka</prefix>
-                                <name>cos-kafka-sink</name>
-                                <version>${cos.kamelets.version}</version>
-                            </kafka>
-                        </connector>
-                        <connector>
-                            <name>${cos.connector.type}-sink-${cos.connector.version}</name>
-                            <title>${project.name} sink</title>
-                            <description>Send data to an Amazon Redshift Database.</description>
-                            <adapter>
-                                <prefix>sql</prefix>
-                                <name>${cos.connector.type}-sink</name>
-                                <version>${camel-kamelets-catalog.version}</version>
-                            </adapter>
-                            <kafka>
-                                <prefix>kafka</prefix>
-                                <name>cos-kafka-source</name>
-                                <version>${cos.kamelets.version}</version>
-                            </kafka>
-                        </connector>
-                    </connectors>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
+        <artifactId>camel-connector-maven-plugin</artifactId>
+        <configuration>
+          <connectors>
+            <connector>
+              <name>${cos.connector.type}-source-${cos.connector.version}</name>
+              <title>${project.name} source</title>
+              <description>Query data from an Amazon Redshift Database.</description>
+              <adapter>
+                <prefix>sql</prefix>
+                <name>${cos.connector.type}-source</name>
+                <version>${camel-kamelets-catalog.version}</version>
+              </adapter>
+              <kafka>
+                <prefix>kafka</prefix>
+                <name>cos-kafka-sink</name>
+                <version>${cos.kamelets.version}</version>
+              </kafka>
+            </connector>
+            <connector>
+              <name>${cos.connector.type}-sink-${cos.connector.version}</name>
+              <title>${project.name} sink</title>
+              <description>Send data to an Amazon Redshift Database.</description>
+              <adapter>
+                <prefix>sql</prefix>
+                <name>${cos.connector.type}-sink</name>
+                <version>${camel-kamelets-catalog.version}</version>
+              </adapter>
+              <kafka>
+                <prefix>kafka</prefix>
+                <name>cos-kafka-source</name>
+                <version>${cos.kamelets.version}</version>
+              </kafka>
+            </connector>
+          </connectors>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>
+

--- a/cos-fleet-catalog-connectors/sql/mariadb-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/sql/mariadb-0.1/pom.xml
@@ -1,87 +1,91 @@
-<?xml version="1.0"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-
-    <parent>
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>org.bf2</groupId>
+    <artifactId>cos-fleet-catalog-connectors-sql</artifactId>
+    <version>999-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>cos-connector-mariadb-0.1</artifactId>
+  <name>MariaDB</name>
+  <description>MariaDB</description>
+  <packaging>jar</packaging>
+  <properties>
+    <cos.connector.type>mariadb</cos.connector.type>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.camel.quarkus</groupId>
+      <artifactId>camel-quarkus-jackson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel.quarkus</groupId>
+      <artifactId>camel-quarkus-sql</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-dbcp2</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.mariadb.jdbc</groupId>
+      <artifactId>mariadb-java-client</artifactId>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
         <groupId>org.bf2</groupId>
-        <artifactId>cos-fleet-catalog-connectors-sql</artifactId>
-        <version>999-SNAPSHOT</version>
-    </parent>
-
-    <modelVersion>4.0.0</modelVersion>
-    <artifactId>cos-connector-mariadb-0.1</artifactId>
-
-    <name>MariaDB</name>
-    <description>MariaDB</description>
-
-    <packaging>jar</packaging>
-
-    <properties>
-        <cos.connector.type>mariadb</cos.connector.type>
-    </properties>
-
-    <dependencies>
-        <dependency>
-            <groupId>org.mariadb.jdbc</groupId>
-            <artifactId>mariadb-java-client</artifactId>
-        </dependency>
-    </dependencies>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.bf2</groupId>
-                <artifactId>camel-connector-maven-plugin</artifactId>
-                <configuration>
-                    <connectors>
-                        <connector>
-                            <name>${cos.connector.type}-source-${cos.connector.version}</name>
-                            <title>${project.name} source</title>
-                            <description>Query data from a MariaDB Database.</description>
-                            <adapter>
-                                <prefix>db</prefix>
-                                <name>${cos.connector.type}-source</name>
-                                <version>${camel-kamelets-catalog.version}</version>
-                            </adapter>
-                            <kafka>
-                                <prefix>kafka</prefix>
-                                <name>cos-kafka-sink</name>
-                                <version>${cos.kamelets.version}</version>
-                            </kafka>
-                            <dataShape>
-                                <produces>
-                                    <formats>
-                                        <format>application/json</format>
-                                    </formats>
-                                </produces>
-                            </dataShape>
-                        </connector>
-                        <connector>
-                            <name>${cos.connector.type}-sink-${cos.connector.version}</name>
-                            <title>${project.name} sink</title>
-                            <description>Send data to a MariaDB Database.</description>
-                            <adapter>
-                                <prefix>db</prefix>
-                                <name>${cos.connector.type}-sink</name>
-                                <version>${camel-kamelets-catalog.version}</version>
-                            </adapter>
-                            <kafka>
-                                <prefix>kafka</prefix>
-                                <name>cos-kafka-source</name>
-                                <version>${cos.kamelets.version}</version>
-                            </kafka>
-                            <dataShape>
-                                <consumes>
-                                    <formats>
-                                        <format>application/json</format>
-                                    </formats>
-                                </consumes>
-                            </dataShape>
-                        </connector>
-                    </connectors>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
+        <artifactId>camel-connector-maven-plugin</artifactId>
+        <configuration>
+          <connectors>
+            <connector>
+              <name>${cos.connector.type}-source-${cos.connector.version}</name>
+              <title>${project.name} source</title>
+              <description>Query data from a MariaDB Database.</description>
+              <adapter>
+                <prefix>db</prefix>
+                <name>${cos.connector.type}-source</name>
+                <version>${camel-kamelets-catalog.version}</version>
+              </adapter>
+              <kafka>
+                <prefix>kafka</prefix>
+                <name>cos-kafka-sink</name>
+                <version>${cos.kamelets.version}</version>
+              </kafka>
+              <dataShape>
+                <produces>
+                  <formats>
+                    <format>application/json</format>
+                  </formats>
+                </produces>
+              </dataShape>
+            </connector>
+            <connector>
+              <name>${cos.connector.type}-sink-${cos.connector.version}</name>
+              <title>${project.name} sink</title>
+              <description>Send data to a MariaDB Database.</description>
+              <adapter>
+                <prefix>db</prefix>
+                <name>${cos.connector.type}-sink</name>
+                <version>${camel-kamelets-catalog.version}</version>
+              </adapter>
+              <kafka>
+                <prefix>kafka</prefix>
+                <name>cos-kafka-source</name>
+                <version>${cos.kamelets.version}</version>
+              </kafka>
+              <dataShape>
+                <consumes>
+                  <formats>
+                    <format>application/json</format>
+                  </formats>
+                </consumes>
+              </dataShape>
+            </connector>
+          </connectors>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>
+

--- a/cos-fleet-catalog-connectors/sql/mysql-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/sql/mysql-0.1/pom.xml
@@ -1,74 +1,77 @@
-<?xml version="1.0"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-
-    <parent>
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>org.bf2</groupId>
+    <artifactId>cos-fleet-catalog-connectors-sql</artifactId>
+    <version>999-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>cos-connector-mysql-0.1</artifactId>
+  <name>MySQL</name>
+  <description>MySQL</description>
+  <packaging>jar</packaging>
+  <properties>
+    <cos.connector.type>mysql</cos.connector.type>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>mysql</groupId>
+      <artifactId>mysql-connector-java</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel.quarkus</groupId>
+      <artifactId>camel-quarkus-jackson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel.quarkus</groupId>
+      <artifactId>camel-quarkus-sql</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-dbcp2</artifactId>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
         <groupId>org.bf2</groupId>
-        <artifactId>cos-fleet-catalog-connectors-sql</artifactId>
-        <version>999-SNAPSHOT</version>
-    </parent>
-
-    <modelVersion>4.0.0</modelVersion>
-    <artifactId>cos-connector-mysql-0.1</artifactId>
-
-    <name>MySQL</name>
-    <description>MySQL</description>
-
-    <packaging>jar</packaging>
-
-    <properties>
-        <cos.connector.type>mysql</cos.connector.type>
-    </properties>
-
-    <dependencies>
-        <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
-        </dependency>
-    </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.bf2</groupId>
-                <artifactId>camel-connector-maven-plugin</artifactId>
-                <configuration>
-                    <connectors>
-                        <connector>
-                            <name>${cos.connector.type}-source-${cos.connector.version}</name>
-                            <title>${project.name} source</title>
-                            <description>Query data from a MySQL Database.</description>
-                            <adapter>
-                                <prefix>db</prefix>
-                                <name>${cos.connector.type}-source</name>
-                                <version>${camel-kamelets-catalog.version}</version>
-                            </adapter>
-                            <kafka>
-                                <prefix>kafka</prefix>
-                                <name>cos-kafka-sink</name>
-                                <version>${cos.kamelets.version}</version>
-                            </kafka>
-                        </connector>
-                        <connector>
-                            <name>${cos.connector.type}-sink-${cos.connector.version}</name>
-                            <title>${project.name} sink</title>
-                            <description>Send data to a MySQL Database.</description>
-                            <adapter>
-                                <prefix>db</prefix>
-                                <name>${cos.connector.type}-sink</name>
-                                <version>${camel-kamelets-catalog.version}</version>
-                            </adapter>
-                            <kafka>
-                                <prefix>kafka</prefix>
-                                <name>cos-kafka-source</name>
-                                <version>${cos.kamelets.version}</version>
-                            </kafka>
-                        </connector>
-                    </connectors>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
+        <artifactId>camel-connector-maven-plugin</artifactId>
+        <configuration>
+          <connectors>
+            <connector>
+              <name>${cos.connector.type}-source-${cos.connector.version}</name>
+              <title>${project.name} source</title>
+              <description>Query data from a MySQL Database.</description>
+              <adapter>
+                <prefix>db</prefix>
+                <name>${cos.connector.type}-source</name>
+                <version>${camel-kamelets-catalog.version}</version>
+              </adapter>
+              <kafka>
+                <prefix>kafka</prefix>
+                <name>cos-kafka-sink</name>
+                <version>${cos.kamelets.version}</version>
+              </kafka>
+            </connector>
+            <connector>
+              <name>${cos.connector.type}-sink-${cos.connector.version}</name>
+              <title>${project.name} sink</title>
+              <description>Send data to a MySQL Database.</description>
+              <adapter>
+                <prefix>db</prefix>
+                <name>${cos.connector.type}-sink</name>
+                <version>${camel-kamelets-catalog.version}</version>
+              </adapter>
+              <kafka>
+                <prefix>kafka</prefix>
+                <name>cos-kafka-source</name>
+                <version>${cos.kamelets.version}</version>
+              </kafka>
+            </connector>
+          </connectors>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>
+

--- a/cos-fleet-catalog-connectors/sql/postgresql-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/sql/postgresql-0.1/pom.xml
@@ -1,67 +1,77 @@
-<?xml version="1.0"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-
-    <parent>
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>org.bf2</groupId>
+    <artifactId>cos-fleet-catalog-connectors-sql</artifactId>
+    <version>999-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>cos-connector-postgresql-0.1</artifactId>
+  <name>PostgreSQL</name>
+  <description>PostgreSQL</description>
+  <packaging>jar</packaging>
+  <properties>
+    <cos.connector.type>postgresql</cos.connector.type>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.camel.quarkus</groupId>
+      <artifactId>camel-quarkus-jackson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel.quarkus</groupId>
+      <artifactId>camel-quarkus-sql</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-dbcp2</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
         <groupId>org.bf2</groupId>
-        <artifactId>cos-fleet-catalog-connectors-sql</artifactId>
-        <version>999-SNAPSHOT</version>
-    </parent>
-
-    <modelVersion>4.0.0</modelVersion>
-    <artifactId>cos-connector-postgresql-0.1</artifactId>
-
-    <name>PostgreSQL</name>
-    <description>PostgreSQL</description>
-
-    <packaging>jar</packaging>
-
-    <properties>
-        <cos.connector.type>postgresql</cos.connector.type>
-    </properties>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.bf2</groupId>
-                <artifactId>camel-connector-maven-plugin</artifactId>
-                <configuration>
-                    <connectors>
-                        <connector>
-                            <name>${cos.connector.type}-source-${cos.connector.version}</name>
-                            <title>${project.name} source</title>
-                            <description>Query data from a PostgreSQL Database.</description>
-                            <adapter>
-                                <prefix>db</prefix>
-                                <name>${cos.connector.type}-source</name>
-                                <version>${camel-kamelets-catalog.version}</version>
-                            </adapter>
-                            <kafka>
-                                <prefix>kafka</prefix>
-                                <name>cos-kafka-sink</name>
-                                <version>${cos.kamelets.version}</version>
-                            </kafka>
-                        </connector>
-                        <connector>
-                            <name>${cos.connector.type}-sink-${cos.connector.version}</name>
-                            <title>${project.name} sink</title>
-                            <description>Send data to a PostgreSQL Database.</description>
-                            <adapter>
-                                <prefix>db</prefix>
-                                <name>${cos.connector.type}-sink</name>
-                                <version>${camel-kamelets-catalog.version}</version>
-                            </adapter>
-                            <kafka>
-                                <prefix>kafka</prefix>
-                                <name>cos-kafka-source</name>
-                                <version>${cos.kamelets.version}</version>
-                            </kafka>
-                        </connector>
-                    </connectors>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
+        <artifactId>camel-connector-maven-plugin</artifactId>
+        <configuration>
+          <connectors>
+            <connector>
+              <name>${cos.connector.type}-source-${cos.connector.version}</name>
+              <title>${project.name} source</title>
+              <description>Query data from a PostgreSQL Database.</description>
+              <adapter>
+                <prefix>db</prefix>
+                <name>${cos.connector.type}-source</name>
+                <version>${camel-kamelets-catalog.version}</version>
+              </adapter>
+              <kafka>
+                <prefix>kafka</prefix>
+                <name>cos-kafka-sink</name>
+                <version>${cos.kamelets.version}</version>
+              </kafka>
+            </connector>
+            <connector>
+              <name>${cos.connector.type}-sink-${cos.connector.version}</name>
+              <title>${project.name} sink</title>
+              <description>Send data to a PostgreSQL Database.</description>
+              <adapter>
+                <prefix>db</prefix>
+                <name>${cos.connector.type}-sink</name>
+                <version>${camel-kamelets-catalog.version}</version>
+              </adapter>
+              <kafka>
+                <prefix>kafka</prefix>
+                <name>cos-kafka-source</name>
+                <version>${cos.kamelets.version}</version>
+              </kafka>
+            </connector>
+          </connectors>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>
+

--- a/cos-fleet-catalog-connectors/sql/sqlserver-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/sql/sqlserver-0.1/pom.xml
@@ -1,81 +1,84 @@
-<?xml version="1.0"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-
-    <parent>
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>org.bf2</groupId>
+    <artifactId>cos-fleet-catalog-connectors-sql</artifactId>
+    <version>999-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>cos-connector-sqlserver-0.1</artifactId>
+  <name>SQL Server</name>
+  <description>SQL Server</description>
+  <packaging>jar</packaging>
+  <properties>
+    <cos.connector.type>sqlserver</cos.connector.type>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>com.microsoft.sqlserver</groupId>
+      <artifactId>mssql-jdbc</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel.quarkus</groupId>
+      <artifactId>camel-quarkus-jackson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel.quarkus</groupId>
+      <artifactId>camel-quarkus-sql</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-dbcp2</artifactId>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
         <groupId>org.bf2</groupId>
-        <artifactId>cos-fleet-catalog-connectors-sql</artifactId>
-        <version>999-SNAPSHOT</version>
-    </parent>
-
-    <modelVersion>4.0.0</modelVersion>
-    <artifactId>cos-connector-sqlserver-0.1</artifactId>
-
-    <name>SQL Server</name>
-    <description>SQL Server</description>
-
-    <packaging>jar</packaging>
-
-    <properties>
-        <cos.connector.type>sqlserver</cos.connector.type>
-    </properties>
-
-    <dependencies>
-        <dependency>
-            <groupId>com.microsoft.sqlserver</groupId>
-            <artifactId>mssql-jdbc</artifactId>
-        </dependency>
-    </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.bf2</groupId>
-                <artifactId>camel-connector-maven-plugin</artifactId>
-                <configuration>
-                    <connectors>
-                        <connector>
-                            <name>${cos.connector.type}-source-${cos.connector.version}</name>
-                            <title>${project.name} source</title>
-                            <description>Query data from a SQL Server Database.</description>
-                            <adapter>
-                                <prefix>db</prefix>
-                                <name>cos-${cos.connector.type}-source</name>
-                                <version>${cos.kamelets.version}</version>
-                            </adapter>
-                            <kafka>
-                                <prefix>kafka</prefix>
-                                <name>cos-kafka-sink</name>
-                                <version>${cos.kamelets.version}</version>
-                            </kafka>
-                            <dataShape>
-                                <produces>
-                                    <formats>
-                                        <format>application/json</format>
-                                    </formats>
-                                </produces>
-                            </dataShape>
-                        </connector>
-                        <connector>
-                            <name>${cos.connector.type}-sink-${cos.connector.version}</name>
-                            <title>${project.name} sink</title>
-                            <description>Send data to a SQL Server Database.</description>
-                            <adapter>
-                                <prefix>db</prefix>
-                                <name>cos-${cos.connector.type}-sink</name>
-                                <version>${cos.kamelets.version}</version>
-                            </adapter>
-                            <kafka>
-                                <prefix>kafka</prefix>
-                                <name>cos-kafka-source</name>
-                                <version>${cos.kamelets.version}</version>
-                            </kafka>
-                        </connector>
-                    </connectors>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
+        <artifactId>camel-connector-maven-plugin</artifactId>
+        <configuration>
+          <connectors>
+            <connector>
+              <name>${cos.connector.type}-source-${cos.connector.version}</name>
+              <title>${project.name} source</title>
+              <description>Query data from a SQL Server Database.</description>
+              <adapter>
+                <prefix>db</prefix>
+                <name>cos-${cos.connector.type}-source</name>
+                <version>${cos.kamelets.version}</version>
+              </adapter>
+              <kafka>
+                <prefix>kafka</prefix>
+                <name>cos-kafka-sink</name>
+                <version>${cos.kamelets.version}</version>
+              </kafka>
+              <dataShape>
+                <produces>
+                  <formats>
+                    <format>application/json</format>
+                  </formats>
+                </produces>
+              </dataShape>
+            </connector>
+            <connector>
+              <name>${cos.connector.type}-sink-${cos.connector.version}</name>
+              <title>${project.name} sink</title>
+              <description>Send data to a SQL Server Database.</description>
+              <adapter>
+                <prefix>db</prefix>
+                <name>cos-${cos.connector.type}-sink</name>
+                <version>${cos.kamelets.version}</version>
+              </adapter>
+              <kafka>
+                <prefix>kafka</prefix>
+                <name>cos-kafka-source</name>
+                <version>${cos.kamelets.version}</version>
+              </kafka>
+            </connector>
+          </connectors>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>
+

--- a/cos-fleet-catalog-connectors/storage/ftps-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/storage/ftps-0.1/pom.xml
@@ -1,81 +1,79 @@
-<?xml version="1.0"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-
-    <parent>
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>org.bf2</groupId>
+    <artifactId>cos-fleet-catalog-connectors-storage</artifactId>
+    <version>999-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>cos-connector-ftps-0.1</artifactId>
+  <name>FTPS</name>
+  <description>FTPS</description>
+  <packaging>jar</packaging>
+  <properties>
+    <cos.connector.type>ftps</cos.connector.type>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.camel.quarkus</groupId>
+      <artifactId>camel-quarkus-ftp</artifactId>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
         <groupId>org.bf2</groupId>
-        <artifactId>cos-fleet-catalog-connectors-storage</artifactId>
-        <version>999-SNAPSHOT</version>
-    </parent>
-
-    <modelVersion>4.0.0</modelVersion>
-    <artifactId>cos-connector-ftps-0.1</artifactId>
-
-    <name>FTPS</name>
-    <description>FTPS</description>
-
-    <packaging>jar</packaging>
-
-    <properties>
-        <cos.connector.type>ftps</cos.connector.type>
-    </properties>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.bf2</groupId>
-                <artifactId>camel-connector-maven-plugin</artifactId>
-                <configuration>
-                    <connectors>
-                        <connector>
-                            <name>${cos.connector.type}-source-${cos.connector.version}</name>
-                            <title>${project.name} source</title>
-                            <description>Retrieve data from an FTPS Server.</description>
-                            <adapter>
-                                <prefix>ftps</prefix>
-                                <name>${cos.connector.type}-source</name>
-                                <version>${camel-kamelets-catalog.version}</version>
-                            </adapter>
-                            <kafka>
-                                <prefix>kafka</prefix>
-                                <name>cos-kafka-sink</name>
-                                <version>${cos.kamelets.version}</version>
-                            </kafka>
-                            <dataShape>
-                                <produces>
-                                    <formats>
-                                        <format>application/octet-stream</format>
-                                    </formats>
-                                </produces>
-                            </dataShape>
-                        </connector>
-                        <connector>
-                            <name>${cos.connector.type}-sink-${cos.connector.version}</name>
-                            <title>${project.name} sink</title>
-                            <description>Send data to an FTPS Server.</description>
-                            <adapter>
-                                <prefix>ftps</prefix>
-                                <name>${cos.connector.type}-sink</name>
-                                <version>${camel-kamelets-catalog.version}</version>
-                            </adapter>
-                            <kafka>
-                                <prefix>kafka</prefix>
-                                <name>cos-kafka-source</name>
-                                <version>${cos.kamelets.version}</version>
-                            </kafka>
-                            <dataShape>
-                                <consumes>
-                                    <formats>
-                                        <format>application/octet-stream</format>
-                                    </formats>
-                                </consumes>
-                            </dataShape>
-                        </connector>
-                    </connectors>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
+        <artifactId>camel-connector-maven-plugin</artifactId>
+        <configuration>
+          <connectors>
+            <connector>
+              <name>${cos.connector.type}-source-${cos.connector.version}</name>
+              <title>${project.name} source</title>
+              <description>Retrieve data from an FTPS Server.</description>
+              <adapter>
+                <prefix>ftps</prefix>
+                <name>${cos.connector.type}-source</name>
+                <version>${camel-kamelets-catalog.version}</version>
+              </adapter>
+              <kafka>
+                <prefix>kafka</prefix>
+                <name>cos-kafka-sink</name>
+                <version>${cos.kamelets.version}</version>
+              </kafka>
+              <dataShape>
+                <produces>
+                  <formats>
+                    <format>application/octet-stream</format>
+                  </formats>
+                </produces>
+              </dataShape>
+            </connector>
+            <connector>
+              <name>${cos.connector.type}-sink-${cos.connector.version}</name>
+              <title>${project.name} sink</title>
+              <description>Send data to an FTPS Server.</description>
+              <adapter>
+                <prefix>ftps</prefix>
+                <name>${cos.connector.type}-sink</name>
+                <version>${camel-kamelets-catalog.version}</version>
+              </adapter>
+              <kafka>
+                <prefix>kafka</prefix>
+                <name>cos-kafka-source</name>
+                <version>${cos.kamelets.version}</version>
+              </kafka>
+              <dataShape>
+                <consumes>
+                  <formats>
+                    <format>application/octet-stream</format>
+                  </formats>
+                </consumes>
+              </dataShape>
+            </connector>
+          </connectors>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>
+

--- a/cos-fleet-catalog-connectors/storage/minio-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/storage/minio-0.1/pom.xml
@@ -1,81 +1,79 @@
-<?xml version="1.0"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-
-    <parent>
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>org.bf2</groupId>
+    <artifactId>cos-fleet-catalog-connectors-storage</artifactId>
+    <version>999-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>cos-connector-minio-0.1</artifactId>
+  <name>MinIO</name>
+  <description>MinIO</description>
+  <packaging>jar</packaging>
+  <properties>
+    <cos.connector.type>minio</cos.connector.type>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.camel.quarkus</groupId>
+      <artifactId>camel-quarkus-minio</artifactId>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
         <groupId>org.bf2</groupId>
-        <artifactId>cos-fleet-catalog-connectors-storage</artifactId>
-        <version>999-SNAPSHOT</version>
-    </parent>
-
-    <modelVersion>4.0.0</modelVersion>
-    <artifactId>cos-connector-minio-0.1</artifactId>
-
-    <name>MinIO</name>
-    <description>MinIO</description>
-
-    <packaging>jar</packaging>
-
-    <properties>
-        <cos.connector.type>minio</cos.connector.type>
-    </properties>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.bf2</groupId>
-                <artifactId>camel-connector-maven-plugin</artifactId>
-                <configuration>
-                    <connectors>
-                        <connector>
-                            <name>${cos.connector.type}-source-${cos.connector.version}</name>
-                            <title>${project.name} source</title>
-                            <description>Retrieve data from MinIO.</description>
-                            <adapter>
-                                <prefix>minio</prefix>
-                                <name>${cos.connector.type}-source</name>
-                                <version>${camel-kamelets-catalog.version}</version>
-                            </adapter>
-                            <kafka>
-                                <prefix>kafka</prefix>
-                                <name>cos-kafka-sink</name>
-                                <version>${cos.kamelets.version}</version>
-                            </kafka>
-                            <dataShape>
-                                <produces>
-                                    <formats>
-                                        <format>application/octet-stream</format>
-                                    </formats>
-                                </produces>
-                            </dataShape>
-                        </connector>
-                        <connector>
-                            <name>${cos.connector.type}-sink-${cos.connector.version}</name>
-                            <title>${project.name} sink</title>
-                            <description>Send data to MinIO.</description>
-                            <adapter>
-                                <prefix>minio</prefix>
-                                <name>${cos.connector.type}-sink</name>
-                                <version>${camel-kamelets-catalog.version}</version>
-                            </adapter>
-                            <kafka>
-                                <prefix>kafka</prefix>
-                                <name>cos-kafka-source</name>
-                                <version>${cos.kamelets.version}</version>
-                            </kafka>
-                            <dataShape>
-                                <consumes>
-                                    <formats>
-                                        <format>application/octet-stream</format>
-                                    </formats>
-                                </consumes>
-                            </dataShape>
-                        </connector>
-                    </connectors>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
+        <artifactId>camel-connector-maven-plugin</artifactId>
+        <configuration>
+          <connectors>
+            <connector>
+              <name>${cos.connector.type}-source-${cos.connector.version}</name>
+              <title>${project.name} source</title>
+              <description>Retrieve data from MinIO.</description>
+              <adapter>
+                <prefix>minio</prefix>
+                <name>${cos.connector.type}-source</name>
+                <version>${camel-kamelets-catalog.version}</version>
+              </adapter>
+              <kafka>
+                <prefix>kafka</prefix>
+                <name>cos-kafka-sink</name>
+                <version>${cos.kamelets.version}</version>
+              </kafka>
+              <dataShape>
+                <produces>
+                  <formats>
+                    <format>application/octet-stream</format>
+                  </formats>
+                </produces>
+              </dataShape>
+            </connector>
+            <connector>
+              <name>${cos.connector.type}-sink-${cos.connector.version}</name>
+              <title>${project.name} sink</title>
+              <description>Send data to MinIO.</description>
+              <adapter>
+                <prefix>minio</prefix>
+                <name>${cos.connector.type}-sink</name>
+                <version>${camel-kamelets-catalog.version}</version>
+              </adapter>
+              <kafka>
+                <prefix>kafka</prefix>
+                <name>cos-kafka-source</name>
+                <version>${cos.kamelets.version}</version>
+              </kafka>
+              <dataShape>
+                <consumes>
+                  <formats>
+                    <format>application/octet-stream</format>
+                  </formats>
+                </consumes>
+              </dataShape>
+            </connector>
+          </connectors>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>
+

--- a/cos-fleet-catalog-connectors/storage/sftp-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/storage/sftp-0.1/pom.xml
@@ -1,81 +1,79 @@
-<?xml version="1.0"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-
-    <parent>
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>org.bf2</groupId>
+    <artifactId>cos-fleet-catalog-connectors-storage</artifactId>
+    <version>999-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>cos-connector-sftp-0.1</artifactId>
+  <name>SFTP</name>
+  <description>SFTP</description>
+  <packaging>jar</packaging>
+  <properties>
+    <cos.connector.type>sftp</cos.connector.type>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.camel.quarkus</groupId>
+      <artifactId>camel-quarkus-ftp</artifactId>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
         <groupId>org.bf2</groupId>
-        <artifactId>cos-fleet-catalog-connectors-storage</artifactId>
-        <version>999-SNAPSHOT</version>
-    </parent>
-
-    <modelVersion>4.0.0</modelVersion>
-    <artifactId>cos-connector-sftp-0.1</artifactId>
-
-    <name>SFTP</name>
-    <description>SFTP</description>
-
-    <packaging>jar</packaging>
-
-    <properties>
-        <cos.connector.type>sftp</cos.connector.type>
-    </properties>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.bf2</groupId>
-                <artifactId>camel-connector-maven-plugin</artifactId>
-                <configuration>
-                    <connectors>
-                        <connector>
-                            <name>${cos.connector.type}-source-${cos.connector.version}</name>
-                            <title>${project.name} source</title>
-                            <description>Retrieve data from an SFTP Server.</description>
-                            <adapter>
-                                <prefix>sftp</prefix>
-                                <name>${cos.connector.type}-source</name>
-                                <version>${camel-kamelets-catalog.version}</version>
-                            </adapter>
-                            <kafka>
-                                <prefix>kafka</prefix>
-                                <name>cos-kafka-sink</name>
-                                <version>${cos.kamelets.version}</version>
-                            </kafka>
-                            <dataShape>
-                                <produces>
-                                    <formats>
-                                        <format>application/octet-stream</format>
-                                    </formats>
-                                </produces>
-                            </dataShape>
-                        </connector>
-                        <connector>
-                            <name>${cos.connector.type}-sink-${cos.connector.version}</name>
-                            <title>${project.name} sink</title>
-                            <description>Send data to an SFTP Server.</description>
-                            <adapter>
-                                <prefix>sftp</prefix>
-                                <name>${cos.connector.type}-sink</name>
-                                <version>${camel-kamelets-catalog.version}</version>
-                            </adapter>
-                            <kafka>
-                                <prefix>kafka</prefix>
-                                <name>cos-kafka-source</name>
-                                <version>${cos.kamelets.version}</version>
-                            </kafka>
-                            <dataShape>
-                                <consumes>
-                                    <formats>
-                                        <format>application/octet-stream</format>
-                                    </formats>
-                                </consumes>
-                            </dataShape>
-                        </connector>
-                    </connectors>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
+        <artifactId>camel-connector-maven-plugin</artifactId>
+        <configuration>
+          <connectors>
+            <connector>
+              <name>${cos.connector.type}-source-${cos.connector.version}</name>
+              <title>${project.name} source</title>
+              <description>Retrieve data from an SFTP Server.</description>
+              <adapter>
+                <prefix>sftp</prefix>
+                <name>${cos.connector.type}-source</name>
+                <version>${camel-kamelets-catalog.version}</version>
+              </adapter>
+              <kafka>
+                <prefix>kafka</prefix>
+                <name>cos-kafka-sink</name>
+                <version>${cos.kamelets.version}</version>
+              </kafka>
+              <dataShape>
+                <produces>
+                  <formats>
+                    <format>application/octet-stream</format>
+                  </formats>
+                </produces>
+              </dataShape>
+            </connector>
+            <connector>
+              <name>${cos.connector.type}-sink-${cos.connector.version}</name>
+              <title>${project.name} sink</title>
+              <description>Send data to an SFTP Server.</description>
+              <adapter>
+                <prefix>sftp</prefix>
+                <name>${cos.connector.type}-sink</name>
+                <version>${camel-kamelets-catalog.version}</version>
+              </adapter>
+              <kafka>
+                <prefix>kafka</prefix>
+                <name>cos-kafka-source</name>
+                <version>${cos.kamelets.version}</version>
+              </kafka>
+              <dataShape>
+                <consumes>
+                  <formats>
+                    <format>application/octet-stream</format>
+                  </formats>
+                </consumes>
+              </dataShape>
+            </connector>
+          </connectors>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>
+

--- a/cos-fleet-catalog-tools/camel-connector-maven-plugin/pom.xml
+++ b/cos-fleet-catalog-tools/camel-connector-maven-plugin/pom.xml
@@ -74,6 +74,11 @@
         </dependency>
 
         <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>maven-model-helper</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-component-annotations</artifactId>
             <scope>provided</scope>

--- a/cos-fleet-catalog-tools/camel-connector-maven-plugin/src/main/java/org/bf2/cos/catalog/camel/maven/connector/EnrichPomMojo.java
+++ b/cos-fleet-catalog-tools/camel-connector-maven-plugin/src/main/java/org/bf2/cos/catalog/camel/maven/connector/EnrichPomMojo.java
@@ -1,0 +1,149 @@
+package org.bf2.cos.catalog.camel.maven.connector;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.Model;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.apache.maven.project.MavenProject;
+import org.bf2.cos.catalog.camel.maven.connector.support.Connector;
+import org.bf2.cos.catalog.camel.maven.connector.support.ConnectorDependency;
+import org.bf2.cos.catalog.camel.maven.connector.support.ConnectorSupport;
+import org.bf2.cos.catalog.camel.maven.connector.support.KameletsCatalog;
+import org.bf2.cos.catalog.camel.maven.connector.support.MojoSupport;
+
+import io.fabric8.maven.Maven;
+
+@Mojo(name = "enrich-pom", defaultPhase = LifecyclePhase.VALIDATE, requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME, requiresDependencyCollection = ResolutionScope.COMPILE_PLUS_RUNTIME)
+public class EnrichPomMojo extends AbstractMojo {
+
+    @Parameter(defaultValue = "false", property = "cos.pom.enrich.skip")
+    private boolean skip = false;
+    @Parameter(defaultValue = "true", property = "cos.pom.enrich.fail")
+    private boolean fail = true;
+    @Parameter(defaultValue = "${camel-quarkus.version}")
+    private String camelQuarkusVersion;
+
+    @Parameter(readonly = true, defaultValue = "${project}")
+    private MavenProject project;
+
+    @Parameter(defaultValue = "${session}", readonly = true)
+    protected MavenSession session;
+    @Parameter
+    private Connector defaults;
+    @Parameter
+    private List<Connector> connectors;
+    @Parameter
+    private List<String> bannedDependencies;
+
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        if (skip) {
+            getLog().info("Skipping POM Enricher");
+            return;
+        }
+
+        String oldDigest = pomChecksum();
+        enrichPom();
+        String newDigest = pomChecksum();
+
+        if (fail && !Objects.equals(oldDigest, newDigest)) {
+            throw new MojoExecutionException(
+                    "The dependencies have changed and the pom.xml has been overwritten, please rebuild");
+        }
+    }
+
+    private void enrichPom() throws MojoExecutionException {
+        Model model = Maven.readModel(project.getFile().toPath());
+        model.getDependencies().clear();
+
+        Stream.concat(localDependencies().stream(), injectedDependencies().stream())
+                .distinct()
+                .map(this::asMavenDependency)
+                .forEach(d -> model.getDependencies().add(d));
+
+        getLog().info("Writing pom.xml");
+
+        Maven.writeModel(model);
+    }
+
+    private String pomChecksum() throws MojoExecutionException {
+        try (InputStream is = Files.newInputStream(project.getFile().toPath())) {
+            return DigestUtils.sha256Hex(is);
+        } catch (IOException e) {
+            throw new MojoExecutionException(e);
+        }
+    }
+
+    private Dependency asMavenDependency(ConnectorDependency cd) {
+        Dependency d = new Dependency();
+        d.setGroupId(cd.groupId);
+        d.setArtifactId(cd.artifactId);
+
+        return d;
+    }
+
+    private Set<ConnectorDependency> localDependencies() {
+        Set<ConnectorDependency> result = new TreeSet<>(Comparator.comparing(ConnectorDependency::toString));
+
+        project.getDependencies().stream()
+                .filter(d -> !"provided".equals(d.getScope()))
+                .filter(d -> Objects.equals(project.getFile().toString(), d.getLocation("").getSource().getLocation()))
+                .map(cd -> new ConnectorDependency(cd.getGroupId(), cd.getArtifactId()))
+                .filter(cd -> !isBanned(cd))
+                .forEach(result::add);
+
+        return result;
+    }
+
+    private Set<ConnectorDependency> injectedDependencies() throws MojoExecutionException {
+        Set<ConnectorDependency> result = new TreeSet<>(Comparator.comparing(ConnectorDependency::toString));
+
+        var projectDeps = project.getDependencies().stream()
+                .filter(d -> !"provided".equals(d.getScope()))
+                .map(cd -> new ConnectorDependency(cd.getGroupId(), cd.getArtifactId()))
+                .filter(cd -> !isBanned(cd))
+                .collect(Collectors.toSet());
+
+        try {
+            for (Connector connector : MojoSupport.inject(session, defaults, connectors)) {
+                Collection<ConnectorDependency> deps = ConnectorSupport.dependencies(
+                        KameletsCatalog.get(project, getLog()),
+                        connector,
+                        camelQuarkusVersion);
+
+                deps.stream()
+                        .filter(cd -> !isBanned(cd))
+                        .map(cd -> new ConnectorDependency(cd.groupId, cd.artifactId))
+                        .filter(cd -> !projectDeps.contains(cd))
+                        .forEach(result::add);
+            }
+        } catch (Exception e) {
+            throw new MojoExecutionException(e);
+        }
+
+        return result;
+    }
+
+    private boolean isBanned(ConnectorDependency cd) {
+        return bannedDependencies != null && bannedDependencies.contains(cd.groupId + ":" + cd.artifactId);
+    }
+}

--- a/cos-fleet-catalog-tools/camel-connector-maven-plugin/src/main/java/org/bf2/cos/catalog/camel/maven/connector/GenerateAppMojo.java
+++ b/cos-fleet-catalog-tools/camel-connector-maven-plugin/src/main/java/org/bf2/cos/catalog/camel/maven/connector/GenerateAppMojo.java
@@ -6,7 +6,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -20,18 +19,11 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.bf2.cos.catalog.camel.maven.connector.support.Connector;
-import org.bf2.cos.catalog.camel.maven.connector.support.ConnectorDependency;
 import org.bf2.cos.catalog.camel.maven.connector.support.ConnectorIndex;
 import org.bf2.cos.catalog.camel.maven.connector.support.ConnectorManifest;
-import org.bf2.cos.catalog.camel.maven.connector.support.ConnectorSupport;
-import org.bf2.cos.catalog.camel.maven.connector.support.KameletsCatalog;
 import org.bf2.cos.catalog.camel.maven.connector.support.MojoSupport;
 
-import io.quarkus.bootstrap.model.AppArtifact;
-import io.quarkus.bootstrap.model.AppDependency;
 import io.quarkus.maven.BuildMojo;
-import io.quarkus.maven.dependency.Dependency;
-import io.quarkus.runtime.LaunchMode;
 
 import static org.bf2.cos.catalog.camel.maven.connector.support.CatalogSupport.JSON_MAPPER;
 
@@ -226,62 +218,5 @@ public class GenerateAppMojo extends BuildMojo {
         } catch (IOException e) {
             throw new MojoExecutionException(e);
         }
-    }
-
-    @Override
-    protected List<Dependency> forcedDependencies(LaunchMode mode) {
-        final Set<ConnectorDependency> connectorsDependecies = new HashSet<>();
-        final Set<ConnectorDependency> projectDependencies = new HashSet<>();
-
-        try {
-            KameletsCatalog catalog = KameletsCatalog.get(mavenProject(), getLog());
-
-            for (Connector connector : MojoSupport.inject(mavenSession(), defaults, connectors)) {
-                ConnectorSupport.dependencies(catalog, connector, camelQuarkusVersion)
-                        .stream()
-                        .filter(cd -> !isBanned(cd))
-                        .forEach(connectorsDependecies::add);
-            }
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-
-        for (org.apache.maven.model.Dependency dependency : mavenProject().getDependencies()) {
-            projectDependencies.add(
-                    new ConnectorDependency(
-                            dependency.getGroupId(),
-                            dependency.getArtifactId(),
-                            dependency.getVersion()));
-        }
-
-        if (bannedDependencies != null) {
-            getLog().info("Banned dependencies:");
-            bannedDependencies.stream()
-                    .distinct()
-                    .sorted()
-                    .forEach(d -> getLog().info("- " + d));
-        }
-
-        getLog().info("Connectors dependencies:");
-        connectorsDependecies.stream()
-                .distinct()
-                .sorted(Comparator.comparing(ConnectorDependency::toString))
-                .forEach(d -> getLog().info("- " + d));
-
-        getLog().info("Project dependencies:");
-        projectDependencies.stream()
-                .distinct()
-                .sorted(Comparator.comparing(ConnectorDependency::toString))
-                .forEach(d -> getLog().info("- " + d));
-
-        return Stream.concat(connectorsDependecies.stream(), projectDependencies.stream())
-                .distinct()
-                .map(d -> new AppArtifact(d.groupId, d.artifactiId, d.version))
-                .map(d -> new AppDependency(d, "compile"))
-                .collect(Collectors.toList());
-    }
-
-    protected boolean isBanned(ConnectorDependency dependency) {
-        return bannedDependencies != null && bannedDependencies.contains(dependency.groupId + ":" + dependency.artifactiId);
     }
 }

--- a/cos-fleet-catalog-tools/camel-connector-maven-plugin/src/main/java/org/bf2/cos/catalog/camel/maven/connector/support/AppBootstrapProvider.java
+++ b/cos-fleet-catalog-tools/camel-connector-maven-plugin/src/main/java/org/bf2/cos/catalog/camel/maven/connector/support/AppBootstrapProvider.java
@@ -270,7 +270,7 @@ public class AppBootstrapProvider {
                 .setForcedDependencies(
                         Stream.concat(connectorsDependecies.stream(), projectDependencies.stream())
                                 .distinct()
-                                .map(d -> new AppArtifact(d.groupId, d.artifactiId, d.version))
+                                .map(d -> new AppArtifact(d.groupId, d.artifactId, d.version))
                                 .map(d -> new AppDependency(d, "compile"))
                                 .collect(Collectors.toList()));
 

--- a/cos-fleet-catalog-tools/camel-connector-maven-plugin/src/main/java/org/bf2/cos/catalog/camel/maven/connector/support/AppBootstrapProvider.java
+++ b/cos-fleet-catalog-tools/camel-connector-maven-plugin/src/main/java/org/bf2/cos/catalog/camel/maven/connector/support/AppBootstrapProvider.java
@@ -5,6 +5,7 @@ import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -213,11 +214,13 @@ public class AppBootstrapProvider {
         }
 
         for (org.apache.maven.model.Dependency dependency : project.getDependencies()) {
-            projectDependencies.add(
-                    new ConnectorDependency(
-                            dependency.getGroupId(),
-                            dependency.getArtifactId(),
-                            dependency.getVersion()));
+            if (!Objects.equals(dependency.getScope(), "provided")) {
+                projectDependencies.add(
+                        new ConnectorDependency(
+                                dependency.getGroupId(),
+                                dependency.getArtifactId(),
+                                dependency.getVersion()));
+            }
         }
 
         getLog().info("Connectors dependencies:");

--- a/cos-fleet-catalog-tools/camel-connector-maven-plugin/src/main/java/org/bf2/cos/catalog/camel/maven/connector/support/ConnectorDependency.java
+++ b/cos-fleet-catalog-tools/camel-connector-maven-plugin/src/main/java/org/bf2/cos/catalog/camel/maven/connector/support/ConnectorDependency.java
@@ -4,12 +4,18 @@ import java.util.Objects;
 
 public class ConnectorDependency {
     public final String groupId;
-    public final String artifactiId;
+    public final String artifactId;
     public final String version;
 
-    public ConnectorDependency(String groupId, String artifactiId, String version) {
+    public ConnectorDependency(String groupId, String artifactId) {
         this.groupId = Objects.requireNonNull(groupId);
-        this.artifactiId = Objects.requireNonNull(artifactiId);
+        this.artifactId = Objects.requireNonNull(artifactId);
+        this.version = null;
+    }
+
+    public ConnectorDependency(String groupId, String artifactId, String version) {
+        this.groupId = Objects.requireNonNull(groupId);
+        this.artifactId = Objects.requireNonNull(artifactId);
         this.version = Objects.requireNonNull(version);
     }
 
@@ -22,19 +28,23 @@ public class ConnectorDependency {
             return false;
         }
 
-        ConnectorDependency artifatc = (ConnectorDependency) o;
-        return Objects.equals(groupId, artifatc.groupId)
-                && Objects.equals(artifactiId, artifatc.artifactiId)
-                && Objects.equals(version, artifatc.version);
+        ConnectorDependency artifact = (ConnectorDependency) o;
+
+        return Objects.equals(groupId, artifact.groupId)
+                && Objects.equals(artifactId, artifact.artifactId)
+                && Objects.equals(version, artifact.version);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(groupId, artifactiId, version);
+        return Objects.hash(groupId, artifactId, version);
     }
 
     @Override
     public String toString() {
-        return groupId + ":" + artifactiId + ":" + version;
+        return version != null
+                ? groupId + ":" + artifactId + ":" + version
+                : groupId + ":" + artifactId;
     }
+
 }

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,10 @@
         <wiremock.version>2.35.0</wiremock.version>
         <assertj-core.version>3.24.2</assertj-core.version>
         <everit-json-schema.version>1.14.1</everit-json-schema.version>
+        <commons-dbcp2.version>2.9.0</commons-dbcp2.version>
+        <aws-redshift.version>2.1.0.10</aws-redshift.version>
+        <artemis-jms-client.version>2.27.1</artemis-jms-client.version>
+        <azure-storage-blob-changefeed.version>12.0.0-beta.17</azure-storage-blob-changefeed.version>
 
         <maven.version>3.8.7</maven.version>
 
@@ -484,6 +488,27 @@
                 <artifactId>commons-collections4</artifactId>
                 <version>${commons-collections4.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-dbcp2</artifactId>
+                <version>${commons-dbcp2.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.amazon.redshift</groupId>
+                <artifactId>redshift-jdbc42</artifactId>
+                <version>${aws-redshift.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>artemis-jms-client-all</artifactId>
+                <version>${artemis-jms-client.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.azure</groupId>
+                <artifactId>azure-storage-blob-changefeed</artifactId>
+                <version>${azure-storage-blob-changefeed.version}</version>
+            </dependency>
+
 
             <dependency>
                 <groupId>com.github.tomakehurst</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,8 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.parameters>true</maven.compiler.parameters>
 
+        <maven-model-helper.version>21</maven-model-helper.version>
+
         <maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>
         <maven-surefire-plugin.version>3.0.0-M8</maven-surefire-plugin.version>
         <maven-failsafe-plugin.version>3.0.0-M8</maven-failsafe-plugin.version>
@@ -203,7 +205,11 @@
                 <version>${maven-shared-utils.version}</version>
             </dependency>
 
-
+            <dependency>
+                <groupId>io.fabric8</groupId>
+                <artifactId>maven-model-helper</artifactId>
+                <version>${maven-model-helper.version}</version>
+            </dependency>
 
             <!-- local -->
             <dependency>


### PR DESCRIPTION
This PR introduces a new Maven Mojo to augment connector's pom with dependencies from kamelets to avoid the magic dependency resolution and injection that happens as today as part of the quarkus build.

The benefit is that the maven projects are now standard maven project and can be easily integrated with external tools (i.e. snyk for dependencies scan) or used as dependencies for testing purpose. 

As drawback, since the resulted dependency list is the merge of the dependencies from kamelets and the local project dependencies, additional care must be taken if the local dependencies change, in such case the pom must be regenerated (i.e. by removing all the kamelet dependencies and let the plugin to re-generate the pom). As a future evolution, we could generate a parent pom that the connector inherit.  
