### PR TITLE
MGDCTRS-2124 Elasticsearch sink leads to misleading messages

### DIFF
--- a/cos-fleet-catalog-connectors/nosql/elasticsearch-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/nosql/elasticsearch-0.1/pom.xml
@@ -32,7 +32,7 @@
                         <connector>
                             <name>${cos.connector.type}-sink-${cos.connector.version}</name>
                             <title>${project.name} sink</title>
-                            <description>Store JSON-formatted data into ElasticSearch.</description>
+                            <description>Send JSON objects to ElasticSearch. Other JSON data types are not supported.</description>
                             <adapter>
                                 <prefix>elasticsearch</prefix>
                                 <name>${cos.connector.type}-index-sink</name>


### PR DESCRIPTION
Update the description to make it clear the Elasticsearch sink connector only supports sending JSON objects.