### PR TITLE
MGDCTRS-2194: Smart Event Processors: Control Plane:  Validate definitions

### DIFF
--- a/cos-fleet-catalog-tools/camel-connector-maven-plugin/pom.xml
+++ b/cos-fleet-catalog-tools/camel-connector-maven-plugin/pom.xml
@@ -524,7 +524,7 @@
                                 <bannedDefinition>org.apache.camel.model.CircuitBreakerDefinition</bannedDefinition>
                                 <bannedDefinition>org.apache.camel.model.ClaimCheckDefinition</bannedDefinition>
                                 <bannedDefinition>org.apache.camel.model.ContextScanDefinition</bannedDefinition>
-                                <bannedDefinition>org.apache.camel.model.ConvertBodyDefinition</bannedDefinition>
+                                <!-- <bannedDefinition>org.apache.camel.model.ConvertBodyDefinition</bannedDefinition> -->
                                 <!-- <bannedDefinition>org.apache.camel.model.DataFormatDefinition</bannedDefinition> -->
                                 <bannedDefinition>org.apache.camel.model.DelayDefinition</bannedDefinition>
                                 <bannedDefinition>org.apache.camel.model.DescriptionDefinition</bannedDefinition>
@@ -594,7 +594,7 @@
                                 <!-- <bannedDefinition>org.apache.camel.model.SetHeaderDefinition</bannedDefinition> -->
                                 <!-- <bannedDefinition>org.apache.camel.model.SetPropertyDefinition</bannedDefinition> -->
                                 <bannedDefinition>org.apache.camel.model.SortDefinition</bannedDefinition>
-                                <bannedDefinition>org.apache.camel.model.SplitDefinition</bannedDefinition>
+                                <!-- <bannedDefinition>org.apache.camel.model.SplitDefinition</bannedDefinition> -->
                                 <!-- <bannedDefinition>org.apache.camel.model.StepDefinition</bannedDefinition> -->
                                 <bannedDefinition>org.apache.camel.model.StopDefinition</bannedDefinition>
                                 <bannedDefinition>org.apache.camel.model.TemplatedRouteBeanDefinition</bannedDefinition>

--- a/cos-fleet-catalog-tools/camel-connector-maven-plugin/pom.xml
+++ b/cos-fleet-catalog-tools/camel-connector-maven-plugin/pom.xml
@@ -506,6 +506,197 @@
                             </bannedDefinitions>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>generate-processors-yaml-schema-kebab-case-restricted</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>generate-yaml-schema</goal>
+                        </goals>
+                        <configuration>
+                            <kebabCase>true</kebabCase>
+                            <outputFile>src/generated/resources/schema/processors-camel-yaml-dsl-restricted.json</outputFile>
+                            <additionalProperties>false</additionalProperties>
+                            <bannedDefinitions>
+                                <bannedDefinition>org.apache.camel.model.AggregateDefinition</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.BeanDefinition</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.CatchDefinition</bannedDefinition>
+                                <!-- <bannedDefinition>org.apache.camel.model.ChoiceDefinition</bannedDefinition> -->
+                                <bannedDefinition>org.apache.camel.model.CircuitBreakerDefinition</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.ClaimCheckDefinition</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.ContextScanDefinition</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.ConvertBodyDefinition</bannedDefinition>
+                                <!-- <bannedDefinition>org.apache.camel.model.DataFormatDefinition</bannedDefinition> -->
+                                <bannedDefinition>org.apache.camel.model.DelayDefinition</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.DescriptionDefinition</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.DynamicRouterDefinition</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.EnrichDefinition</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.ErrorHandlerDefinition</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.FaultToleranceConfigurationDefinition</bannedDefinition>
+                                <!-- <bannedDefinition>org.apache.camel.model.FilterDefinition</bannedDefinition> -->
+                                <bannedDefinition>org.apache.camel.model.FinallyDefinition</bannedDefinition>
+                                <!-- <bannedDefinition>org.apache.camel.model.FromDefinition</bannedDefinition> -->
+                                <bannedDefinition>org.apache.camel.model.GlobalOptionDefinition</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.GlobalOptionsDefinition</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.IdempotentConsumerDefinition</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.InOnlyDefinition</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.InOutDefinition</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.InputTypeDefinition</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.InterceptDefinition</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.InterceptFromDefinition</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.InterceptSendToEndpointDefinition</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.KameletDefinition</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.LoadBalanceDefinition</bannedDefinition>
+                                <!-- <bannedDefinition>org.apache.camel.model.LogDefinition</bannedDefinition> -->
+                                <bannedDefinition>org.apache.camel.model.LoopDefinition</bannedDefinition>
+                                <!-- <bannedDefinition>org.apache.camel.model.MarshalDefinition</bannedDefinition> -->
+                                <bannedDefinition>org.apache.camel.model.MulticastDefinition</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.OnCompletionDefinition</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.OnExceptionDefinition</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.OnFallbackDefinition</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.OptimisticLockRetryPolicyDefinition</bannedDefinition>
+                                <!-- <bannedDefinition>org.apache.camel.model.OtherwiseDefinition</bannedDefinition> -->
+                                <bannedDefinition>org.apache.camel.model.OutputDefinition</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.OutputTypeDefinition</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.PackageScanDefinition</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.PausableDefinition</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.PipelineDefinition</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.PolicyDefinition</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.PollEnrichDefinition</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.ProcessDefinition</bannedDefinition>
+                                <!-- <bannedDefinition>org.apache.camel.model.PropertyDefinition</bannedDefinition> -->
+                                <bannedDefinition>org.apache.camel.model.PropertyExpressionDefinition</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.RecipientListDefinition</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.RedeliveryPolicyDefinition</bannedDefinition>
+                                <!-- <bannedDefinition>org.apache.camel.model.RemoveHeaderDefinition</bannedDefinition> -->
+                                <!-- <bannedDefinition>org.apache.camel.model.RemoveHeadersDefinition</bannedDefinition> -->
+                                <!-- <bannedDefinition>org.apache.camel.model.RemovePropertyDefinition</bannedDefinition> -->
+                                <!-- <bannedDefinition>org.apache.camel.model.RemovePropertiesDefinition</bannedDefinition> -->
+                                <bannedDefinition>org.apache.camel.model.ResequenceDefinition</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.Resilience4jConfigurationDefinition</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.RestContextRefDefinition</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.ResumableDefinition</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.RollbackDefinition</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.RouteBuilderDefinition</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.RouteConfigurationContextRefDefinition</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.RouteConfigurationDefinition</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.RouteContextRefDefinition</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.RouteDefinition</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.RouteTemplateBeanDefinition</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.RouteTemplateDefinition</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.RouteTemplateParameterDefinition</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.RoutingSlipDefinition</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.SagaActionUriDefinition</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.SagaDefinition</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.SamplingDefinition</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.ScriptDefinition</bannedDefinition>
+                                <!-- <bannedDefinition>org.apache.camel.model.SetBodyDefinition</bannedDefinition> -->
+                                <bannedDefinition>org.apache.camel.model.SetExchangePatternDefinition</bannedDefinition>
+                                <!-- <bannedDefinition>org.apache.camel.model.SetHeaderDefinition</bannedDefinition> -->
+                                <!-- <bannedDefinition>org.apache.camel.model.SetPropertyDefinition</bannedDefinition> -->
+                                <bannedDefinition>org.apache.camel.model.SortDefinition</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.SplitDefinition</bannedDefinition>
+                                <!-- <bannedDefinition>org.apache.camel.model.StepDefinition</bannedDefinition> -->
+                                <bannedDefinition>org.apache.camel.model.StopDefinition</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.TemplatedRouteBeanDefinition</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.TemplatedRouteDefinition</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.TemplatedRouteParameterDefinition</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.ThreadPoolProfileDefinition</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.ThreadsDefinition</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.ThrottleDefinition</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.ThrowExceptionDefinition</bannedDefinition>
+                                <!-- <bannedDefinition>org.apache.camel.model.ToDefinition</bannedDefinition> -->
+                                <bannedDefinition>org.apache.camel.model.ToDynamicDefinition</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.TransactedDefinition</bannedDefinition>
+                                <!-- <bannedDefinition>org.apache.camel.model.TransformDefinition</bannedDefinition> -->
+                                <bannedDefinition>org.apache.camel.model.TryDefinition</bannedDefinition>
+                                <!-- <bannedDefinition>org.apache.camel.model.UnmarshalDefinition</bannedDefinition> -->
+                                <bannedDefinition>org.apache.camel.model.ValidateDefinition</bannedDefinition>
+                                <!-- <bannedDefinition>org.apache.camel.model.WhenDefinition</bannedDefinition> -->
+                                <bannedDefinition>org.apache.camel.model.WhenSkipSendToEndpointDefinition</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.WireTapDefinition</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.cloud.*</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.config.*</bannedDefinition>
+
+                                <bannedDefinition>org.apache.camel.model.dataformat.Any23DataFormat</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.dataformat.ASN1DataFormat</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.dataformat.AvroDataFormat</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.dataformat.BarcodeDataFormat</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.dataformat.Base64DataFormat</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.dataformat.BindyDataFormat</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.dataformat.CBORDataFormat</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.dataformat.CryptoDataFormat</bannedDefinition>
+                                <!-- <bannedDefinition>org.apache.camel.model.dataformat.CsvDataFormat</bannedDefinition> -->
+                                <bannedDefinition>org.apache.camel.model.dataformat.CustomDataFormat</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.dataformat.DataFormatsDefinition</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.dataformat.FhirDataformat</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.dataformat.FhirJsonDataFormat</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.dataformat.FhirXmlDataFormat</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.dataformat.FlatpackDataFormat</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.dataformat.GrokDataFormat</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.dataformat.GzipDeflaterDataFormat</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.dataformat.HL7DataFormat</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.dataformat.IcalDataFormat</bannedDefinition>
+                                <!-- <bannedDefinition>org.apache.camel.model.dataformat.JacksonXMLDataFormat</bannedDefinition> -->
+                                <!-- <bannedDefinition>org.apache.camel.model.dataformat.JaxbDataFormat</bannedDefinition> -->
+                                <bannedDefinition>org.apache.camel.model.dataformat.JsonApiDataFormat</bannedDefinition>
+                                <!-- <bannedDefinition>org.apache.camel.model.dataformat.JsonDataFormat</bannedDefinition> -->
+                                <bannedDefinition>org.apache.camel.model.dataformat.LZFDataFormat</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.dataformat.MimeMultipartDataFormat</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.dataformat.PGPDataFormat</bannedDefinition>
+                                <!-- <bannedDefinition>org.apache.camel.model.dataformat.ProtobufDataFormat</bannedDefinition> -->
+                                <bannedDefinition>org.apache.camel.model.dataformat.RssDataFormat</bannedDefinition>
+                                <!-- <bannedDefinition>org.apache.camel.model.dataformat.SoapDataFormat</bannedDefinition> -->
+                                <bannedDefinition>org.apache.camel.model.dataformat.SyslogDataFormat</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.dataformat.TarFileDataFormat</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.dataformat.ThriftDataFormat</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.dataformat.TidyMarkupDataFormat</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.dataformat.UniVocityAbstractDataFormat</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.dataformat.UniVocityCsvDataFormat</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.dataformat.UniVocityFixedDataFormat</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.dataformat.UniVocityHeader</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.dataformat.UniVocityTsvDataFormat</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.dataformat.XMLSecurityDataFormat</bannedDefinition>
+                                <!-- <bannedDefinition>org.apache.camel.model.dataformat.XStreamDataFormat</bannedDefinition> -->
+                                <!-- <bannedDefinition>org.apache.camel.model.dataformat.YAMLDataFormat</bannedDefinition> -->
+                                <!-- <bannedDefinition>org.apache.camel.model.dataformat.YAMLTypeFilterDefinition</bannedDefinition> -->
+                                <bannedDefinition>org.apache.camel.model.dataformat.ZipDeflaterDataFormat</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.dataformat.ZipFileDataFormat</bannedDefinition>
+
+                                <bannedDefinition>org.apache.camel.model.errorhandler.*</bannedDefinition>
+                                <!-- <bannedDefinition>org.apache.camel.model.language.ConstantExpression</bannedDefinition> -->
+                                <bannedDefinition>org.apache.camel.model.language.CSimpleExpression</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.language.DatasonnetExpression</bannedDefinition>
+                                <!-- <bannedDefinition>org.apache.camel.model.language.ExchangePropertyExpression</bannedDefinition> -->
+                                <bannedDefinition>org.apache.camel.model.language.GroovyExpression</bannedDefinition>
+                                <!-- <bannedDefinition>org.apache.camel.model.language.HeaderExpression</bannedDefinition> -->
+                                <bannedDefinition>org.apache.camel.model.language.Hl7TerserExpression</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.language.JoorExpression</bannedDefinition>
+                                <!-- <bannedDefinition>org.apache.camel.model.language.JqExpression</bannedDefinition> -->
+                                <!-- <bannedDefinition>org.apache.camel.model.language.JsonPathExpression</bannedDefinition> -->
+                                <bannedDefinition>org.apache.camel.model.language.LanguageExpression</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.language.MethodCallExpression</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.language.MvelExpression</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.language.OgnlExpression</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.language.PythonExpression</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.language.RefExpression</bannedDefinition>
+                                <!-- <bannedDefinition>org.apache.camel.model.language.SimpleExpression</bannedDefinition> -->
+                                <bannedDefinition>org.apache.camel.model.language.SpELExpression</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.language.TokenizerExpression</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.language.XPathExpression</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.language.XQueryExpression</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.language.XMLTokenizerExpression</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.loadbalancer.*</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.rest.*</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.transformer.*</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.model.validator.*</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.dsl.yaml.deserializers.BeansDeserializer</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.dsl.yaml.deserializers.ErrorHandlerBuilderDeserializer</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.dsl.yaml.deserializers.NamedBeanDefinition</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.dsl.yaml.deserializers.OutputAwareFromDefinition</bannedDefinition>
+                                <bannedDefinition>org.apache.camel.dsl.yaml.deserializers.RouteFromDefinitionDeserializer</bannedDefinition>
+                            </bannedDefinitions>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
             <plugin>

--- a/cos-fleet-catalog-tools/camel-connector-maven-plugin/src/generated/resources/schema/processors-camel-yaml-dsl-restricted.json
+++ b/cos-fleet-catalog-tools/camel-connector-maven-plugin/src/generated/resources/schema/processors-camel-yaml-dsl-restricted.json
@@ -12,6 +12,12 @@
           "choice" : {
             "$ref" : "#/items/definitions/org.apache.camel.model.ChoiceDefinition"
           },
+          "convert-body-to" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.ConvertBodyDefinition"
+          },
+          "convertBodyTo" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.ConvertBodyDefinition"
+          },
           "filter" : {
             "$ref" : "#/items/definitions/org.apache.camel.model.FilterDefinition"
           },
@@ -66,6 +72,9 @@
           "setProperty" : {
             "$ref" : "#/items/definitions/org.apache.camel.model.SetPropertyDefinition"
           },
+          "split" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.SplitDefinition"
+          },
           "step" : {
             "$ref" : "#/items/definitions/org.apache.camel.model.StepDefinition"
           },
@@ -115,6 +124,35 @@
             }
           }
         }
+      },
+      "org.apache.camel.model.ConvertBodyDefinition" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "charset" : {
+              "type" : "string"
+            },
+            "description" : {
+              "type" : "string"
+            },
+            "id" : {
+              "type" : "string"
+            },
+            "inherit-error-handler" : {
+              "type" : "boolean"
+            },
+            "mandatory" : {
+              "type" : "boolean"
+            },
+            "type" : {
+              "type" : "string"
+            }
+          }
+        } ],
+        "required" : [ "type" ]
       },
       "org.apache.camel.model.DataFormatDefinition" : {
         "type" : "object",
@@ -484,6 +522,69 @@
           }
         },
         "required" : [ "name" ]
+      },
+      "org.apache.camel.model.SplitDefinition" : {
+        "type" : "object",
+        "additionalProperties" : false,
+        "anyOf" : [ {
+          "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+        } ],
+        "properties" : {
+          "aggregation-strategy" : {
+            "type" : "string"
+          },
+          "aggregation-strategy-method-allow-null" : {
+            "type" : "boolean"
+          },
+          "aggregation-strategy-method-name" : {
+            "type" : "string"
+          },
+          "delimiter" : {
+            "type" : "string"
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "executor-service" : {
+            "type" : "string"
+          },
+          "expression" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "inherit-error-handler" : {
+            "type" : "boolean"
+          },
+          "on-prepare" : {
+            "type" : "string"
+          },
+          "parallel-aggregate" : {
+            "type" : "boolean"
+          },
+          "parallel-processing" : {
+            "type" : "boolean"
+          },
+          "share-unit-of-work" : {
+            "type" : "boolean"
+          },
+          "steps" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
+            }
+          },
+          "stop-on-exception" : {
+            "type" : "boolean"
+          },
+          "streaming" : {
+            "type" : "boolean"
+          },
+          "timeout" : {
+            "type" : "string"
+          }
+        }
       },
       "org.apache.camel.model.StepDefinition" : {
         "type" : "object",

--- a/cos-fleet-catalog-tools/camel-connector-maven-plugin/src/generated/resources/schema/processors-camel-yaml-dsl-restricted.json
+++ b/cos-fleet-catalog-tools/camel-connector-maven-plugin/src/generated/resources/schema/processors-camel-yaml-dsl-restricted.json
@@ -1,0 +1,1349 @@
+{
+  "$schema" : "http://json-schema.org/draft-04/schema#",
+  "type" : "array",
+  "items" : {
+    "maxProperties" : 1,
+    "definitions" : {
+      "org.apache.camel.model.ProcessorDefinition" : {
+        "type" : "object",
+        "maxProperties" : 1,
+        "additionalProperties" : false,
+        "properties" : {
+          "choice" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.ChoiceDefinition"
+          },
+          "filter" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.FilterDefinition"
+          },
+          "log" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.LogDefinition"
+          },
+          "marshal" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.MarshalDefinition"
+          },
+          "otherwise" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.OtherwiseDefinition"
+          },
+          "remove-header" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.RemoveHeaderDefinition"
+          },
+          "removeHeader" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.RemoveHeaderDefinition"
+          },
+          "remove-headers" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.RemoveHeadersDefinition"
+          },
+          "removeHeaders" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.RemoveHeadersDefinition"
+          },
+          "remove-properties" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.RemovePropertiesDefinition"
+          },
+          "removeProperties" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.RemovePropertiesDefinition"
+          },
+          "remove-property" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.RemovePropertyDefinition"
+          },
+          "removeProperty" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.RemovePropertyDefinition"
+          },
+          "set-body" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.SetBodyDefinition"
+          },
+          "setBody" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.SetBodyDefinition"
+          },
+          "set-header" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.SetHeaderDefinition"
+          },
+          "setHeader" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.SetHeaderDefinition"
+          },
+          "set-property" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.SetPropertyDefinition"
+          },
+          "setProperty" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.SetPropertyDefinition"
+          },
+          "step" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.StepDefinition"
+          },
+          "to" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.ToDefinition"
+          },
+          "transform" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.TransformDefinition"
+          },
+          "unmarshal" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.UnmarshalDefinition"
+          },
+          "when" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.WhenDefinition"
+          }
+        }
+      },
+      "org.apache.camel.model.ChoiceDefinition" : {
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "description" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "inherit-error-handler" : {
+            "type" : "boolean"
+          },
+          "otherwise" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.OtherwiseDefinition"
+          },
+          "precondition" : {
+            "type" : "boolean"
+          },
+          "steps" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
+            }
+          },
+          "when" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.WhenDefinition"
+            }
+          }
+        }
+      },
+      "org.apache.camel.model.DataFormatDefinition" : {
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "id" : {
+            "type" : "string"
+          }
+        }
+      },
+      "org.apache.camel.model.ExpressionSubElementDefinition" : {
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "constant" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ConstantExpression"
+          },
+          "exchange-property" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExchangePropertyExpression"
+          },
+          "exchangeProperty" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExchangePropertyExpression"
+          },
+          "header" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.HeaderExpression"
+          },
+          "jq" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.JqExpression"
+          },
+          "jsonpath" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.JsonPathExpression"
+          },
+          "simple" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.SimpleExpression"
+          }
+        }
+      },
+      "org.apache.camel.model.FilterDefinition" : {
+        "type" : "object",
+        "additionalProperties" : false,
+        "anyOf" : [ {
+          "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+        } ],
+        "properties" : {
+          "description" : {
+            "type" : "string"
+          },
+          "expression" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "inherit-error-handler" : {
+            "type" : "boolean"
+          },
+          "status-property-name" : {
+            "type" : "string"
+          },
+          "steps" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
+            }
+          }
+        }
+      },
+      "org.apache.camel.model.FromDefinition" : {
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "description" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "parameters" : {
+            "type" : "object"
+          },
+          "steps" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
+            }
+          },
+          "uri" : {
+            "type" : "string"
+          }
+        },
+        "required" : [ "steps", "uri" ]
+      },
+      "org.apache.camel.model.LogDefinition" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "description" : {
+              "type" : "string"
+            },
+            "id" : {
+              "type" : "string"
+            },
+            "inherit-error-handler" : {
+              "type" : "boolean"
+            },
+            "log-name" : {
+              "type" : "string"
+            },
+            "logger" : {
+              "type" : "string"
+            },
+            "logging-level" : {
+              "type" : "string",
+              "enum" : [ "TRACE", "DEBUG", "INFO", "WARN", "ERROR", "OFF" ]
+            },
+            "marker" : {
+              "type" : "string"
+            },
+            "message" : {
+              "type" : "string"
+            }
+          }
+        } ],
+        "required" : [ "message" ]
+      },
+      "org.apache.camel.model.MarshalDefinition" : {
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "csv" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.CsvDataFormat"
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "inherit-error-handler" : {
+            "type" : "boolean"
+          },
+          "jackson-xml" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.JacksonXMLDataFormat"
+          },
+          "jaxb" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.JaxbDataFormat"
+          },
+          "json" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.JsonDataFormat"
+          },
+          "protobuf" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.ProtobufDataFormat"
+          },
+          "soap" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.SoapDataFormat"
+          },
+          "xstream" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.XStreamDataFormat"
+          },
+          "yaml" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.YAMLDataFormat"
+          }
+        }
+      },
+      "org.apache.camel.model.OtherwiseDefinition" : {
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "description" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "inherit-error-handler" : {
+            "type" : "boolean"
+          },
+          "steps" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
+            }
+          }
+        }
+      },
+      "org.apache.camel.model.PropertyDefinition" : {
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "key" : {
+            "type" : "string"
+          },
+          "value" : {
+            "type" : "string"
+          }
+        },
+        "required" : [ "key", "value" ]
+      },
+      "org.apache.camel.model.RemoveHeaderDefinition" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "description" : {
+              "type" : "string"
+            },
+            "id" : {
+              "type" : "string"
+            },
+            "inherit-error-handler" : {
+              "type" : "boolean"
+            },
+            "name" : {
+              "type" : "string"
+            }
+          }
+        } ],
+        "required" : [ "name" ]
+      },
+      "org.apache.camel.model.RemoveHeadersDefinition" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "description" : {
+              "type" : "string"
+            },
+            "exclude-pattern" : {
+              "type" : "string"
+            },
+            "id" : {
+              "type" : "string"
+            },
+            "inherit-error-handler" : {
+              "type" : "boolean"
+            },
+            "pattern" : {
+              "type" : "string"
+            }
+          }
+        } ],
+        "required" : [ "pattern" ]
+      },
+      "org.apache.camel.model.RemovePropertiesDefinition" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "description" : {
+              "type" : "string"
+            },
+            "exclude-pattern" : {
+              "type" : "string"
+            },
+            "id" : {
+              "type" : "string"
+            },
+            "inherit-error-handler" : {
+              "type" : "boolean"
+            },
+            "pattern" : {
+              "type" : "string"
+            }
+          }
+        } ],
+        "required" : [ "pattern" ]
+      },
+      "org.apache.camel.model.RemovePropertyDefinition" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "description" : {
+              "type" : "string"
+            },
+            "id" : {
+              "type" : "string"
+            },
+            "inherit-error-handler" : {
+              "type" : "boolean"
+            },
+            "name" : {
+              "type" : "string"
+            }
+          }
+        } ],
+        "required" : [ "name" ]
+      },
+      "org.apache.camel.model.SetBodyDefinition" : {
+        "type" : "object",
+        "additionalProperties" : false,
+        "anyOf" : [ {
+          "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+        } ],
+        "properties" : {
+          "description" : {
+            "type" : "string"
+          },
+          "expression" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "inherit-error-handler" : {
+            "type" : "boolean"
+          }
+        }
+      },
+      "org.apache.camel.model.SetHeaderDefinition" : {
+        "type" : "object",
+        "additionalProperties" : false,
+        "anyOf" : [ {
+          "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+        } ],
+        "properties" : {
+          "description" : {
+            "type" : "string"
+          },
+          "expression" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "inherit-error-handler" : {
+            "type" : "boolean"
+          },
+          "name" : {
+            "type" : "string"
+          }
+        },
+        "required" : [ "name" ]
+      },
+      "org.apache.camel.model.SetPropertyDefinition" : {
+        "type" : "object",
+        "additionalProperties" : false,
+        "anyOf" : [ {
+          "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+        } ],
+        "properties" : {
+          "description" : {
+            "type" : "string"
+          },
+          "expression" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "inherit-error-handler" : {
+            "type" : "boolean"
+          },
+          "name" : {
+            "type" : "string"
+          }
+        },
+        "required" : [ "name" ]
+      },
+      "org.apache.camel.model.StepDefinition" : {
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "description" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "inherit-error-handler" : {
+            "type" : "boolean"
+          },
+          "steps" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
+            }
+          }
+        }
+      },
+      "org.apache.camel.model.ToDefinition" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "description" : {
+              "type" : "string"
+            },
+            "id" : {
+              "type" : "string"
+            },
+            "inherit-error-handler" : {
+              "type" : "boolean"
+            },
+            "parameters" : {
+              "type" : "object"
+            },
+            "pattern" : {
+              "type" : "string",
+              "enum" : [ "InOnly", "InOut", "InOptionalOut" ]
+            },
+            "uri" : {
+              "type" : "string"
+            }
+          }
+        } ],
+        "required" : [ "uri" ]
+      },
+      "org.apache.camel.model.TransformDefinition" : {
+        "type" : "object",
+        "additionalProperties" : false,
+        "anyOf" : [ {
+          "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+        } ],
+        "properties" : {
+          "description" : {
+            "type" : "string"
+          },
+          "expression" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "inherit-error-handler" : {
+            "type" : "boolean"
+          }
+        }
+      },
+      "org.apache.camel.model.UnmarshalDefinition" : {
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "allow-null-body" : {
+            "type" : "boolean"
+          },
+          "csv" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.CsvDataFormat"
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "inherit-error-handler" : {
+            "type" : "boolean"
+          },
+          "jackson-xml" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.JacksonXMLDataFormat"
+          },
+          "jaxb" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.JaxbDataFormat"
+          },
+          "json" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.JsonDataFormat"
+          },
+          "protobuf" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.ProtobufDataFormat"
+          },
+          "soap" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.SoapDataFormat"
+          },
+          "xstream" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.XStreamDataFormat"
+          },
+          "yaml" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.YAMLDataFormat"
+          }
+        }
+      },
+      "org.apache.camel.model.WhenDefinition" : {
+        "type" : "object",
+        "additionalProperties" : false,
+        "anyOf" : [ {
+          "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+        } ],
+        "properties" : {
+          "description" : {
+            "type" : "string"
+          },
+          "expression" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExpressionDefinition"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "inherit-error-handler" : {
+            "type" : "boolean"
+          },
+          "steps" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.ProcessorDefinition"
+            }
+          }
+        }
+      },
+      "org.apache.camel.model.dataformat.CsvDataFormat" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "allow-missing-column-names" : {
+              "type" : "boolean"
+            },
+            "capture-header-record" : {
+              "type" : "boolean"
+            },
+            "comment-marker" : {
+              "type" : "string"
+            },
+            "comment-marker-disabled" : {
+              "type" : "boolean"
+            },
+            "delimiter" : {
+              "type" : "string"
+            },
+            "escape" : {
+              "type" : "string"
+            },
+            "escape-disabled" : {
+              "type" : "boolean"
+            },
+            "format-name" : {
+              "type" : "string",
+              "enum" : [ "DEFAULT", "EXCEL", "INFORMIX_UNLOAD", "INFORMIX_UNLOAD_CSV", "MYSQL", "RFC4180" ]
+            },
+            "format-ref" : {
+              "type" : "string"
+            },
+            "header" : {
+              "type" : "array",
+              "items" : {
+                "type" : "string"
+              }
+            },
+            "header-disabled" : {
+              "type" : "boolean"
+            },
+            "id" : {
+              "type" : "string"
+            },
+            "ignore-empty-lines" : {
+              "type" : "boolean"
+            },
+            "ignore-header-case" : {
+              "type" : "boolean"
+            },
+            "ignore-surrounding-spaces" : {
+              "type" : "boolean"
+            },
+            "lazy-load" : {
+              "type" : "boolean"
+            },
+            "marshaller-factory-ref" : {
+              "type" : "string"
+            },
+            "null-string" : {
+              "type" : "string"
+            },
+            "null-string-disabled" : {
+              "type" : "boolean"
+            },
+            "quote" : {
+              "type" : "string"
+            },
+            "quote-disabled" : {
+              "type" : "boolean"
+            },
+            "quote-mode" : {
+              "type" : "string",
+              "enum" : [ "ALL", "ALL_NON_NULL", "MINIMAL", "NON_NUMERIC", "NONE" ]
+            },
+            "record-converter-ref" : {
+              "type" : "string"
+            },
+            "record-separator" : {
+              "type" : "string"
+            },
+            "record-separator-disabled" : {
+              "type" : "string"
+            },
+            "skip-header-record" : {
+              "type" : "boolean"
+            },
+            "trailing-delimiter" : {
+              "type" : "boolean"
+            },
+            "trim" : {
+              "type" : "boolean"
+            },
+            "use-maps" : {
+              "type" : "boolean"
+            },
+            "use-ordered-maps" : {
+              "type" : "boolean"
+            }
+          }
+        } ]
+      },
+      "org.apache.camel.model.dataformat.JacksonXMLDataFormat" : {
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "allow-jms-type" : {
+            "type" : "boolean"
+          },
+          "allow-unmarshall-type" : {
+            "type" : "boolean"
+          },
+          "collection-type" : {
+            "type" : "string"
+          },
+          "content-type-header" : {
+            "type" : "boolean"
+          },
+          "disable-features" : {
+            "type" : "string"
+          },
+          "enable-features" : {
+            "type" : "string"
+          },
+          "enable-jaxb-annotation-module" : {
+            "type" : "boolean"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "include" : {
+            "type" : "string"
+          },
+          "json-view" : {
+            "type" : "string"
+          },
+          "module-class-names" : {
+            "type" : "string"
+          },
+          "module-refs" : {
+            "type" : "string"
+          },
+          "pretty-print" : {
+            "type" : "boolean"
+          },
+          "timezone" : {
+            "type" : "string"
+          },
+          "unmarshal-type" : {
+            "type" : "string"
+          },
+          "use-list" : {
+            "type" : "boolean"
+          },
+          "xml-mapper" : {
+            "type" : "string"
+          }
+        }
+      },
+      "org.apache.camel.model.dataformat.JaxbDataFormat" : {
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "content-type-header" : {
+            "type" : "boolean"
+          },
+          "context-path" : {
+            "type" : "string"
+          },
+          "context-path-is-class-name" : {
+            "type" : "boolean"
+          },
+          "encoding" : {
+            "type" : "string"
+          },
+          "filter-non-xml-chars" : {
+            "type" : "boolean"
+          },
+          "fragment" : {
+            "type" : "boolean"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "ignore-jaxb-element" : {
+            "type" : "boolean"
+          },
+          "jaxb-provider-properties" : {
+            "type" : "string"
+          },
+          "must-be-jaxb-element" : {
+            "type" : "boolean"
+          },
+          "namespace-prefix-ref" : {
+            "type" : "string"
+          },
+          "no-namespace-schema-location" : {
+            "type" : "string"
+          },
+          "object-factory" : {
+            "type" : "boolean"
+          },
+          "part-class" : {
+            "type" : "string"
+          },
+          "part-namespace" : {
+            "type" : "string"
+          },
+          "pretty-print" : {
+            "type" : "boolean"
+          },
+          "schema" : {
+            "type" : "string"
+          },
+          "schema-location" : {
+            "type" : "string"
+          },
+          "schema-severity-level" : {
+            "type" : "string",
+            "enum" : [ "0", "1", "2" ]
+          },
+          "xml-stream-writer-wrapper" : {
+            "type" : "string"
+          }
+        },
+        "required" : [ "context-path" ]
+      },
+      "org.apache.camel.model.dataformat.JsonDataFormat" : {
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "allow-jms-type" : {
+            "type" : "boolean"
+          },
+          "allow-unmarshall-type" : {
+            "type" : "boolean"
+          },
+          "auto-discover-object-mapper" : {
+            "type" : "boolean"
+          },
+          "auto-discover-schema-resolver" : {
+            "type" : "boolean"
+          },
+          "collection-type" : {
+            "type" : "string"
+          },
+          "content-type-header" : {
+            "type" : "boolean"
+          },
+          "disable-features" : {
+            "type" : "string"
+          },
+          "drop-root-node" : {
+            "type" : "boolean"
+          },
+          "enable-features" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "include" : {
+            "type" : "string"
+          },
+          "json-view" : {
+            "type" : "string"
+          },
+          "library" : {
+            "type" : "string",
+            "enum" : [ "Fastjson", "Gson", "Jackson", "Johnzon", "Jsonb", "XStream" ]
+          },
+          "module-class-names" : {
+            "type" : "string"
+          },
+          "module-refs" : {
+            "type" : "string"
+          },
+          "naming-strategy" : {
+            "type" : "string"
+          },
+          "object-mapper" : {
+            "type" : "string"
+          },
+          "permissions" : {
+            "type" : "string"
+          },
+          "pretty-print" : {
+            "type" : "boolean"
+          },
+          "schema-resolver" : {
+            "type" : "string"
+          },
+          "timezone" : {
+            "type" : "string"
+          },
+          "unmarshal-type" : {
+            "type" : "string"
+          },
+          "use-default-object-mapper" : {
+            "type" : "boolean"
+          },
+          "use-list" : {
+            "type" : "boolean"
+          }
+        }
+      },
+      "org.apache.camel.model.dataformat.ProtobufDataFormat" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "allow-jms-type" : {
+              "type" : "boolean"
+            },
+            "allow-unmarshall-type" : {
+              "type" : "boolean"
+            },
+            "auto-discover-object-mapper" : {
+              "type" : "boolean"
+            },
+            "auto-discover-schema-resolver" : {
+              "type" : "boolean"
+            },
+            "collection-type" : {
+              "type" : "string"
+            },
+            "content-type-format" : {
+              "type" : "string",
+              "enum" : [ "native", "json" ]
+            },
+            "content-type-header" : {
+              "type" : "boolean"
+            },
+            "disable-features" : {
+              "type" : "string"
+            },
+            "enable-features" : {
+              "type" : "string"
+            },
+            "id" : {
+              "type" : "string"
+            },
+            "include" : {
+              "type" : "string"
+            },
+            "instance-class" : {
+              "type" : "string"
+            },
+            "json-view" : {
+              "type" : "string"
+            },
+            "library" : {
+              "type" : "string",
+              "enum" : [ "GoogleProtobuf", "Jackson" ]
+            },
+            "module-class-names" : {
+              "type" : "string"
+            },
+            "module-refs" : {
+              "type" : "string"
+            },
+            "object-mapper" : {
+              "type" : "string"
+            },
+            "schema-resolver" : {
+              "type" : "string"
+            },
+            "timezone" : {
+              "type" : "string"
+            },
+            "unmarshal-type" : {
+              "type" : "string"
+            },
+            "use-default-object-mapper" : {
+              "type" : "boolean"
+            },
+            "use-list" : {
+              "type" : "boolean"
+            }
+          }
+        } ]
+      },
+      "org.apache.camel.model.dataformat.SoapDataFormat" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "context-path" : {
+              "type" : "string"
+            },
+            "element-name-strategy-ref" : {
+              "type" : "string"
+            },
+            "encoding" : {
+              "type" : "string"
+            },
+            "id" : {
+              "type" : "string"
+            },
+            "namespace-prefix-ref" : {
+              "type" : "string"
+            },
+            "schema" : {
+              "type" : "string"
+            },
+            "version" : {
+              "type" : "string",
+              "enum" : [ "1.1", "1.2" ]
+            }
+          }
+        } ],
+        "required" : [ "context-path" ]
+      },
+      "org.apache.camel.model.dataformat.XStreamDataFormat" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "aliases" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.PropertyDefinition"
+              }
+            },
+            "content-type-header" : {
+              "type" : "boolean"
+            },
+            "converters" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.PropertyDefinition"
+              }
+            },
+            "driver" : {
+              "type" : "string"
+            },
+            "driver-ref" : {
+              "type" : "string"
+            },
+            "encoding" : {
+              "type" : "string"
+            },
+            "id" : {
+              "type" : "string"
+            },
+            "implicit-collections" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.PropertyDefinition"
+              }
+            },
+            "mode" : {
+              "type" : "string",
+              "enum" : [ "NO_REFERENCES", "ID_REFERENCES", "XPATH_RELATIVE_REFERENCES", "XPATH_ABSOLUTE_REFERENCES", "SINGLE_NODE_XPATH_RELATIVE_REFERENCES", "SINGLE_NODE_XPATH_ABSOLUTE_REFERENCES" ]
+            },
+            "omit-fields" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/items/definitions/org.apache.camel.model.PropertyDefinition"
+              }
+            },
+            "permissions" : {
+              "type" : "string"
+            }
+          }
+        } ]
+      },
+      "org.apache.camel.model.dataformat.YAMLDataFormat" : {
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "allow-any-type" : {
+            "type" : "boolean"
+          },
+          "allow-recursive-keys" : {
+            "type" : "boolean"
+          },
+          "constructor" : {
+            "type" : "string"
+          },
+          "dumper-options" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "library" : {
+            "type" : "string",
+            "enum" : [ "SnakeYAML" ]
+          },
+          "max-aliases-for-collections" : {
+            "type" : "number"
+          },
+          "pretty-flow" : {
+            "type" : "boolean"
+          },
+          "representer" : {
+            "type" : "string"
+          },
+          "resolver" : {
+            "type" : "string"
+          },
+          "type-filter" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/items/definitions/org.apache.camel.model.dataformat.YAMLTypeFilterDefinition"
+            }
+          },
+          "unmarshal-type" : {
+            "type" : "string"
+          },
+          "use-application-context-class-loader" : {
+            "type" : "boolean"
+          }
+        }
+      },
+      "org.apache.camel.model.dataformat.YAMLTypeFilterDefinition" : {
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "type" : {
+            "type" : "string"
+          },
+          "value" : {
+            "type" : "string"
+          }
+        }
+      },
+      "org.apache.camel.model.language.ConstantExpression" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "expression" : {
+              "type" : "string"
+            },
+            "id" : {
+              "type" : "string"
+            },
+            "result-type" : {
+              "type" : "string"
+            },
+            "trim" : {
+              "type" : "boolean"
+            }
+          }
+        } ],
+        "required" : [ "expression" ]
+      },
+      "org.apache.camel.model.language.ExchangePropertyExpression" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "expression" : {
+              "type" : "string"
+            },
+            "id" : {
+              "type" : "string"
+            },
+            "trim" : {
+              "type" : "boolean"
+            }
+          }
+        } ],
+        "required" : [ "expression" ]
+      },
+      "org.apache.camel.model.language.ExpressionDefinition" : {
+        "type" : "object",
+        "additionalProperties" : false,
+        "properties" : {
+          "constant" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ConstantExpression"
+          },
+          "exchange-property" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExchangePropertyExpression"
+          },
+          "exchangeProperty" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.ExchangePropertyExpression"
+          },
+          "header" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.HeaderExpression"
+          },
+          "jq" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.JqExpression"
+          },
+          "jsonpath" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.JsonPathExpression"
+          },
+          "simple" : {
+            "$ref" : "#/items/definitions/org.apache.camel.model.language.SimpleExpression"
+          }
+        }
+      },
+      "org.apache.camel.model.language.HeaderExpression" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "expression" : {
+              "type" : "string"
+            },
+            "id" : {
+              "type" : "string"
+            },
+            "trim" : {
+              "type" : "boolean"
+            }
+          }
+        } ],
+        "required" : [ "expression" ]
+      },
+      "org.apache.camel.model.language.JqExpression" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "expression" : {
+              "type" : "string"
+            },
+            "header-name" : {
+              "type" : "string"
+            },
+            "id" : {
+              "type" : "string"
+            },
+            "result-type" : {
+              "type" : "string"
+            },
+            "trim" : {
+              "type" : "boolean"
+            }
+          }
+        } ],
+        "required" : [ "expression" ]
+      },
+      "org.apache.camel.model.language.JsonPathExpression" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "allow-easy-predicate" : {
+              "type" : "boolean"
+            },
+            "allow-simple" : {
+              "type" : "boolean"
+            },
+            "expression" : {
+              "type" : "string"
+            },
+            "header-name" : {
+              "type" : "string"
+            },
+            "id" : {
+              "type" : "string"
+            },
+            "option" : {
+              "type" : "string",
+              "enum" : [ "DEFAULT_PATH_LEAF_TO_NULL", "ALWAYS_RETURN_LIST", "AS_PATH_LIST", "SUPPRESS_EXCEPTIONS", "REQUIRE_PROPERTIES" ]
+            },
+            "result-type" : {
+              "type" : "string"
+            },
+            "suppress-exceptions" : {
+              "type" : "boolean"
+            },
+            "trim" : {
+              "type" : "boolean"
+            },
+            "write-as-string" : {
+              "type" : "boolean"
+            }
+          }
+        } ],
+        "required" : [ "expression" ]
+      },
+      "org.apache.camel.model.language.SimpleExpression" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "expression" : {
+              "type" : "string"
+            },
+            "id" : {
+              "type" : "string"
+            },
+            "result-type" : {
+              "type" : "string"
+            },
+            "trim" : {
+              "type" : "boolean"
+            }
+          }
+        } ],
+        "required" : [ "expression" ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
See https://issues.redhat.com/browse/MGDCTRS-2194

This adds generation of a new JSON Schema for use by Smart Event Processors.

Smart Event Processors need more Camel features exposed; such as `FromDefinition`, `Unmarshall` and `JsonDataFormat`.