### PR TITLE
amend connector's pom to include kamelets dependencies

### DIFF
--- a/cos-fleet-catalog-connectors/aws/aws-cloudwatch-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/aws/aws-cloudwatch-0.1/pom.xml
@@ -56,4 +56,28 @@
         </plugins>
     </build>
 
+    <profiles>
+        <!--This is auto generate, do not change it-->
+        <profile>
+            <id>kamelets-deps</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-aws2-cw</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kafka</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kamelet</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
 </project>

--- a/cos-fleet-catalog-connectors/aws/aws-dynamodb-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/aws/aws-dynamodb-0.1/pom.xml
@@ -49,4 +49,36 @@
         </plugins>
     </build>
 
+    <profiles>
+        <!--This is auto generate, do not change it-->
+        <profile>
+            <id>kamelets-deps</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-aws2-ddb</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-core</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-jackson</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kafka</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kamelet</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
 </project>

--- a/cos-fleet-catalog-connectors/aws/aws-dynamodb-streams-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/aws/aws-dynamodb-streams-0.1/pom.xml
@@ -49,4 +49,32 @@
         </plugins>
     </build>
 
+    <profiles>
+        <!--This is auto generate, do not change it-->
+        <profile>
+            <id>kamelets-deps</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-aws2-ddb</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-gson</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kafka</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kamelet</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
 </project>

--- a/cos-fleet-catalog-connectors/aws/aws-kinesis-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/aws/aws-kinesis-0.1/pom.xml
@@ -71,4 +71,32 @@
         </plugins>
     </build>
 
+    <profiles>
+        <!--This is auto generate, do not change it-->
+        <profile>
+            <id>kamelets-deps</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-aws2-kinesis</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-core</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kafka</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kamelet</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
 </project>

--- a/cos-fleet-catalog-connectors/aws/aws-lambda-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/aws/aws-lambda-0.1/pom.xml
@@ -56,4 +56,28 @@
         </plugins>
     </build>
 
+    <profiles>
+        <!--This is auto generate, do not change it-->
+        <profile>
+            <id>kamelets-deps</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-aws2-lambda</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kafka</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kamelet</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
 </project>

--- a/cos-fleet-catalog-connectors/aws/aws-s3-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/aws/aws-s3-0.1/pom.xml
@@ -78,4 +78,32 @@
         </plugins>
     </build>
 
+    <profiles>
+        <!--This is auto generate, do not change it-->
+        <profile>
+            <id>kamelets-deps</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-aws2-s3</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-core</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kafka</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kamelet</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
 </project>

--- a/cos-fleet-catalog-connectors/aws/aws-ses-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/aws/aws-ses-0.1/pom.xml
@@ -56,4 +56,32 @@
         </plugins>
     </build>
 
+    <profiles>
+        <!--This is auto generate, do not change it-->
+        <profile>
+            <id>kamelets-deps</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-aws2-ses</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-core</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kafka</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kamelet</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
 </project>

--- a/cos-fleet-catalog-connectors/aws/aws-sns-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/aws/aws-sns-0.1/pom.xml
@@ -56,4 +56,32 @@
         </plugins>
     </build>
 
+    <profiles>
+        <!--This is auto generate, do not change it-->
+        <profile>
+            <id>kamelets-deps</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-aws2-sns</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-core</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kafka</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kamelet</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
 </project>

--- a/cos-fleet-catalog-connectors/aws/aws-sqs-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/aws/aws-sqs-0.1/pom.xml
@@ -78,4 +78,28 @@
         </plugins>
     </build>
 
+    <profiles>
+        <!--This is auto generate, do not change it-->
+        <profile>
+            <id>kamelets-deps</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-aws2-sqs</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kafka</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kamelet</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
 </project>

--- a/cos-fleet-catalog-connectors/azure/azure-eventhubs-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/azure/azure-eventhubs-0.1/pom.xml
@@ -85,4 +85,36 @@
         </plugins>
     </build>
 
+    <profiles>
+        <!--This is auto generate, do not change it-->
+        <profile>
+            <id>kamelets-deps</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-azure-eventhubs</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-core</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-jackson</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kafka</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kamelet</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
 </project>

--- a/cos-fleet-catalog-connectors/azure/azure-functions-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/azure/azure-functions-0.1/pom.xml
@@ -60,4 +60,32 @@
         </plugins>
     </build>
 
+    <profiles>
+        <!--This is auto generate, do not change it-->
+        <profile>
+            <id>kamelets-deps</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-core</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kafka</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kamelet</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-vertx-http</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
 </project>

--- a/cos-fleet-catalog-connectors/azure/azure-storage-blob-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/azure/azure-storage-blob-0.1/pom.xml
@@ -78,4 +78,36 @@
         </plugins>
     </build>
 
+    <profiles>
+        <!--This is auto generate, do not change it-->
+        <profile>
+            <id>kamelets-deps</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-azure-storage-blob</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-core</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kafka</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kamelet</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-timer</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
 </project>

--- a/cos-fleet-catalog-connectors/azure/azure-storage-blob-changefeed-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/azure/azure-storage-blob-changefeed-0.1/pom.xml
@@ -62,4 +62,52 @@
         </plugins>
     </build>
 
+    <profiles>
+        <!--This is auto generate, do not change it-->
+        <profile>
+            <id>kamelets-deps</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>com.azure</groupId>
+                    <artifactId>azure-storage-blob-changefeed</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>com.fasterxml.jackson.datatype</groupId>
+                    <artifactId>jackson-datatype-jsr310</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-azure-storage-blob</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-core</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-jackson</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-jsonpath</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kafka</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kamelet</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-timer</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
 </project>

--- a/cos-fleet-catalog-connectors/azure/azure-storage-queue-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/azure/azure-storage-queue-0.1/pom.xml
@@ -78,4 +78,32 @@
         </plugins>
     </build>
 
+    <profiles>
+        <!--This is auto generate, do not change it-->
+        <profile>
+            <id>kamelets-deps</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-azure-storage-queue</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-core</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kafka</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kamelet</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
 </project>

--- a/cos-fleet-catalog-connectors/gcp/google-bigquery-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/gcp/google-bigquery-0.1/pom.xml
@@ -49,4 +49,36 @@
         </plugins>
     </build>
 
+    <profiles>
+        <!--This is auto generate, do not change it-->
+        <profile>
+            <id>kamelets-deps</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-core</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-google-bigquery</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-jackson</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kafka</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kamelet</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
 </project>

--- a/cos-fleet-catalog-connectors/gcp/google-functions-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/gcp/google-functions-0.1/pom.xml
@@ -56,4 +56,32 @@
         </plugins>
     </build>
 
+    <profiles>
+        <!--This is auto generate, do not change it-->
+        <profile>
+            <id>kamelets-deps</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-google-functions</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-jackson</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kafka</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kamelet</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
 </project>

--- a/cos-fleet-catalog-connectors/gcp/google-pubsub-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/gcp/google-pubsub-0.1/pom.xml
@@ -78,4 +78,32 @@
         </plugins>
     </build>
 
+    <profiles>
+        <!--This is auto generate, do not change it-->
+        <profile>
+            <id>kamelets-deps</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-google-pubsub</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-jackson</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kafka</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kamelet</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
 </project>

--- a/cos-fleet-catalog-connectors/gcp/google-storage-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/gcp/google-storage-0.1/pom.xml
@@ -78,4 +78,36 @@
         </plugins>
     </build>
 
+    <profiles>
+        <!--This is auto generate, do not change it-->
+        <profile>
+            <id>kamelets-deps</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-core</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-google-storage</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-jackson</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kafka</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kamelet</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
 </project>

--- a/cos-fleet-catalog-connectors/itops/ansible-tower-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/itops/ansible-tower-0.1/pom.xml
@@ -57,4 +57,32 @@
         </plugins>
     </build>
 
+    <profiles>
+        <!--This is auto generate, do not change it-->
+        <profile>
+            <id>kamelets-deps</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-core</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kafka</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kamelet</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-vertx-http</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
 </project>

--- a/cos-fleet-catalog-connectors/itops/splunk-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/itops/splunk-0.1/pom.xml
@@ -56,4 +56,32 @@
         </plugins>
     </build>
 
+    <profiles>
+        <!--This is auto generate, do not change it-->
+        <profile>
+            <id>kamelets-deps</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-core</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kafka</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kamelet</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-splunk</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
 </project>

--- a/cos-fleet-catalog-connectors/messaging/http-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/messaging/http-0.1/pom.xml
@@ -63,4 +63,32 @@
         </plugins>
     </build>
 
+    <profiles>
+        <!--This is auto generate, do not change it-->
+        <profile>
+            <id>kamelets-deps</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-core</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-http</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kafka</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kamelet</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
 </project>

--- a/cos-fleet-catalog-connectors/messaging/jms-amqp-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/messaging/jms-amqp-0.1/pom.xml
@@ -85,4 +85,28 @@
         </plugins>
     </build>
 
+    <profiles>
+        <!--This is auto generate, do not change it-->
+        <profile>
+            <id>kamelets-deps</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-jms</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kafka</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kamelet</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
 </project>

--- a/cos-fleet-catalog-connectors/messaging/jms-artemis-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/messaging/jms-artemis-0.1/pom.xml
@@ -85,4 +85,28 @@
         </plugins>
     </build>
 
+    <profiles>
+        <!--This is auto generate, do not change it-->
+        <profile>
+            <id>kamelets-deps</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-jms</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kafka</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kamelet</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
 </project>

--- a/cos-fleet-catalog-connectors/messaging/openapi-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/messaging/openapi-0.1/pom.xml
@@ -57,4 +57,36 @@
         </plugins>
     </build>
 
+    <profiles>
+        <!--This is auto generate, do not change it-->
+        <profile>
+            <id>kamelets-deps</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-core</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kafka</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kamelet</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-rest-openapi</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-vertx-http</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
 </project>

--- a/cos-fleet-catalog-connectors/misc/data-generator-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/misc/data-generator-0.1/pom.xml
@@ -63,4 +63,32 @@
         </plugins>
     </build>
 
+    <profiles>
+        <!--This is auto generate, do not change it-->
+        <profile>
+            <id>kamelets-deps</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-core</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kafka</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kamelet</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-timer</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
 </project>

--- a/cos-fleet-catalog-connectors/nosql/cassandra-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/nosql/cassandra-0.1/pom.xml
@@ -79,4 +79,32 @@
         </plugins>
     </build>
 
+    <profiles>
+        <!--This is auto generate, do not change it-->
+        <profile>
+            <id>kamelets-deps</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-cassandraql</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-jackson</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kafka</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kamelet</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
 </project>

--- a/cos-fleet-catalog-connectors/nosql/elasticsearch-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/nosql/elasticsearch-0.1/pom.xml
@@ -57,4 +57,44 @@
         </plugins>
     </build>
 
+    <profiles>
+        <!--This is auto generate, do not change it-->
+        <profile>
+            <id>kamelets-deps</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-bean</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-core</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-elasticsearch-rest</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-gson</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-jackson</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kafka</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kamelet</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
 </project>

--- a/cos-fleet-catalog-connectors/nosql/mongodb-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/nosql/mongodb-0.1/pom.xml
@@ -78,4 +78,36 @@
         </plugins>
     </build>
 
+    <profiles>
+        <!--This is auto generate, do not change it-->
+        <profile>
+            <id>kamelets-deps</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-core</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-jackson</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kafka</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kamelet</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-mongodb</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
 </project>

--- a/cos-fleet-catalog-connectors/pom.xml
+++ b/cos-fleet-catalog-connectors/pom.xml
@@ -119,7 +119,14 @@
                     <artifactId>camel-connector-maven-plugin</artifactId>
                     <executions>
                         <execution>
-                            <id>generate</id>
+                            <id>generate-pom</id>
+                            <phase>process-resources</phase>
+                            <goals>
+                                <goal>enrich-pom</goal>
+                            </goals>
+                        </execution>
+                        <execution>
+                            <id>generate-catalog</id>
                             <phase>process-resources</phase>
                             <goals>
                                 <goal>generate-catalog</goal>

--- a/cos-fleet-catalog-connectors/saas/jira-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/saas/jira-0.1/pom.xml
@@ -86,4 +86,36 @@
         </plugins>
     </build>
 
+    <profiles>
+        <!--This is auto generate, do not change it-->
+        <profile>
+            <id>kamelets-deps</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-core</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-jackson</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-jira</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kafka</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kamelet</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
 </project>

--- a/cos-fleet-catalog-connectors/saas/salesforce-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/saas/salesforce-0.1/pom.xml
@@ -117,4 +117,40 @@
         </plugins>
     </build>
 
+    <profiles>
+        <!--This is auto generate, do not change it-->
+        <profile>
+            <id>kamelets-deps</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-core</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-jackson</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-jsonpath</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kafka</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kamelet</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-salesforce</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
 </project>

--- a/cos-fleet-catalog-connectors/social/slack-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/social/slack-0.1/pom.xml
@@ -85,4 +85,36 @@
         </plugins>
     </build>
 
+    <profiles>
+        <!--This is auto generate, do not change it-->
+        <profile>
+            <id>kamelets-deps</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-gson</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-jackson</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kafka</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kamelet</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-slack</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
 </project>

--- a/cos-fleet-catalog-connectors/social/telegram-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/social/telegram-0.1/pom.xml
@@ -78,4 +78,36 @@
         </plugins>
     </build>
 
+    <profiles>
+        <!--This is auto generate, do not change it-->
+        <profile>
+            <id>kamelets-deps</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-core</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-jackson</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kafka</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kamelet</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-telegram</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
 </project>

--- a/cos-fleet-catalog-connectors/sql/aws-redshift-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/sql/aws-redshift-0.1/pom.xml
@@ -71,4 +71,32 @@
         </plugins>
     </build>
 
+    <profiles>
+        <!--This is auto generate, do not change it-->
+        <profile>
+            <id>kamelets-deps</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-jackson</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kafka</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kamelet</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-sql</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
 </project>

--- a/cos-fleet-catalog-connectors/sql/mariadb-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/sql/mariadb-0.1/pom.xml
@@ -85,4 +85,32 @@
         </plugins>
     </build>
 
+    <profiles>
+        <!--This is auto generate, do not change it-->
+        <profile>
+            <id>kamelets-deps</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-jackson</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kafka</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kamelet</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-sql</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
 </project>

--- a/cos-fleet-catalog-connectors/sql/mysql-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/sql/mysql-0.1/pom.xml
@@ -71,4 +71,32 @@
         </plugins>
     </build>
 
+    <profiles>
+        <!--This is auto generate, do not change it-->
+        <profile>
+            <id>kamelets-deps</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-jackson</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kafka</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kamelet</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-sql</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
 </project>

--- a/cos-fleet-catalog-connectors/sql/postgresql-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/sql/postgresql-0.1/pom.xml
@@ -71,4 +71,32 @@
         </plugins>
     </build>
 
+    <profiles>
+        <!--This is auto generate, do not change it-->
+        <profile>
+            <id>kamelets-deps</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-jackson</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kafka</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kamelet</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-sql</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
 </project>

--- a/cos-fleet-catalog-connectors/sql/sqlserver-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/sql/sqlserver-0.1/pom.xml
@@ -78,4 +78,32 @@
         </plugins>
     </build>
 
+    <profiles>
+        <!--This is auto generate, do not change it-->
+        <profile>
+            <id>kamelets-deps</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-jackson</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kafka</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kamelet</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-sql</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
 </project>

--- a/cos-fleet-catalog-connectors/storage/ftps-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/storage/ftps-0.1/pom.xml
@@ -85,4 +85,32 @@
         </plugins>
     </build>
 
+    <profiles>
+        <!--This is auto generate, do not change it-->
+        <profile>
+            <id>kamelets-deps</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-core</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-ftp</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kafka</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kamelet</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
 </project>

--- a/cos-fleet-catalog-connectors/storage/minio-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/storage/minio-0.1/pom.xml
@@ -85,4 +85,32 @@
         </plugins>
     </build>
 
+    <profiles>
+        <!--This is auto generate, do not change it-->
+        <profile>
+            <id>kamelets-deps</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-core</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kafka</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kamelet</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-minio</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
 </project>

--- a/cos-fleet-catalog-connectors/storage/sftp-0.1/pom.xml
+++ b/cos-fleet-catalog-connectors/storage/sftp-0.1/pom.xml
@@ -85,4 +85,32 @@
         </plugins>
     </build>
 
+    <profiles>
+        <!--This is auto generate, do not change it-->
+        <profile>
+            <id>kamelets-deps</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-core</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-ftp</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kafka</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-kamelet</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
 </project>

--- a/cos-fleet-catalog-kamelets/aws/src/main/resources/kamelets/cos-aws-cloudwatch-sink.kamelet.yaml
+++ b/cos-fleet-catalog-kamelets/aws/src/main/resources/kamelets/cos-aws-cloudwatch-sink.kamelet.yaml
@@ -69,7 +69,6 @@ spec:
           - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
   dependencies:
-    - "camel:core"
     - "camel:aws2-cw"
     - "camel:kamelet"
   template:

--- a/cos-fleet-catalog-tools/camel-connector-maven-plugin/src/it/generate-connector-simple/pom.xml
+++ b/cos-fleet-catalog-tools/camel-connector-maven-plugin/src/it/generate-connector-simple/pom.xml
@@ -13,6 +13,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <connector.generate.skip>true</connector.generate.skip>
         <kamelet.generate.skip>true</kamelet.generate.skip>
+        <cos.pom.enrich.skip>true</cos.pom.enrich.skip>
 
         <cos.connector.container.registry>quay.io</cos.connector.container.registry>
         <cos.connector.container.organization>cos</cos.connector.container.organization>

--- a/cos-fleet-catalog-tools/camel-connector-maven-plugin/src/it/generate-connector-with-capabilities/pom.xml
+++ b/cos-fleet-catalog-tools/camel-connector-maven-plugin/src/it/generate-connector-with-capabilities/pom.xml
@@ -13,6 +13,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <connector.generate.skip>true</connector.generate.skip>
         <kamelet.generate.skip>true</kamelet.generate.skip>
+        <cos.pom.enrich.skip>true</cos.pom.enrich.skip>
 
         <quarkus.container-image.registry>registry.io</quarkus.container-image.registry>
         <quarkus.container-image.group>${project.groupId}</quarkus.container-image.group>

--- a/cos-fleet-catalog-tools/camel-connector-maven-plugin/src/main/java/org/bf2/cos/catalog/camel/maven/connector/EnrichPomMojo.java
+++ b/cos-fleet-catalog-tools/camel-connector-maven-plugin/src/main/java/org/bf2/cos/catalog/camel/maven/connector/EnrichPomMojo.java
@@ -1,0 +1,146 @@
+package org.bf2.cos.catalog.camel.maven.connector;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.apache.maven.project.MavenProject;
+import org.bf2.cos.catalog.camel.maven.connector.support.Builders;
+import org.bf2.cos.catalog.camel.maven.connector.support.Connector;
+import org.bf2.cos.catalog.camel.maven.connector.support.ConnectorDependency;
+import org.bf2.cos.catalog.camel.maven.connector.support.ConnectorSupport;
+import org.bf2.cos.catalog.camel.maven.connector.support.KameletsCatalog;
+import org.bf2.cos.catalog.camel.maven.connector.support.MojoSupport;
+import org.l2x6.pom.tuner.Comparators;
+import org.l2x6.pom.tuner.model.Gavtcs;
+
+@Mojo(name = "enrich-pom", defaultPhase = LifecyclePhase.VALIDATE, requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME, requiresDependencyCollection = ResolutionScope.COMPILE_PLUS_RUNTIME)
+public class EnrichPomMojo extends AbstractMojo {
+
+    @Parameter(defaultValue = "false", property = "cos.pom.enrich.skip")
+    private boolean skip = false;
+    @Parameter(defaultValue = "true", property = "cos.pom.enrich.fail")
+    private boolean fail = true;
+    @Parameter(defaultValue = "${camel-quarkus.version}")
+    private String camelQuarkusVersion;
+
+    @Parameter(readonly = true, defaultValue = "${project}")
+    private MavenProject project;
+
+    @Parameter(defaultValue = "${session}", readonly = true)
+    protected MavenSession session;
+    @Parameter
+    private Connector defaults;
+    @Parameter
+    private List<Connector> connectors;
+    @Parameter
+    private List<String> bannedDependencies;
+
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        if (skip) {
+            getLog().info("Skipping POM Enricher");
+            return;
+        }
+
+        String oldDigest = pomChecksum();
+        enrichPom();
+        String newDigest = pomChecksum();
+
+        if (fail && !Objects.equals(oldDigest, newDigest)) {
+            throw new MojoExecutionException(
+                    "The dependencies have changed and the pom.xml has been overwritten, please rebuild");
+        }
+    }
+
+    private void enrichPom() throws MojoExecutionException {
+        var builder = new Builders.Pom();
+        builder = builder.withPath(project.getFile().toPath());
+
+        try {
+            builder = builder.withTransformation((document, context) -> {
+                var profile = context.getOrAddProfile("kamelets-deps");
+                profile.prependCommentIfNeeded("This is auto generate, do not change it");
+                profile.getOrAddChildContainerElement("activation").addChildTextElementIfNeeded(
+                        "activeByDefault",
+                        "true",
+                        Comparators.entryValueOnly());
+
+                var deps = profile.getOrAddChildContainerElement("dependencies");
+
+                for (var child : deps.childElements()) {
+                    child.remove(true, true);
+                }
+
+                try {
+                    for (var dep : injectedDependencies()) {
+                        deps.addGavtcsIfNeeded(asGavtcs(dep), Gavtcs.groupFirstComparator());
+                    }
+                } catch (MojoExecutionException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+
+            getLog().info("Writing pom.xml");
+
+            builder.build();
+        } catch (Exception e) {
+            throw new MojoExecutionException(e);
+        }
+
+    }
+
+    private String pomChecksum() throws MojoExecutionException {
+        try (InputStream is = Files.newInputStream(project.getFile().toPath())) {
+            return DigestUtils.sha256Hex(is);
+        } catch (IOException e) {
+            throw new MojoExecutionException(e);
+        }
+    }
+
+    private Gavtcs asGavtcs(ConnectorDependency cd) {
+        return new Gavtcs(cd.groupId, cd.artifactId, null);
+    }
+
+    private Set<ConnectorDependency> injectedDependencies() throws MojoExecutionException {
+        Set<ConnectorDependency> result = new TreeSet<>(Comparator.comparing(ConnectorDependency::toString));
+
+        try {
+            for (Connector connector : MojoSupport.inject(session, defaults, connectors)) {
+                Collection<ConnectorDependency> deps = ConnectorSupport.dependencies(
+                        getLog(),
+                        KameletsCatalog.get(project, getLog()),
+                        connector,
+                        camelQuarkusVersion);
+
+                deps.stream()
+                        .filter(cd -> !isBanned(cd))
+                        .map(cd -> new ConnectorDependency(cd.groupId, cd.artifactId))
+                        .forEach(result::add);
+            }
+        } catch (Exception e) {
+            throw new MojoExecutionException(e);
+        }
+
+        return result;
+    }
+
+    private boolean isBanned(ConnectorDependency cd) {
+        return bannedDependencies != null && bannedDependencies.contains(cd.groupId + ":" + cd.artifactId);
+    }
+}

--- a/cos-fleet-catalog-tools/camel-connector-maven-plugin/src/main/java/org/bf2/cos/catalog/camel/maven/connector/GenerateAppMojo.java
+++ b/cos-fleet-catalog-tools/camel-connector-maven-plugin/src/main/java/org/bf2/cos/catalog/camel/maven/connector/GenerateAppMojo.java
@@ -1,18 +1,6 @@
 package org.bf2.cos.catalog.camel.maven.connector;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
+import io.quarkus.maven.BuildMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
@@ -20,18 +8,21 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.bf2.cos.catalog.camel.maven.connector.support.Connector;
-import org.bf2.cos.catalog.camel.maven.connector.support.ConnectorDependency;
 import org.bf2.cos.catalog.camel.maven.connector.support.ConnectorIndex;
 import org.bf2.cos.catalog.camel.maven.connector.support.ConnectorManifest;
-import org.bf2.cos.catalog.camel.maven.connector.support.ConnectorSupport;
-import org.bf2.cos.catalog.camel.maven.connector.support.KameletsCatalog;
 import org.bf2.cos.catalog.camel.maven.connector.support.MojoSupport;
 
-import io.quarkus.bootstrap.model.AppArtifact;
-import io.quarkus.bootstrap.model.AppDependency;
-import io.quarkus.maven.BuildMojo;
-import io.quarkus.maven.dependency.Dependency;
-import io.quarkus.runtime.LaunchMode;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.bf2.cos.catalog.camel.maven.connector.support.CatalogSupport.JSON_MAPPER;
 
@@ -226,62 +217,5 @@ public class GenerateAppMojo extends BuildMojo {
         } catch (IOException e) {
             throw new MojoExecutionException(e);
         }
-    }
-
-    @Override
-    protected List<Dependency> forcedDependencies(LaunchMode mode) {
-        final Set<ConnectorDependency> connectorsDependecies = new HashSet<>();
-        final Set<ConnectorDependency> projectDependencies = new HashSet<>();
-
-        try {
-            KameletsCatalog catalog = KameletsCatalog.get(mavenProject(), getLog());
-
-            for (Connector connector : MojoSupport.inject(mavenSession(), defaults, connectors)) {
-                ConnectorSupport.dependencies(catalog, connector, camelQuarkusVersion)
-                        .stream()
-                        .filter(cd -> !isBanned(cd))
-                        .forEach(connectorsDependecies::add);
-            }
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-
-        for (org.apache.maven.model.Dependency dependency : mavenProject().getDependencies()) {
-            projectDependencies.add(
-                    new ConnectorDependency(
-                            dependency.getGroupId(),
-                            dependency.getArtifactId(),
-                            dependency.getVersion()));
-        }
-
-        if (bannedDependencies != null) {
-            getLog().info("Banned dependencies:");
-            bannedDependencies.stream()
-                    .distinct()
-                    .sorted()
-                    .forEach(d -> getLog().info("- " + d));
-        }
-
-        getLog().info("Connectors dependencies:");
-        connectorsDependecies.stream()
-                .distinct()
-                .sorted(Comparator.comparing(ConnectorDependency::toString))
-                .forEach(d -> getLog().info("- " + d));
-
-        getLog().info("Project dependencies:");
-        projectDependencies.stream()
-                .distinct()
-                .sorted(Comparator.comparing(ConnectorDependency::toString))
-                .forEach(d -> getLog().info("- " + d));
-
-        return Stream.concat(connectorsDependecies.stream(), projectDependencies.stream())
-                .distinct()
-                .map(d -> new AppArtifact(d.groupId, d.artifactiId, d.version))
-                .map(d -> new AppDependency(d, "compile"))
-                .collect(Collectors.toList());
-    }
-
-    protected boolean isBanned(ConnectorDependency dependency) {
-        return bannedDependencies != null && bannedDependencies.contains(dependency.groupId + ":" + dependency.artifactiId);
     }
 }

--- a/cos-fleet-catalog-tools/camel-connector-maven-plugin/src/main/java/org/bf2/cos/catalog/camel/maven/connector/support/Builders.java
+++ b/cos-fleet-catalog-tools/camel-connector-maven-plugin/src/main/java/org/bf2/cos/catalog/camel/maven/connector/support/Builders.java
@@ -1,5 +1,10 @@
 package org.bf2.cos.catalog.camel.maven.connector.support;
 
+import com.github.mustachejava.DefaultMustacheFactory;
+import com.github.mustachejava.Mustache;
+import com.github.mustachejava.MustacheFactory;
+import org.l2x6.pom.tuner.PomTransformer;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -13,12 +18,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import org.l2x6.pom.tuner.PomTransformer;
-
-import com.github.mustachejava.DefaultMustacheFactory;
-import com.github.mustachejava.Mustache;
-import com.github.mustachejava.MustacheFactory;
 
 public final class Builders {
     private Builders() {
@@ -89,6 +88,11 @@ public final class Builders {
 
         public Pom withPath(String first, String... more) {
             this.path = Paths.get(first, more);
+            return this;
+        }
+
+        public Pom withPath(Path path) {
+            this.path = path;
             return this;
         }
 

--- a/cos-fleet-catalog-tools/camel-connector-maven-plugin/src/main/java/org/bf2/cos/catalog/camel/maven/connector/support/ConnectorDependency.java
+++ b/cos-fleet-catalog-tools/camel-connector-maven-plugin/src/main/java/org/bf2/cos/catalog/camel/maven/connector/support/ConnectorDependency.java
@@ -4,13 +4,19 @@ import java.util.Objects;
 
 public class ConnectorDependency {
     public final String groupId;
-    public final String artifactiId;
+    public final String artifactId;
     public final String version;
 
-    public ConnectorDependency(String groupId, String artifactiId, String version) {
+    public ConnectorDependency(String groupId, String artifactId, String version) {
         this.groupId = Objects.requireNonNull(groupId);
-        this.artifactiId = Objects.requireNonNull(artifactiId);
+        this.artifactId = Objects.requireNonNull(artifactId);
         this.version = Objects.requireNonNull(version);
+    }
+
+    public ConnectorDependency(String groupId, String artifactId) {
+        this.groupId = Objects.requireNonNull(groupId);
+        this.artifactId = Objects.requireNonNull(artifactId);
+        this.version = null;
     }
 
     @Override
@@ -24,17 +30,17 @@ public class ConnectorDependency {
 
         ConnectorDependency artifatc = (ConnectorDependency) o;
         return Objects.equals(groupId, artifatc.groupId)
-                && Objects.equals(artifactiId, artifatc.artifactiId)
+                && Objects.equals(artifactId, artifatc.artifactId)
                 && Objects.equals(version, artifatc.version);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(groupId, artifactiId, version);
+        return Objects.hash(groupId, artifactId, version);
     }
 
     @Override
     public String toString() {
-        return groupId + ":" + artifactiId + ":" + version;
+        return groupId + ":" + artifactId + ":" + version;
     }
 }

--- a/cos-fleet-catalog-tools/camel-connector-maven-plugin/src/main/resources/pom-enricher-template/kamelets-dependencies-profile.xml
+++ b/cos-fleet-catalog-tools/camel-connector-maven-plugin/src/main/resources/pom-enricher-template/kamelets-dependencies-profile.xml
@@ -1,0 +1,8 @@
+<profiles xmlns="http://maven.apache.org/POM/4.0.0">
+    <profile>
+        <id>kamelets-deps</id>
+        <activation>
+            <activeByDefault>true</activeByDefault>
+        </activation>
+    </profile>
+</profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
         <artemis-jms.version>2.23.1</artemis-jms.version>
         <qpid-jms.version>1.0.0</qpid-jms.version>
         <mustache.version>0.9.10</mustache.version>
+        <azure-storage-blob-changefeed.version>12.0.0-beta.17</azure-storage-blob-changefeed.version>
 
         <pom-tuner.version>4.2.0</pom-tuner.version>
         <maven.version>3.8.7</maven.version>
@@ -597,6 +598,11 @@
                 <groupId>org.apache.qpid</groupId>
                 <artifactId>qpid-jms-client</artifactId>
                 <version>${qpid-jms.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.azure</groupId>
+                <artifactId>azure-storage-blob-changefeed</artifactId>
+                <version>${azure-storage-blob-changefeed.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
This PR introduces a new Maven Mojo to augment connector's pom with dependencies from kamelets to avoid the magic dependency resolution and injection that happens as today as part of the quarkus build.

The benefit is that the maven projects are now standard maven project and can be easily integrated with external tools (i.e. snyk for dependencies scan) or used as dependencies for testing purpose.

The dependecies are added to an active-by-default profile to avoid mixing local deps with kamelet deps which would complicate the process to augment the pom quite a lot.

The generated profile looks like:

```xml
    <profiles>
        <!--This is auto generate, do not change it-->
        <profile>
            <id>kamelets-deps</id>
            <activation>
                <activeByDefault>true</activeByDefault>
            </activation>
            <dependencies>
                <dependency>
                    <groupId>org.apache.camel.quarkus</groupId>
                    <artifactId>camel-quarkus-aws2-kinesis</artifactId>
                </dependency>
                <dependency>
                    <groupId>org.apache.camel.quarkus</groupId>
                    <artifactId>camel-quarkus-core</artifactId>
                </dependency>
                <dependency>
                    <groupId>org.apache.camel.quarkus</groupId>
                    <artifactId>camel-quarkus-kafka</artifactId>
                </dependency>
                <dependency>
                    <groupId>org.apache.camel.quarkus</groupId>
                    <artifactId>camel-quarkus-kamelet</artifactId>
                </dependency>
            </dependencies>
        </profile>
    </profiles>
```

This way we could generate a SBOM for the project or use the SBOM feature provided by [GitHub](https://github.blog/2023-03-28-introducing-self-service-sboms/)